### PR TITLE
Format wide DECIMAL values from their exact digits instead of coercing them through a JS number

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -93,6 +93,7 @@
   "extensions/positron-data-driver-snowflake/": ["@:connections"],
   "extensions/positron-data-driver-sqlite/": ["@:connections"],
   "extensions/positron-data-explorer-duckdb/": ["@:connections"],
+  "extensions/positron-data-explorer-formatting/": ["@:connections", "@:data-explorer"],
   "extensions/positron-data-explorer-protocol/": ["@:data-explorer"],
   "extensions/positron-dev-containers/": [],
   "extensions/positron-environment/": [],

--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -55,8 +55,11 @@ const compilations = [
 	// Shared, generated Data Explorer protocol types consumed by the data driver extensions.
 	// Compiled here so the data driver extensions can resolve its out/ (.js + .d.ts).
 	'extensions/positron-data-explorer-protocol/tsconfig.json',
+	// Shared Data Explorer value formatting consumed by the data driver extensions. Depends on the
+	// protocol package above; compiled before its consumers.
+	'extensions/positron-data-explorer-formatting/tsconfig.json',
 	// Shared DuckDB-backed Data Explorer backend consumed by the DuckDB (and later pins) data
-	// driver extensions. Depends on the protocol package above; compiled before its consumers.
+	// driver extensions. Depends on the two packages above; compiled before its consumers.
 	'extensions/positron-data-explorer-duckdb/tsconfig.json',
 	'extensions/authentication/tsconfig.json',
 	'extensions/open-remote-ssh/tsconfig.json',
@@ -325,9 +328,10 @@ task.task(transpileExtensionsTask);
 // must compile before their dependents. Running every compile task in parallel causes a race: the
 // clean step deletes out/, and a dependent that starts compiling before its prerequisite rebuilds
 // fails to resolve the import. Compile these prerequisites first, in order (the DuckDB backend itself
-// imports the protocol types), then the rest in parallel.
+// imports the protocol types and the shared formatting), then the rest in parallel.
 const orderedPrerequisites = [
 	'extensions/positron-data-explorer-protocol/tsconfig.json',
+	'extensions/positron-data-explorer-formatting/tsconfig.json',
 	'extensions/positron-data-explorer-duckdb/tsconfig.json',
 ]
 	.map(tsconfig => compilations.indexOf(tsconfig))

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -585,6 +585,10 @@ const excludedExtensions = [
 	// the data driver extensions bundle via esbuild. It is not an extension and
 	// must not be packaged or activated at runtime.
 	'positron-data-explorer-protocol',
+	// Build-time-only package: shared Data Explorer value formatting that the data
+	// driver extensions bundle via esbuild. It is not an extension and must not be
+	// packaged or activated at runtime.
+	'positron-data-explorer-formatting',
 	// Build-time-only package: shared DuckDB-backed Data Explorer backend that the
 	// DuckDB (and later pins) data driver extensions bundle via esbuild. It is not
 	// an extension and must not be packaged or activated at runtime.

--- a/build/npm/dirs.ts
+++ b/build/npm/dirs.ts
@@ -33,6 +33,7 @@ export let dirs = [
 	'extensions/positron-duckdb',
 	'extensions/positron-environment',
 	'extensions/positron-data-explorer-protocol',
+	'extensions/positron-data-explorer-formatting',
 	'extensions/positron-data-explorer-duckdb',
 	'extensions/positron-data-driver-databricks',
 	'extensions/positron-data-driver-duckdb',

--- a/extensions/positron-data-driver-databricks/package-lock.json
+++ b/extensions/positron-data-driver-databricks/package-lock.json
@@ -19,12 +19,21 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
       "engines": {
         "vscode": "^1.65.0"
+      }
+    },
+    "../positron-data-explorer-formatting": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
       }
     },
     "../positron-data-explorer-protocol": {
@@ -5938,6 +5947,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/positron-data-explorer-formatting": {
+      "resolved": "../positron-data-explorer-formatting",
+      "link": true
     },
     "node_modules/positron-data-explorer-protocol": {
       "resolved": "../positron-data-explorer-protocol",

--- a/extensions/positron-data-driver-databricks/package.json
+++ b/extensions/positron-data-driver-databricks/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
+    "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
     "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/node": "14.x",
     "@typescript-eslint/eslint-plugin": "^5.12.1",

--- a/extensions/positron-data-driver-databricks/src/databricksTableView.ts
+++ b/extensions/positron-data-driver-databricks/src/databricksTableView.ts
@@ -70,6 +70,15 @@ import {
 	TableSelectionKind,
 	TextSearchType,
 } from 'positron-data-explorer-protocol';
+import {
+	formatDecimal,
+	formatFloat,
+	formatInteger,
+	formatNumericStat,
+	isDecimalLiteral,
+	isIntegerLiteral,
+	truncate,
+} from 'positron-data-explorer-formatting';
 import type * as positron from 'positron';
 import { quoteAlias, quoteIdentifier, quoteLiteral } from './databricksSql.js';
 
@@ -451,6 +460,14 @@ export class DatabricksTableView {
 		switch (displayType) {
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal: {
+				// A DECIMAL arrives as an exact digit string precisely because a double cannot hold it
+				// (see `preserveBigNumericPrecision` in databricksClient.ts), so it is formatted
+				// textually: `Number` would drop the whole-number digits past 2^53 and would also shift
+				// the rounding at the digit limit. A FLOAT/DOUBLE really is a double, so it keeps the
+				// numeric path, as does anything that isn't a plain decimal literal.
+				if (displayType === ColumnDisplayType.Decimal && isDecimalLiteral(value)) {
+					return formatDecimal(value, opts);
+				}
 				const num = typeof value === 'number' ? value : Number(value);
 				if (Number.isNaN(num)) { return SENTINEL_NAN; }
 				if (num === Infinity) { return SENTINEL_INF; }
@@ -985,7 +1002,7 @@ export class DatabricksTableView {
 					min_value: lo === null || lo === undefined ? undefined : String(lo),
 					max_value: hi === null || hi === undefined ? undefined : String(hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: medianRaw === null || medianRaw === undefined ? undefined : fmt(Number(medianRaw)),
+					median: formatNumericStat(medianRaw, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};
@@ -1247,57 +1264,6 @@ export class DatabricksTableView {
 /** Type guard distinguishing a contiguous index range from an explicit index set. */
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
-}
-
-/** Applies a thousands separator to the integer part of an already-formatted number string. */
-function applyThousandsSep(formatted: string, sep: string): string {
-	const negative = formatted.startsWith('-');
-	const body = negative ? formatted.slice(1) : formatted;
-	const [intPart, fracPart] = body.split('.');
-	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
-	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
-	return negative ? `-${result}` : result;
-}
-
-/** Formats a floating-point value following the Data Explorer FormatOptions. */
-function formatFloat(value: number, opts: FormatOptions): string {
-	const sciLimit = Math.pow(10, opts.max_integral_digits);
-	let formatted: string;
-	const abs = Math.abs(value);
-	if (abs !== 0 && abs >= sciLimit) {
-		return value.toExponential(opts.large_num_digits);
-	} else if (abs !== 0 && abs < 1) {
-		formatted = value.toFixed(opts.small_num_digits);
-	} else {
-		formatted = value.toFixed(opts.large_num_digits);
-	}
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/**
- * Whether a value is an exact integer literal: a string of digits with an optional sign. A
- * DECIMAL(n,0) arrives in this form, and it is only safe to format such a string as-is when it holds
- * nothing but digits -- anything else (an exponent, a decimal point, stray text) still goes through
- * `Number` so it is normalized rather than printed raw.
- */
-function isIntegerLiteral(value: unknown): value is string {
-	return typeof value === 'string' && /^[+-]?\d+$/.test(value);
-}
-
-/**
- * Formats an integer value, optionally with a thousands separator. Accepts an exact digit string
- * alongside number and bigint so a wide DECIMAL(n,0) keeps every digit: the body only stringifies its
- * argument, and `applyThousandsSep` groups the digits textually, so no step here narrows the value to
- * a JS number.
- */
-function formatInteger(value: number | bigint | string, opts: FormatOptions): string {
-	const formatted = value.toString();
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Truncates a string to the configured maximum formatted length. */
-function truncate(value: string, opts: FormatOptions): string {
-	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
 }
 
 /**

--- a/extensions/positron-data-driver-databricks/src/databricksTableView.ts
+++ b/extensions/positron-data-driver-databricks/src/databricksTableView.ts
@@ -1002,7 +1002,7 @@ export class DatabricksTableView {
 					min_value: lo === null || lo === undefined ? undefined : String(lo),
 					max_value: hi === null || hi === undefined ? undefined : String(hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: formatNumericStat(medianRaw, formatOptions),
+					median: formatNumericStat(medianRaw, display, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};

--- a/extensions/positron-data-driver-databricks/src/test/databricksTableView.test.ts
+++ b/extensions/positron-data-driver-databricks/src/test/databricksTableView.test.ts
@@ -90,11 +90,13 @@ suite('Databricks Column Profiles', () => {
 		// Constructor count + one scalar query; the median costs no separate round-trip.
 		assert.strictEqual(queries.length, 2);
 		assert.match(queries[1], /percentile_cont\(0\.5\) WITHIN GROUP \(ORDER BY `n`\)/);
+		// The median of an integer column formats as an integer, matching min_value and max_value
+		// (which are stringified directly) and the column's own cells. It used to read '20.00'.
 		assert.deepStrictEqual(profiles[0].summary_stats?.number_stats, {
 			min_value: '10',
 			max_value: '40',
 			mean: '25.00',
-			median: '20.00',
+			median: '20',
 			stdev: '12.91',
 		});
 	});

--- a/extensions/positron-data-driver-databricks/src/test/databricksTableView.test.ts
+++ b/extensions/positron-data-driver-databricks/src/test/databricksTableView.test.ts
@@ -349,6 +349,33 @@ suite('Databricks Cell Formatting', () => {
 		assert.strictEqual(await firstCell(entryToRead, 1e21), '1e+21');
 		assert.strictEqual(await firstCell(entryToRead, 42), '42');
 	});
+
+	test('a wide DECIMAL(n,2) keeps its exact digits', async () => {
+		// Same flag as the DECIMAL(n,0) case above, but a scale of 2 makes this a Decimal column
+		// rather than an Integer one. The integral part is past 2^53, so Number() would report
+		// ...994.00 for it. Room for the integral digits, so the value is not folded into a mantissa.
+		const wide = { ...FORMAT_OPTIONS, max_integral_digits: 40 };
+		const entryToRead = entry('amount', ColumnDisplayType.Decimal, 'decimal(38,2)');
+
+		assert.strictEqual(await firstCell(entryToRead, '9007199254740993.01', wide), '9007199254740993.01');
+	});
+
+	test('a DECIMAL rounds on its exact digits, while a DOUBLE still rounds as a double', async () => {
+		// The double nearest 1.005 is just below the half-way digit, so the two display types
+		// legitimately disagree here: the DECIMAL column holds exactly 1.005 and the DOUBLE does not.
+		const decimalEntry = entry('amount', ColumnDisplayType.Decimal, 'decimal(10,3)');
+		const doubleEntry = entry('rate', ColumnDisplayType.Floating, 'double');
+
+		assert.strictEqual(await firstCell(decimalEntry, '1.005'), '1.01');
+		assert.strictEqual(await firstCell(doubleEntry, 1.005), '1.00');
+	});
+
+	test('a DECIMAL that is not a plain decimal literal still goes through Number', async () => {
+		const entryToRead = entry('amount', ColumnDisplayType.Decimal, 'decimal(10,2)');
+
+		assert.strictEqual(await firstCell(entryToRead, ' 1.5 '), '1.50');
+		assert.strictEqual(await firstCell(entryToRead, 1.5), '1.50');
+	});
 });
 
 suite('Databricks Row Index Queries', () => {

--- a/extensions/positron-data-driver-databricks/src/test/valueFormatting.test.ts
+++ b/extensions/positron-data-driver-databricks/src/test/valueFormatting.test.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Covers positron-data-explorer-formatting, which every Data Explorer driver shares. The tests live
+// in this extension's suite because a build-time-only package has no suite of its own, and this one
+// already runs in CI (scripts/test-integration.sh).
+
+import * as assert from 'assert';
+import { FormatOptions } from 'positron-data-explorer-protocol';
+import { formatDecimal, formatFloat, formatNumericStat, isDecimalLiteral, isIntegerLiteral } from 'positron-data-explorer-formatting';
+
+// The options the Data Explorer actually sends (see languageRuntimeDataExplorerClient.ts): two
+// digits for a value at or above 1, four below it, and exponential notation past seven integral
+// digits.
+const DISPLAY: FormatOptions = {
+	large_num_digits: 2,
+	small_num_digits: 4,
+	max_integral_digits: 7,
+	max_value_length: 1000,
+	thousands_sep: '',
+};
+
+// The same options with room for a wide integral part. The exact digits of a DECIMAL(38,2) are only
+// visible when the options allow that many, so this is what the "keeps every digit" cases use.
+const WIDE: FormatOptions = { ...DISPLAY, max_integral_digits: 40 };
+
+const SEPARATED: FormatOptions = { ...DISPLAY, thousands_sep: ',' };
+
+suite('Shared Decimal Formatting', () => {
+
+	test('a value wider than a double keeps every digit', () => {
+		const values = [
+			'123456789012345678901234567890.12',
+			'9007199254740993.01',
+			'-9007199254740993.01',
+			// Rounding carries all the way into the integral part.
+			'9007199254740992.999',
+		];
+
+		assert.deepStrictEqual(values.map(v => formatDecimal(v, WIDE)), [
+			'123456789012345678901234567890.12',
+			'9007199254740993.01',
+			'-9007199254740993.01',
+			'9007199254740993.00',
+		]);
+		// What the same values used to render as, when they were coerced to a double first: the wide
+		// one collapses into exponential notation, and the ones near 2^53 land on the wrong digits.
+		assert.deepStrictEqual(values.map(v => formatFloat(Number(v), WIDE)), [
+			'1.2345678901234568e+29',
+			'9007199254740994.00',
+			'-9007199254740994.00',
+			'9007199254740992.00',
+		]);
+	});
+
+	test('rounding at the digit limit goes half away from zero on the exact digits', () => {
+		const values = ['1.005', '-1.005', '2.675', '0.00005', '0.000049', '0.999'];
+
+		assert.deepStrictEqual(values.map(v => formatDecimal(v, DISPLAY)),
+			['1.01', '-1.01', '2.68', '0.0001', '0.0000', '0.9990']);
+		// The double nearest 1.005 and 2.675 is just below the half-way digit, so coercing first
+		// rounds them down. This is the difference a financial column notices.
+		assert.deepStrictEqual(values.map(v => formatFloat(Number(v), DISPLAY)),
+			['1.00', '-1.00', '2.67', '0.0001', '0.0000', '0.9990']);
+	});
+
+	test('exponential notation starts past max_integral_digits', () => {
+		const values = ['9999999.99', '10000000', '99999999.9', '-12345678.9', '9999999.999'];
+
+		assert.deepStrictEqual(values.map(v => formatDecimal(v, DISPLAY)), [
+			'9999999.99',
+			'1.00e+7',
+			'1.00e+8',
+			'-1.23e+7',
+			// The notation is chosen from the unrounded magnitude, so a carry out of the fraction
+			// widens the result rather than pushing it into exponential form -- matching formatFloat.
+			'10000000.00',
+		]);
+	});
+
+	test('the thousands separator groups positional notation and leaves exponential alone', () => {
+		const values = ['1234567.891', '-1234567.891', '12345678.9', '0.5'];
+
+		assert.deepStrictEqual(values.map(v => formatDecimal(v, SEPARATED)),
+			['1,234,567.89', '-1,234,567.89', '1.23e+7', '0.5000']);
+	});
+
+	test('zero, sub-1 magnitudes and redundant digits render as a double would', () => {
+		const values = ['0', '-0.00', '0.5', '-0.00001', '.5', '007.5'];
+
+		assert.deepStrictEqual(values.map(v => formatDecimal(v, DISPLAY)),
+			['0.00', '0.00', '0.5000', '-0.0000', '0.5000', '7.50']);
+	});
+
+	test('every value a double holds exactly formats identically either way', () => {
+		// The exact path is only correct if it is a strict superset of the numeric one, so for values
+		// with no representation error the two must agree character for character.
+		const values = ['0', '1', '-1.5', '0.25', '-0.25', '0.0000152587890625', '1024.125',
+			'9999999', '9999999.25', '10000000', '-10000000', '123456789', '-0.001953125'];
+
+		assert.deepStrictEqual(
+			values.map(v => formatDecimal(v, DISPLAY)),
+			values.map(v => formatFloat(Number(v), DISPLAY)));
+	});
+
+	test('only plain positional notation takes the exact path', () => {
+		// Everything else has to keep going through Number: the non-finite numerics Postgres allows,
+		// exponent notation, and anything that isn't a number at all.
+		const values = ['12.5', '-12', '.5', 'NaN', 'Infinity', '-Infinity', '1e5', '', '12abc', ' 12 ', 12];
+
+		assert.deepStrictEqual(values.map(v => isDecimalLiteral(v)),
+			[true, true, true, false, false, false, false, false, false, false, false]);
+	});
+
+	test('only a canonical integer literal takes the exact path', () => {
+		// A non-canonical digit string must not reach `formatInteger`, which prints its argument
+		// verbatim: '007' would display as '007', and a zero-padded literal would be grouped into
+		// something like '00,000,000,000,000,001'. Excluding them here sends them through Number,
+		// which normalizes them.
+		const values = ['0', '42', '-42', '123456789012345678901234567890', '007', '+42', '-007',
+			'00000000000000001', '-0', '1.0', '1e5', '', ' 42 ', 42];
+
+		assert.deepStrictEqual(values.map(v => isIntegerLiteral(v)),
+			[true, true, true, true, false, false, false, false, false, false, false, false, false, false]);
+	});
+
+	test('a summary statistic keeps an exact decimal exact and passes a missing one through', () => {
+		assert.deepStrictEqual([
+			formatNumericStat(undefined, DISPLAY),
+			formatNumericStat(null, DISPLAY),
+			formatNumericStat('9007199254740993.01', WIDE),
+			formatNumericStat('1.005', DISPLAY),
+			// A computed statistic is a double by construction and takes the numeric path.
+			formatNumericStat(1.005, DISPLAY),
+		], [undefined, undefined, '9007199254740993.01', '1.01', '1.00']);
+	});
+});

--- a/extensions/positron-data-driver-databricks/src/test/valueFormatting.test.ts
+++ b/extensions/positron-data-driver-databricks/src/test/valueFormatting.test.ts
@@ -8,7 +8,7 @@
 // already runs in CI (scripts/test-integration.sh).
 
 import * as assert from 'assert';
-import { FormatOptions } from 'positron-data-explorer-protocol';
+import { ColumnDisplayType, FormatOptions } from 'positron-data-explorer-protocol';
 import { formatDecimal, formatFloat, formatNumericStat, isDecimalLiteral, isIntegerLiteral } from 'positron-data-explorer-formatting';
 
 // The options the Data Explorer actually sends (see languageRuntimeDataExplorerClient.ts): two
@@ -128,12 +128,46 @@ suite('Shared Decimal Formatting', () => {
 
 	test('a summary statistic keeps an exact decimal exact and passes a missing one through', () => {
 		assert.deepStrictEqual([
-			formatNumericStat(undefined, DISPLAY),
-			formatNumericStat(null, DISPLAY),
-			formatNumericStat('9007199254740993.01', WIDE),
-			formatNumericStat('1.005', DISPLAY),
+			formatNumericStat(undefined, ColumnDisplayType.Decimal, DISPLAY),
+			formatNumericStat(null, ColumnDisplayType.Decimal, DISPLAY),
+			formatNumericStat('9007199254740993.01', ColumnDisplayType.Decimal, WIDE),
+			formatNumericStat('1.005', ColumnDisplayType.Decimal, DISPLAY),
 			// A computed statistic is a double by construction and takes the numeric path.
-			formatNumericStat(1.005, DISPLAY),
+			formatNumericStat(1.005, ColumnDisplayType.Decimal, DISPLAY),
 		], [undefined, undefined, '9007199254740993.01', '1.01', '1.00']);
+	});
+
+	test('an integer column\'s statistics format as integers, matching its own min and max', () => {
+		// `min_value`/`max_value` are stringified directly by every driver, so a median that went
+		// through the float path reported a third format for the same column: min '1', max '5',
+		// median '3.00'.
+		assert.deepStrictEqual([
+			// A bigint must never reach `Number`, which would round it past 2^53.
+			formatNumericStat(9007199254740993n, ColumnDisplayType.Integer, SEPARATED),
+			// PostgreSQL hands back int8 as an exact string.
+			formatNumericStat('9007199254740993', ColumnDisplayType.Integer, SEPARATED),
+			formatNumericStat(42n, ColumnDisplayType.Integer, DISPLAY),
+			formatNumericStat(3, ColumnDisplayType.Integer, DISPLAY),
+		], ['9,007,199,254,740,993', '9,007,199,254,740,993', '42', '3']);
+	});
+
+	test('a fractional median of an integer column still renders as a decimal', () => {
+		// Several drivers compute the median with `percentile_cont`, which returns a double and
+		// yields a half value on an even number of rows. That is not a whole number and must not be
+		// printed as one.
+		assert.deepStrictEqual([
+			formatNumericStat(1.5, ColumnDisplayType.Integer, DISPLAY),
+			formatNumericStat(2.5, ColumnDisplayType.Integer, DISPLAY),
+		], ['1.50', '2.50']);
+	});
+
+	test('a whole-numbered decimal column keeps its fractional digits', () => {
+		// A DECIMAL(n,0) median arrives as '42' and looks like an integer, but its column renders
+		// cells as '42.00'. Routing on the value's shape rather than the column's display type would
+		// disagree with those cells.
+		assert.deepStrictEqual([
+			formatNumericStat('42', ColumnDisplayType.Decimal, DISPLAY),
+			formatNumericStat(42, ColumnDisplayType.Floating, DISPLAY),
+		], ['42.00', '42.00']);
 	});
 });

--- a/extensions/positron-data-driver-duckdb/package-lock.json
+++ b/extensions/positron-data-driver-duckdb/package-lock.json
@@ -36,6 +36,7 @@
       },
       "devDependencies": {
         "@types/node": "14.x",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "typescript": "^4.5.5"
       }

--- a/extensions/positron-data-driver-odbc/package-lock.json
+++ b/extensions/positron-data-driver-odbc/package-lock.json
@@ -19,12 +19,21 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
       "engines": {
         "vscode": "^1.65.0"
+      }
+    },
+    "../positron-data-explorer-formatting": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
       }
     },
     "../positron-data-explorer-protocol": {
@@ -4945,6 +4954,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/positron-data-explorer-formatting": {
+      "resolved": "../positron-data-explorer-formatting",
+      "link": true
     },
     "node_modules/positron-data-explorer-protocol": {
       "resolved": "../positron-data-explorer-protocol",

--- a/extensions/positron-data-driver-odbc/package.json
+++ b/extensions/positron-data-driver-odbc/package.json
@@ -22,6 +22,7 @@
     "odbc": "^2.5.0"
   },
   "devDependencies": {
+    "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
     "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",

--- a/extensions/positron-data-driver-odbc/src/odbcTableView.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcTableView.ts
@@ -949,7 +949,7 @@ export class OdbcTableView {
 					min_value: lo === null || lo === undefined ? undefined : String(lo),
 					max_value: hi === null || hi === undefined ? undefined : String(hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: formatNumericStat(median, formatOptions),
+					median: formatNumericStat(median, display, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};

--- a/extensions/positron-data-driver-odbc/src/odbcTableView.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcTableView.ts
@@ -69,6 +69,15 @@ import {
 	TableSelectionKind,
 	TextSearchType,
 } from 'positron-data-explorer-protocol';
+import {
+	formatDecimal,
+	formatFloat,
+	formatInteger,
+	formatNumericStat,
+	isDecimalLiteral,
+	isIntegerLiteral,
+	truncate,
+} from 'positron-data-explorer-formatting';
 
 /** Sentinel codes for special cell values, matching the Data Explorer wire protocol. */
 const SENTINEL_NULL = 0;
@@ -591,6 +600,13 @@ export class OdbcTableView {
 		switch (entry.type_display) {
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal: {
+				// Whether a DECIMAL/NUMERIC arrives as an exact string or as a JS number is up to the
+				// ODBC driver behind the connection. When it is a string, format it textually rather than
+				// coercing it: `Number` would drop the whole-number digits past 2^53 and would also shift
+				// the rounding at the digit limit.
+				if (entry.type_display === ColumnDisplayType.Decimal && isDecimalLiteral(value)) {
+					return formatDecimal(value, opts);
+				}
 				const num = typeof value === 'number' ? value : Number(value);
 				if (Number.isNaN(num)) { return SENTINEL_NAN; }
 				if (num === Infinity) { return SENTINEL_INF; }
@@ -598,7 +614,11 @@ export class OdbcTableView {
 				return formatFloat(num, opts);
 			}
 			case ColumnDisplayType.Integer: {
-				const num = typeof value === 'bigint' ? value : Number(value);
+				// Both wide integer shapes reach the formatter without passing through a JS number, which
+				// would round anything beyond 2^53: a 64-bit integer arrives as a bigint, and a
+				// DECIMAL(n,0) as an exact digit string. Anything else -- a plain number, or a string that
+				// isn't a clean integer literal -- is coerced as before.
+				const num = typeof value === 'bigint' || isIntegerLiteral(value) ? value : Number(value);
 				return formatInteger(num, opts);
 			}
 			case ColumnDisplayType.Boolean:
@@ -929,7 +949,7 @@ export class OdbcTableView {
 					min_value: lo === null || lo === undefined ? undefined : String(lo),
 					max_value: hi === null || hi === undefined ? undefined : String(hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: median === undefined ? undefined : fmt(median),
+					median: formatNumericStat(median, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};
@@ -1002,8 +1022,14 @@ export class OdbcTableView {
 	/**
 	 * Computes a quantile (0..1) by ordering the non-null values and reading the value at the
 	 * corresponding offset. `n` is the count of non-null values.
+	 *
+	 * Returns the raw cell value rather than a JS number, because its callers want different things
+	 * from it. The median is reported to the user, and a DECIMAL/NUMERIC median arrives as an exact
+	 * digit string that a double cannot hold, so `formatNumericStat` formats it textually. The
+	 * histogram's interquartile range is arithmetic on a bin width, which is approximate either way,
+	 * so those callers coerce.
 	 */
-	private async _quantile(quotedName: string, q: number, n: number): Promise<number | undefined> {
+	private async _quantile(quotedName: string, q: number, n: number): Promise<unknown> {
 		if (n === 0) {
 			return undefined;
 		}
@@ -1012,7 +1038,7 @@ export class OdbcTableView {
 			`SELECT ${quotedName} AS v FROM ${this._quotedTable}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
 			`ORDER BY ${quotedName}${this._paginate(1, offset)}`);
 		const value = firstValue(rows[0], 'v');
-		return value === null || value === undefined ? undefined : Number(value);
+		return value === null ? undefined : value;
 	}
 
 	private async _frequencyTable(quotedName: string, limit: number, filteredRows: number): Promise<ColumnFrequencyTable> {
@@ -1064,9 +1090,9 @@ export class OdbcTableView {
 				binWidth = peakToPeak / params.num_bins;
 				break;
 			case ColumnHistogramParamsMethod.FreedmanDiaconis: {
-				const q1 = await this._quantile(quotedName, 0.25, nonNull);
-				const q3 = await this._quantile(quotedName, 0.75, nonNull);
-				const iqr = (q3 ?? 0) - (q1 ?? 0);
+				const q1 = Number(await this._quantile(quotedName, 0.25, nonNull) ?? 0);
+				const q3 = Number(await this._quantile(quotedName, 0.75, nonNull) ?? 0);
+				const iqr = q3 - q1;
 				if (iqr > 0) {
 					binWidth = 2 * iqr * Math.pow(nonNull, -1 / 3);
 				}
@@ -1160,42 +1186,6 @@ function escapeLikePattern(term: string): string {
 /** Type guard distinguishing a contiguous index range from an explicit index set. */
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
-}
-
-/** Applies a thousands separator to the integer part of an already-formatted number string. */
-function applyThousandsSep(formatted: string, sep: string): string {
-	const negative = formatted.startsWith('-');
-	const body = negative ? formatted.slice(1) : formatted;
-	const [intPart, fracPart] = body.split('.');
-	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
-	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
-	return negative ? `-${result}` : result;
-}
-
-/** Formats a floating-point value following the Data Explorer FormatOptions. */
-function formatFloat(value: number, opts: FormatOptions): string {
-	const sciLimit = Math.pow(10, opts.max_integral_digits);
-	let formatted: string;
-	const abs = Math.abs(value);
-	if (abs !== 0 && abs >= sciLimit) {
-		return value.toExponential(opts.large_num_digits);
-	} else if (abs !== 0 && abs < 1) {
-		formatted = value.toFixed(opts.small_num_digits);
-	} else {
-		formatted = value.toFixed(opts.large_num_digits);
-	}
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Formats an integer value (number or bigint), optionally with a thousands separator. */
-function formatInteger(value: number | bigint, opts: FormatOptions): string {
-	const formatted = value.toString();
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Truncates a string to the configured maximum formatted length. */
-function truncate(value: string, opts: FormatOptions): string {
-	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
 }
 
 /** Stringifies a raw ODBC value for export, rendering null as 'NULL' and binary compactly. */

--- a/extensions/positron-data-driver-pins/package-lock.json
+++ b/extensions/positron-data-driver-pins/package-lock.json
@@ -37,6 +37,7 @@
       },
       "devDependencies": {
         "@types/node": "14.x",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "typescript": "^4.5.5"
       }

--- a/extensions/positron-data-driver-postgresql/package-lock.json
+++ b/extensions/positron-data-driver-postgresql/package-lock.json
@@ -20,12 +20,21 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
       "engines": {
         "vscode": "^1.65.0"
+      }
+    },
+    "../positron-data-explorer-formatting": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
       }
     },
     "../positron-data-explorer-protocol": {
@@ -4873,6 +4882,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/positron-data-explorer-formatting": {
+      "resolved": "../positron-data-explorer-formatting",
+      "link": true
     },
     "node_modules/positron-data-explorer-protocol": {
       "resolved": "../positron-data-explorer-protocol",

--- a/extensions/positron-data-driver-postgresql/package.json
+++ b/extensions/positron-data-driver-postgresql/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
+    "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
     "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/node": "14.x",
     "@types/pg": "^8.20.0",

--- a/extensions/positron-data-driver-postgresql/src/postgresqlTableView.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlTableView.ts
@@ -743,7 +743,7 @@ export class PostgresTableView {
 					min_value: rows[0]?.lo === null || rows[0]?.lo === undefined ? undefined : String(rows[0].lo),
 					max_value: rows[0]?.hi === null || rows[0]?.hi === undefined ? undefined : String(rows[0].hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: formatNumericStat(median, formatOptions),
+					median: formatNumericStat(median, display, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};

--- a/extensions/positron-data-driver-postgresql/src/postgresqlTableView.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlTableView.ts
@@ -60,6 +60,15 @@ import {
 	TableSelectionKind,
 	TextSearchType,
 } from 'positron-data-explorer-protocol';
+import {
+	formatDecimal,
+	formatFloat,
+	formatInteger,
+	formatNumericStat,
+	isDecimalLiteral,
+	isIntegerLiteral,
+	truncate,
+} from 'positron-data-explorer-formatting';
 
 /** The query surface the table view needs. Implemented by the connection over its `pg` client. */
 export interface IPostgresQueryClient {
@@ -422,6 +431,14 @@ export class PostgresTableView {
 		switch (displayType) {
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal: {
+				// `pg` hands back numeric/decimal as an exact string precisely because a JS number cannot
+				// hold it, so it is formatted textually: `Number` would drop the whole-number digits past
+				// 2^53 and would also shift the rounding at the digit limit. A float4/float8 really is a
+				// double, so it keeps the numeric path, as do the non-finite numerics Postgres allows
+				// ('NaN', 'Infinity', '-Infinity'), which fall through to the sentinels below.
+				if (displayType === ColumnDisplayType.Decimal && isDecimalLiteral(value)) {
+					return formatDecimal(value, opts);
+				}
 				const num = typeof value === 'number' ? value : Number(value);
 				if (Number.isNaN(num)) { return SENTINEL_NAN; }
 				if (num === Infinity) { return SENTINEL_INF; }
@@ -726,7 +743,7 @@ export class PostgresTableView {
 					min_value: rows[0]?.lo === null || rows[0]?.lo === undefined ? undefined : String(rows[0].lo),
 					max_value: rows[0]?.hi === null || rows[0]?.hi === undefined ? undefined : String(rows[0].hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: median === undefined ? undefined : fmt(median),
+					median: formatNumericStat(median, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};
@@ -792,8 +809,14 @@ export class PostgresTableView {
 	/**
 	 * Computes a quantile (0..1) by ordering the non-null values and reading the value at the
 	 * corresponding offset. `n` is the count of non-null values.
+	 *
+	 * Returns the raw cell value rather than a JS number, because its callers want different things
+	 * from it. The median is reported to the user, and a DECIMAL/NUMERIC median arrives as an exact
+	 * digit string that a double cannot hold, so `formatNumericStat` formats it textually. The
+	 * histogram's interquartile range is arithmetic on a bin width, which is approximate either way,
+	 * so those callers coerce.
 	 */
-	private async _quantile(quotedName: string, q: number, n: number): Promise<number | undefined> {
+	private async _quantile(quotedName: string, q: number, n: number): Promise<unknown> {
 		if (n === 0) {
 			return undefined;
 		}
@@ -802,7 +825,7 @@ export class PostgresTableView {
 			`SELECT ${quotedName} AS v FROM ${this._quotedTable}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
 			`ORDER BY ${quotedName} LIMIT 1 OFFSET ${offset}`);
 		const value = rows[0]?.v;
-		return value === null || value === undefined ? undefined : Number(value);
+		return value === null ? undefined : value;
 	}
 
 	private async _frequencyTable(quotedName: string, limit: number, filteredRows: number): Promise<ColumnFrequencyTable> {
@@ -852,9 +875,9 @@ export class PostgresTableView {
 				binWidth = peakToPeak / params.num_bins;
 				break;
 			case ColumnHistogramParamsMethod.FreedmanDiaconis: {
-				const q1 = await this._quantile(quotedName, 0.25, nonNull);
-				const q3 = await this._quantile(quotedName, 0.75, nonNull);
-				const iqr = (q3 ?? 0) - (q1 ?? 0);
+				const q1 = Number(await this._quantile(quotedName, 0.25, nonNull) ?? 0);
+				const q3 = Number(await this._quantile(quotedName, 0.75, nonNull) ?? 0);
+				const iqr = q3 - q1;
 				if (iqr > 0) {
 					binWidth = 2 * iqr * Math.pow(nonNull, -1 / 3);
 				}
@@ -901,57 +924,6 @@ export class PostgresTableView {
 /** Type guard distinguishing a contiguous index range from an explicit index set. */
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
-}
-
-/** Applies a thousands separator to the integer part of an already-formatted number string. */
-function applyThousandsSep(formatted: string, sep: string): string {
-	const negative = formatted.startsWith('-');
-	const body = negative ? formatted.slice(1) : formatted;
-	const [intPart, fracPart] = body.split('.');
-	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
-	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
-	return negative ? `-${result}` : result;
-}
-
-/** Formats a floating-point value following the Data Explorer FormatOptions. */
-function formatFloat(value: number, opts: FormatOptions): string {
-	const sciLimit = Math.pow(10, opts.max_integral_digits);
-	let formatted: string;
-	const abs = Math.abs(value);
-	if (abs !== 0 && abs >= sciLimit) {
-		return value.toExponential(opts.large_num_digits);
-	} else if (abs !== 0 && abs < 1) {
-		formatted = value.toFixed(opts.small_num_digits);
-	} else {
-		formatted = value.toFixed(opts.large_num_digits);
-	}
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/**
- * Whether a value is an exact integer literal: a string of digits with an optional sign. `pg` returns
- * int8/bigint in this form, and it is only safe to format such a string as-is when it holds nothing
- * but digits -- anything else (an exponent, a decimal point, stray text) still goes through `Number`
- * so it is normalized rather than printed raw.
- */
-function isIntegerLiteral(value: unknown): value is string {
-	return typeof value === 'string' && /^[+-]?\d+$/.test(value);
-}
-
-/**
- * Formats an integer value, optionally with a thousands separator. Accepts an exact digit string
- * alongside number and bigint so a wide int8 keeps every digit: the body only stringifies its
- * argument, and `applyThousandsSep` groups the digits textually, so no step here narrows the value to
- * a JS number.
- */
-function formatInteger(value: number | bigint | string, opts: FormatOptions): string {
-	const formatted = value.toString();
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Truncates a string to the configured maximum formatted length. */
-function truncate(value: string, opts: FormatOptions): string {
-	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
 }
 
 /** Stringifies a raw PostgreSQL value for export, rendering null as 'NULL' and dates as ISO. */

--- a/extensions/positron-data-driver-redshift/package-lock.json
+++ b/extensions/positron-data-driver-redshift/package-lock.json
@@ -20,12 +20,21 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
       "engines": {
         "vscode": "^1.65.0"
+      }
+    },
+    "../positron-data-explorer-formatting": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
       }
     },
     "../positron-data-explorer-protocol": {
@@ -4915,6 +4924,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/positron-data-explorer-formatting": {
+      "resolved": "../positron-data-explorer-formatting",
+      "link": true
     },
     "node_modules/positron-data-explorer-protocol": {
       "resolved": "../positron-data-explorer-protocol",

--- a/extensions/positron-data-driver-redshift/package.json
+++ b/extensions/positron-data-driver-redshift/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
+    "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
     "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/node": "14.x",
     "@types/pg": "^8.20.0",

--- a/extensions/positron-data-driver-redshift/src/redshiftTableView.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftTableView.ts
@@ -976,7 +976,7 @@ export class RedshiftTableView {
 					min_value: lo === null || lo === undefined ? undefined : String(lo),
 					max_value: hi === null || hi === undefined ? undefined : String(hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: formatNumericStat(medianRaw, formatOptions),
+					median: formatNumericStat(medianRaw, display, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};

--- a/extensions/positron-data-driver-redshift/src/redshiftTableView.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftTableView.ts
@@ -67,6 +67,15 @@ import {
 	TableSelectionKind,
 	TextSearchType,
 } from 'positron-data-explorer-protocol';
+import {
+	formatDecimal,
+	formatFloat,
+	formatInteger,
+	formatNumericStat,
+	isDecimalLiteral,
+	isIntegerLiteral,
+	truncate,
+} from 'positron-data-explorer-formatting';
 
 /** The query surface the table view needs. Implemented by the connection over its `pg` client. */
 export interface IRedshiftQueryClient {
@@ -478,6 +487,14 @@ export class RedshiftTableView {
 		switch (displayType) {
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal: {
+				// `pg` hands back numeric/decimal as an exact string precisely because a JS number cannot
+				// hold it, so it is formatted textually: `Number` would drop the whole-number digits past
+				// 2^53 and would also shift the rounding at the digit limit. A float4/float8 really is a
+				// double, so it keeps the numeric path, as does anything that isn't a plain decimal
+				// literal.
+				if (displayType === ColumnDisplayType.Decimal && isDecimalLiteral(value)) {
+					return formatDecimal(value, opts);
+				}
 				const num = typeof value === 'number' ? value : Number(value);
 				if (Number.isNaN(num)) { return SENTINEL_NAN; }
 				if (num === Infinity) { return SENTINEL_INF; }
@@ -959,7 +976,7 @@ export class RedshiftTableView {
 					min_value: lo === null || lo === undefined ? undefined : String(lo),
 					max_value: hi === null || hi === undefined ? undefined : String(hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: medianRaw === null || medianRaw === undefined ? undefined : fmt(Number(medianRaw)),
+					median: formatNumericStat(medianRaw, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};
@@ -1231,57 +1248,6 @@ export class RedshiftTableView {
 /** Type guard distinguishing a contiguous index range from an explicit index set. */
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
-}
-
-/** Applies a thousands separator to the integer part of an already-formatted number string. */
-function applyThousandsSep(formatted: string, sep: string): string {
-	const negative = formatted.startsWith('-');
-	const body = negative ? formatted.slice(1) : formatted;
-	const [intPart, fracPart] = body.split('.');
-	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
-	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
-	return negative ? `-${result}` : result;
-}
-
-/** Formats a floating-point value following the Data Explorer FormatOptions. */
-function formatFloat(value: number, opts: FormatOptions): string {
-	const sciLimit = Math.pow(10, opts.max_integral_digits);
-	let formatted: string;
-	const abs = Math.abs(value);
-	if (abs !== 0 && abs >= sciLimit) {
-		return value.toExponential(opts.large_num_digits);
-	} else if (abs !== 0 && abs < 1) {
-		formatted = value.toFixed(opts.small_num_digits);
-	} else {
-		formatted = value.toFixed(opts.large_num_digits);
-	}
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/**
- * Whether a value is an exact integer literal: a string of digits with an optional sign. `pg` returns
- * int8/bigint in this form, and it is only safe to format such a string as-is when it holds nothing
- * but digits -- anything else (an exponent, a decimal point, stray text) still goes through `Number`
- * so it is normalized rather than printed raw.
- */
-function isIntegerLiteral(value: unknown): value is string {
-	return typeof value === 'string' && /^[+-]?\d+$/.test(value);
-}
-
-/**
- * Formats an integer value, optionally with a thousands separator. Accepts an exact digit string
- * alongside number and bigint so a wide int8 keeps every digit: the body only stringifies its
- * argument, and `applyThousandsSep` groups the digits textually, so no step here narrows the value to
- * a JS number.
- */
-function formatInteger(value: number | bigint | string, opts: FormatOptions): string {
-	const formatted = value.toString();
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Truncates a string to the configured maximum formatted length. */
-function truncate(value: string, opts: FormatOptions): string {
-	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
 }
 
 /** Stringifies a raw Redshift value for export, rendering null as 'NULL' and dates as ISO. */

--- a/extensions/positron-data-driver-redshift/src/test/redshiftTableView.test.ts
+++ b/extensions/positron-data-driver-redshift/src/test/redshiftTableView.test.ts
@@ -88,11 +88,13 @@ suite('Redshift Column Profiles', () => {
 		// Constructor count + one scalar query; the median no longer costs a separate round-trip.
 		assert.strictEqual(queries.length, 2);
 		assert.strictEqual(profiles[0].null_count, 0);
+		// The median of an integer column formats as an integer, matching min_value and max_value
+		// (which are stringified directly) and the column's own cells. It used to read '20.00'.
 		assert.deepStrictEqual(profiles[0].summary_stats?.number_stats, {
 			min_value: '10',
 			max_value: '40',
 			mean: '25.00',
-			median: '20.00',
+			median: '20',
 			stdev: '12.91',
 		});
 	});

--- a/extensions/positron-data-driver-snowflake/package-lock.json
+++ b/extensions/positron-data-driver-snowflake/package-lock.json
@@ -20,12 +20,21 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
       "engines": {
         "vscode": "^1.65.0"
+      }
+    },
+    "../positron-data-explorer-formatting": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
       }
     },
     "../positron-data-explorer-protocol": {
@@ -5964,6 +5973,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/positron-data-explorer-formatting": {
+      "resolved": "../positron-data-explorer-formatting",
+      "link": true
     },
     "node_modules/positron-data-explorer-protocol": {
       "resolved": "../positron-data-explorer-protocol",

--- a/extensions/positron-data-driver-snowflake/package.json
+++ b/extensions/positron-data-driver-snowflake/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
+    "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
     "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/node": "14.x",
     "@typescript-eslint/eslint-plugin": "^5.12.1",

--- a/extensions/positron-data-driver-snowflake/src/snowflakeTableView.ts
+++ b/extensions/positron-data-driver-snowflake/src/snowflakeTableView.ts
@@ -69,6 +69,15 @@ import {
 	TableSelectionKind,
 	TextSearchType,
 } from 'positron-data-explorer-protocol';
+import {
+	formatDecimal,
+	formatFloat,
+	formatInteger,
+	formatNumericStat,
+	isDecimalLiteral,
+	isIntegerLiteral,
+	truncate,
+} from 'positron-data-explorer-formatting';
 
 /** The query surface the table view needs. Implemented by the connection over its sdk client. */
 export interface ISnowflakeQueryClient {
@@ -505,6 +514,14 @@ export class SnowflakeTableView {
 		switch (displayType) {
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal: {
+				// `snowflake-sdk` yields a JS number for NUMBER columns, so a wide DECIMAL has already
+				// lost its precision by the time it reaches here and this guard does not fire. Recovering
+				// it means changing how the SDK's results are parsed, which is separable work (see
+				// #15366); the exact-string path is shared with the other drivers so it will simply start
+				// working once the values arrive intact.
+				if (displayType === ColumnDisplayType.Decimal && isDecimalLiteral(value)) {
+					return formatDecimal(value, opts);
+				}
 				const num = typeof value === 'number' ? value : Number(value);
 				if (Number.isNaN(num)) { return SENTINEL_NAN; }
 				if (num === Infinity) { return SENTINEL_INF; }
@@ -512,7 +529,11 @@ export class SnowflakeTableView {
 				return formatFloat(num, opts);
 			}
 			case ColumnDisplayType.Integer: {
-				const num = typeof value === 'bigint' ? value : Number(value);
+				// Both wide integer shapes reach the formatter without passing through a JS number, which
+				// would round anything beyond 2^53: a 64-bit integer arrives as a bigint, and a
+				// DECIMAL(n,0) as an exact digit string. Anything else -- a plain number, or a string that
+				// isn't a clean integer literal -- is coerced as before.
+				const num = typeof value === 'bigint' || isIntegerLiteral(value) ? value : Number(value);
 				return formatInteger(num, opts);
 			}
 			case ColumnDisplayType.Boolean:
@@ -1000,7 +1021,7 @@ export class SnowflakeTableView {
 					min_value: lo === null || lo === undefined ? undefined : String(lo),
 					max_value: hi === null || hi === undefined ? undefined : String(hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: medianRaw === null || medianRaw === undefined ? undefined : fmt(Number(medianRaw)),
+					median: formatNumericStat(medianRaw, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};
@@ -1264,42 +1285,6 @@ export class SnowflakeTableView {
 /** Type guard distinguishing a contiguous index range from an explicit index set. */
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
-}
-
-/** Applies a thousands separator to the integer part of an already-formatted number string. */
-function applyThousandsSep(formatted: string, sep: string): string {
-	const negative = formatted.startsWith('-');
-	const body = negative ? formatted.slice(1) : formatted;
-	const [intPart, fracPart] = body.split('.');
-	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
-	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
-	return negative ? `-${result}` : result;
-}
-
-/** Formats a floating-point value following the Data Explorer FormatOptions. */
-function formatFloat(value: number, opts: FormatOptions): string {
-	const sciLimit = Math.pow(10, opts.max_integral_digits);
-	let formatted: string;
-	const abs = Math.abs(value);
-	if (abs !== 0 && abs >= sciLimit) {
-		return value.toExponential(opts.large_num_digits);
-	} else if (abs !== 0 && abs < 1) {
-		formatted = value.toFixed(opts.small_num_digits);
-	} else {
-		formatted = value.toFixed(opts.large_num_digits);
-	}
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Formats an integer value (number or bigint), optionally with a thousands separator. */
-function formatInteger(value: number | bigint, opts: FormatOptions): string {
-	const formatted = value.toString();
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Truncates a string to the configured maximum formatted length. */
-function truncate(value: string, opts: FormatOptions): string {
-	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
 }
 
 /**

--- a/extensions/positron-data-driver-snowflake/src/snowflakeTableView.ts
+++ b/extensions/positron-data-driver-snowflake/src/snowflakeTableView.ts
@@ -1021,7 +1021,7 @@ export class SnowflakeTableView {
 					min_value: lo === null || lo === undefined ? undefined : String(lo),
 					max_value: hi === null || hi === undefined ? undefined : String(hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: formatNumericStat(medianRaw, formatOptions),
+					median: formatNumericStat(medianRaw, display, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};

--- a/extensions/positron-data-driver-snowflake/src/test/snowflakeTableView.test.ts
+++ b/extensions/positron-data-driver-snowflake/src/test/snowflakeTableView.test.ts
@@ -88,11 +88,13 @@ suite('Snowflake Column Profiles', () => {
 		// Constructor count + one scalar query; the median no longer costs a separate round-trip.
 		assert.strictEqual(queries.length, 2);
 		assert.strictEqual(profiles[0].null_count, 0);
+		// The median of an integer column formats as an integer, matching min_value and max_value
+		// (which are stringified directly) and the column's own cells. It used to read '20.00'.
 		assert.deepStrictEqual(profiles[0].summary_stats?.number_stats, {
 			min_value: '10',
 			max_value: '40',
 			mean: '25.00',
-			median: '20.00',
+			median: '20',
 			stdev: '12.91',
 		});
 	});

--- a/extensions/positron-data-driver-sqlite/package-lock.json
+++ b/extensions/positron-data-driver-sqlite/package-lock.json
@@ -20,12 +20,21 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
       "engines": {
         "vscode": "^1.65.0"
+      }
+    },
+    "../positron-data-explorer-formatting": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
       }
     },
     "../positron-data-explorer-protocol": {
@@ -4793,6 +4802,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/positron-data-explorer-formatting": {
+      "resolved": "../positron-data-explorer-formatting",
+      "link": true
     },
     "node_modules/positron-data-explorer-protocol": {
       "resolved": "../positron-data-explorer-protocol",

--- a/extensions/positron-data-driver-sqlite/package.json
+++ b/extensions/positron-data-driver-sqlite/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
+    "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
     "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",

--- a/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
@@ -59,6 +59,15 @@ import {
 	TableSelectionKind,
 	TextSearchType,
 } from 'positron-data-explorer-protocol';
+import {
+	formatDecimal,
+	formatFloat,
+	formatInteger,
+	formatNumericStat,
+	isDecimalLiteral,
+	isIntegerLiteral,
+	truncate,
+} from 'positron-data-explorer-formatting';
 
 /** Sentinel codes for special cell values, matching the Data Explorer wire protocol. */
 const SENTINEL_NULL = 0;
@@ -394,6 +403,14 @@ export class SqliteTableView {
 		switch (displayType) {
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal: {
+				// A DECIMAL column has NUMERIC affinity, which converts an inserted literal to REAL or
+				// INTEGER at write time, so the exact digits of a wide value never reach the file and
+				// this guard does not fire for them. It is still worth having: a value stored in a column
+				// SQLite could not convert arrives as text, and formatting that textually avoids a
+				// round-trip through a double.
+				if (displayType === ColumnDisplayType.Decimal && isDecimalLiteral(value)) {
+					return formatDecimal(value, opts);
+				}
 				const num = typeof value === 'number' ? value : Number(value);
 				if (Number.isNaN(num)) { return SENTINEL_NAN; }
 				if (num === Infinity) { return SENTINEL_INF; }
@@ -401,7 +418,11 @@ export class SqliteTableView {
 				return formatFloat(num, opts);
 			}
 			case ColumnDisplayType.Integer: {
-				const num = typeof value === 'bigint' ? value : Number(value);
+				// Both wide integer shapes reach the formatter without passing through a JS number, which
+				// would round anything beyond 2^53: a 64-bit integer arrives as a bigint, and a
+				// DECIMAL(n,0) as an exact digit string. Anything else -- a plain number, or a string that
+				// isn't a clean integer literal -- is coerced as before.
+				const num = typeof value === 'bigint' || isIntegerLiteral(value) ? value : Number(value);
 				return formatInteger(num, opts);
 			}
 			case ColumnDisplayType.Boolean:
@@ -731,7 +752,7 @@ export class SqliteTableView {
 					min_value: rows[0]?.lo === null || rows[0]?.lo === undefined ? undefined : String(rows[0].lo),
 					max_value: rows[0]?.hi === null || rows[0]?.hi === undefined ? undefined : String(rows[0].hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: median === undefined ? undefined : fmt(median),
+					median: formatNumericStat(median, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};
@@ -796,8 +817,14 @@ export class SqliteTableView {
 	/**
 	 * Computes a quantile (0..1) by ordering the non-null values and reading the value at the
 	 * corresponding offset. `n` is the count of non-null values.
+	 *
+	 * Returns the raw cell value rather than a JS number, because its callers want different things
+	 * from it. The median is reported to the user, and a DECIMAL/NUMERIC median arrives as an exact
+	 * digit string that a double cannot hold, so `formatNumericStat` formats it textually. The
+	 * histogram's interquartile range is arithmetic on a bin width, which is approximate either way,
+	 * so those callers coerce.
 	 */
-	private async _quantile(quotedName: string, q: number, n: number): Promise<number | undefined> {
+	private async _quantile(quotedName: string, q: number, n: number): Promise<unknown> {
 		if (n === 0) {
 			return undefined;
 		}
@@ -806,7 +833,7 @@ export class SqliteTableView {
 			`SELECT ${quotedName} AS v FROM ${await this._relation()}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
 			`ORDER BY ${quotedName} LIMIT 1 OFFSET ${offset}`);
 		const value = rows[0]?.v;
-		return value === null || value === undefined ? undefined : Number(value);
+		return value === null ? undefined : value;
 	}
 
 	private async _frequencyTable(quotedName: string, limit: number, filteredRows: number): Promise<ColumnFrequencyTable> {
@@ -856,9 +883,9 @@ export class SqliteTableView {
 				binWidth = peakToPeak / params.num_bins;
 				break;
 			case ColumnHistogramParamsMethod.FreedmanDiaconis: {
-				const q1 = await this._quantile(quotedName, 0.25, nonNull);
-				const q3 = await this._quantile(quotedName, 0.75, nonNull);
-				const iqr = (q3 ?? 0) - (q1 ?? 0);
+				const q1 = Number(await this._quantile(quotedName, 0.25, nonNull) ?? 0);
+				const q3 = Number(await this._quantile(quotedName, 0.75, nonNull) ?? 0);
+				const iqr = q3 - q1;
 				if (iqr > 0) {
 					binWidth = 2 * iqr * Math.pow(nonNull, -1 / 3);
 				}
@@ -906,42 +933,6 @@ export class SqliteTableView {
 /** Type guard distinguishing a contiguous index range from an explicit index set. */
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
-}
-
-/** Applies a thousands separator to the integer part of an already-formatted number string. */
-function applyThousandsSep(formatted: string, sep: string): string {
-	const negative = formatted.startsWith('-');
-	const body = negative ? formatted.slice(1) : formatted;
-	const [intPart, fracPart] = body.split('.');
-	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
-	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
-	return negative ? `-${result}` : result;
-}
-
-/** Formats a floating-point value following the Data Explorer FormatOptions. */
-function formatFloat(value: number, opts: FormatOptions): string {
-	const sciLimit = Math.pow(10, opts.max_integral_digits);
-	let formatted: string;
-	const abs = Math.abs(value);
-	if (abs !== 0 && abs >= sciLimit) {
-		return value.toExponential(opts.large_num_digits);
-	} else if (abs !== 0 && abs < 1) {
-		formatted = value.toFixed(opts.small_num_digits);
-	} else {
-		formatted = value.toFixed(opts.large_num_digits);
-	}
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Formats an integer value (number or bigint), optionally with a thousands separator. */
-function formatInteger(value: number | bigint, opts: FormatOptions): string {
-	const formatted = value.toString();
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Truncates a string to the configured maximum formatted length. */
-function truncate(value: string, opts: FormatOptions): string {
-	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
 }
 
 /** Stringifies a raw SQLite value for export, rendering null as 'NULL' and BLOBs compactly. */

--- a/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
+++ b/extensions/positron-data-driver-sqlite/src/sqliteTableView.ts
@@ -752,7 +752,7 @@ export class SqliteTableView {
 					min_value: rows[0]?.lo === null || rows[0]?.lo === undefined ? undefined : String(rows[0].lo),
 					max_value: rows[0]?.hi === null || rows[0]?.hi === undefined ? undefined : String(rows[0].hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: formatNumericStat(median, formatOptions),
+					median: formatNumericStat(median, display, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};

--- a/extensions/positron-data-explorer-duckdb/package-lock.json
+++ b/extensions/positron-data-explorer-duckdb/package-lock.json
@@ -12,6 +12,15 @@
       },
       "devDependencies": {
         "@types/node": "14.x",
+        "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
+      }
+    },
+    "../positron-data-explorer-formatting": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
         "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "typescript": "^4.5.5"
       }
@@ -182,6 +191,10 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/positron-data-explorer-formatting": {
+      "resolved": "../positron-data-explorer-formatting",
+      "link": true
     },
     "node_modules/positron-data-explorer-protocol": {
       "resolved": "../positron-data-explorer-protocol",

--- a/extensions/positron-data-explorer-duckdb/package.json
+++ b/extensions/positron-data-explorer-duckdb/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "14.x",
+    "positron-data-explorer-formatting": "file:../positron-data-explorer-formatting",
     "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "typescript": "^4.5.5"
   }

--- a/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
@@ -773,7 +773,7 @@ export class DuckDBTableView {
 					min_value: rows[0]?.lo === null || rows[0]?.lo === undefined ? undefined : String(rows[0].lo),
 					max_value: rows[0]?.hi === null || rows[0]?.hi === undefined ? undefined : String(rows[0].hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: formatNumericStat(median, formatOptions),
+					median: formatNumericStat(median, display, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};

--- a/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
+++ b/extensions/positron-data-explorer-duckdb/src/duckdbTableView.ts
@@ -63,6 +63,15 @@ import {
 	TableSelectionKind,
 	TextSearchType,
 } from 'positron-data-explorer-protocol';
+import {
+	formatDecimal,
+	formatFloat,
+	formatInteger,
+	formatNumericStat,
+	isDecimalLiteral,
+	isIntegerLiteral,
+	truncate,
+} from 'positron-data-explorer-formatting';
 
 /** Sentinel codes for special cell values, matching the Data Explorer wire protocol. */
 const SENTINEL_NULL = 0;
@@ -421,6 +430,14 @@ export class DuckDBTableView {
 		switch (displayType) {
 			case ColumnDisplayType.Floating:
 			case ColumnDisplayType.Decimal: {
+				// `getRowObjectsJS` yields a JS number for DECIMAL columns, so a wide DECIMAL has already
+				// lost its precision by the time it reaches here and this guard does not fire. Recovering
+				// it means reading those columns as their exact text at the worker boundary, which is
+				// separable work (see #15366); the exact-string path is shared with the other drivers so
+				// it will simply start working once the values arrive intact.
+				if (displayType === ColumnDisplayType.Decimal && isDecimalLiteral(value)) {
+					return formatDecimal(value, opts);
+				}
 				const num = typeof value === 'number' ? value : Number(value);
 				if (Number.isNaN(num)) { return SENTINEL_NAN; }
 				if (num === Infinity) { return SENTINEL_INF; }
@@ -428,7 +445,11 @@ export class DuckDBTableView {
 				return formatFloat(num, opts);
 			}
 			case ColumnDisplayType.Integer: {
-				const num = typeof value === 'bigint' ? value : Number(value);
+				// Both wide integer shapes reach the formatter without passing through a JS number, which
+				// would round anything beyond 2^53: a 64-bit integer arrives as a bigint, and a
+				// DECIMAL(n,0) as an exact digit string. Anything else -- a plain number, or a string that
+				// isn't a clean integer literal -- is coerced as before.
+				const num = typeof value === 'bigint' || isIntegerLiteral(value) ? value : Number(value);
 				return formatInteger(num, opts);
 			}
 			case ColumnDisplayType.Boolean:
@@ -752,7 +773,7 @@ export class DuckDBTableView {
 					min_value: rows[0]?.lo === null || rows[0]?.lo === undefined ? undefined : String(rows[0].lo),
 					max_value: rows[0]?.hi === null || rows[0]?.hi === undefined ? undefined : String(rows[0].hi),
 					mean: n > 0 ? fmt(mean) : undefined,
-					median: median === undefined ? undefined : fmt(median),
+					median: formatNumericStat(median, formatOptions),
 					stdev: n > 1 ? fmt(Math.sqrt(variance)) : undefined,
 				},
 			};
@@ -818,8 +839,14 @@ export class DuckDBTableView {
 	/**
 	 * Computes a quantile (0..1) by ordering the non-null values and reading the value at the
 	 * corresponding offset. `n` is the count of non-null values.
+	 *
+	 * Returns the raw cell value rather than a JS number, because its callers want different things
+	 * from it. The median is reported to the user, and a DECIMAL/NUMERIC median arrives as an exact
+	 * digit string that a double cannot hold, so `formatNumericStat` formats it textually. The
+	 * histogram's interquartile range is arithmetic on a bin width, which is approximate either way,
+	 * so those callers coerce.
 	 */
-	private async _quantile(quotedName: string, q: number, n: number): Promise<number | undefined> {
+	private async _quantile(quotedName: string, q: number, n: number): Promise<unknown> {
 		if (n === 0) {
 			return undefined;
 		}
@@ -828,7 +855,7 @@ export class DuckDBTableView {
 			`SELECT ${quotedName} AS v FROM ${await this._relation()}${this._wherePlus(`${quotedName} IS NOT NULL`)} ` +
 			`ORDER BY ${quotedName} LIMIT 1 OFFSET ${offset}`);
 		const value = rows[0]?.v;
-		return value === null || value === undefined ? undefined : Number(value);
+		return value === null ? undefined : value;
 	}
 
 	private async _frequencyTable(quotedName: string, limit: number, filteredRows: number): Promise<ColumnFrequencyTable> {
@@ -878,9 +905,9 @@ export class DuckDBTableView {
 				binWidth = peakToPeak / params.num_bins;
 				break;
 			case ColumnHistogramParamsMethod.FreedmanDiaconis: {
-				const q1 = await this._quantile(quotedName, 0.25, nonNull);
-				const q3 = await this._quantile(quotedName, 0.75, nonNull);
-				const iqr = (q3 ?? 0) - (q1 ?? 0);
+				const q1 = Number(await this._quantile(quotedName, 0.25, nonNull) ?? 0);
+				const q3 = Number(await this._quantile(quotedName, 0.75, nonNull) ?? 0);
+				const iqr = q3 - q1;
 				if (iqr > 0) {
 					binWidth = 2 * iqr * Math.pow(nonNull, -1 / 3);
 				}
@@ -927,42 +954,6 @@ export class DuckDBTableView {
 /** Type guard distinguishing a contiguous index range from an explicit index set. */
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
-}
-
-/** Applies a thousands separator to the integer part of an already-formatted number string. */
-function applyThousandsSep(formatted: string, sep: string): string {
-	const negative = formatted.startsWith('-');
-	const body = negative ? formatted.slice(1) : formatted;
-	const [intPart, fracPart] = body.split('.');
-	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
-	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
-	return negative ? `-${result}` : result;
-}
-
-/** Formats a floating-point value following the Data Explorer FormatOptions. */
-function formatFloat(value: number, opts: FormatOptions): string {
-	const sciLimit = Math.pow(10, opts.max_integral_digits);
-	let formatted: string;
-	const abs = Math.abs(value);
-	if (abs !== 0 && abs >= sciLimit) {
-		return value.toExponential(opts.large_num_digits);
-	} else if (abs !== 0 && abs < 1) {
-		formatted = value.toFixed(opts.small_num_digits);
-	} else {
-		formatted = value.toFixed(opts.large_num_digits);
-	}
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Formats an integer value (number or bigint), optionally with a thousands separator. */
-function formatInteger(value: number | bigint, opts: FormatOptions): string {
-	const formatted = value.toString();
-	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
-}
-
-/** Truncates a string to the configured maximum formatted length. */
-function truncate(value: string, opts: FormatOptions): string {
-	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
 }
 
 /** Stringifies a raw DuckDB value for export, rendering null as 'NULL' and BLOBs compactly. */

--- a/extensions/positron-data-explorer-formatting/package-lock.json
+++ b/extensions/positron-data-explorer-formatting/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "positron-data-explorer-formatting",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "positron-data-explorer-formatting",
+      "version": "0.0.1",
+      "devDependencies": {
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+        "typescript": "^4.5.5"
+      }
+    },
+    "../positron-data-explorer-protocol": {
+      "version": "0.0.1",
+      "dev": true,
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/positron-data-explorer-protocol": {
+      "resolved": "../positron-data-explorer-protocol",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  }
+}

--- a/extensions/positron-data-explorer-formatting/package.json
+++ b/extensions/positron-data-explorer-formatting/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "positron-data-explorer-formatting",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Shared Data Explorer value formatting helpers (FormatOptions-driven number, decimal and string rendering) for Positron extensions that provide a Data Explorer backend. Build-time-only: consumed by the data driver extensions via esbuild, not packaged or activated as an extension.",
+  "main": "./out/valueFormatting.js",
+  "types": "./out/valueFormatting.d.ts",
+  "exports": {
+    ".": {
+      "types": "./out/valueFormatting.d.ts",
+      "default": "./out/valueFormatting.js"
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p tsconfig.json",
+    "watch": "tsc -w -p tsconfig.json",
+    "prepare": "npm run compile"
+  },
+  "devDependencies": {
+    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
+    "typescript": "^4.5.5"
+  }
+}

--- a/extensions/positron-data-explorer-formatting/src/valueFormatting.ts
+++ b/extensions/positron-data-explorer-formatting/src/valueFormatting.ts
@@ -8,7 +8,7 @@
 // so these helpers live here rather than being copy-pasted into each driver's table view, which is
 // how they started out and how they drifted (see #15366).
 
-import { FormatOptions } from 'positron-data-explorer-protocol';
+import { ColumnDisplayType, FormatOptions } from 'positron-data-explorer-protocol';
 
 /** Applies a thousands separator to the integer part of an already-formatted number string. */
 export function applyThousandsSep(formatted: string, sep: string): string {
@@ -106,20 +106,44 @@ export function formatDecimal(value: string, opts: FormatOptions): string {
 }
 
 /**
- * Formats a raw numeric summary statistic, keeping an exact decimal exact. A statistic read straight
- * out of the data -- a median, a minimum -- is a DECIMAL/NUMERIC digit string when its column is one,
- * and formatting it textually is the difference between reporting the value that is in the table and
- * reporting the nearest double. A statistic that is computed instead (a mean, a standard deviation)
- * is a double by construction and takes the numeric path.
+ * Formats a raw numeric summary statistic, keeping an exact value exact. A statistic read straight
+ * out of the data -- a median, a minimum -- carries its column's own exactness, and formatting it
+ * textually is the difference between reporting the value that is in the table and reporting the
+ * nearest double. A statistic that is computed instead (a mean, a standard deviation) is a double by
+ * construction and takes the numeric path.
+ *
+ * `displayType` is the column's, not the value's, and it decides which exact path applies. The value
+ * alone cannot: a DECIMAL(n,0) median arrives as `'42'` and looks like an integer, but its column
+ * renders its cells as `42.00`, so formatting the statistic as `42` would disagree with them. The
+ * column is the only thing that knows which is right.
  *
  * A missing statistic passes through as undefined, which is how the protocol represents "there is no
  * value here" (an empty column has no median).
  */
-export function formatNumericStat(value: unknown, opts: FormatOptions): string | undefined {
+export function formatNumericStat(value: unknown, displayType: ColumnDisplayType, opts: FormatOptions): string | undefined {
 	if (value === null || value === undefined) {
 		return undefined;
 	}
+	// An integer column's statistics format as integers, matching both its cells and its own
+	// `min_value`/`max_value` (which are stringified directly). The whole-value guard matters because
+	// the median is not necessarily one: several drivers compute it with `percentile_cont`, which
+	// returns a double and yields something like 1.5 on an even number of rows.
+	if (displayType === ColumnDisplayType.Integer && isWholeValue(value)) {
+		return formatInteger(value, opts);
+	}
 	return isDecimalLiteral(value) ? formatDecimal(value, opts) : formatFloat(Number(value), opts);
+}
+
+/**
+ * Whether a value is a whole number that `formatInteger` can print without narrowing it: a bigint, a
+ * canonical digit string, or a number with no fractional part. A `bigint` and a digit string are
+ * exact by construction; a whole `number` is already as precise as it will ever be, so printing it
+ * as an integer loses nothing that `Number()` had not already lost.
+ */
+function isWholeValue(value: unknown): value is number | bigint | string {
+	return typeof value === 'bigint'
+		|| isIntegerLiteral(value)
+		|| (typeof value === 'number' && Number.isInteger(value));
 }
 
 /** Truncates a string to the configured maximum formatted length. */

--- a/extensions/positron-data-explorer-formatting/src/valueFormatting.ts
+++ b/extensions/positron-data-explorer-formatting/src/valueFormatting.ts
@@ -1,0 +1,195 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Value formatting shared by the Data Explorer backend extensions. Every driver renders a cell the
+// same way -- the Data Explorer's FormatOptions describe the rendering, not the source database --
+// so these helpers live here rather than being copy-pasted into each driver's table view, which is
+// how they started out and how they drifted (see #15366).
+
+import { FormatOptions } from 'positron-data-explorer-protocol';
+
+/** Applies a thousands separator to the integer part of an already-formatted number string. */
+export function applyThousandsSep(formatted: string, sep: string): string {
+	const negative = formatted.startsWith('-');
+	const body = negative ? formatted.slice(1) : formatted;
+	const [intPart, fracPart] = body.split('.');
+	const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, sep);
+	const result = fracPart === undefined ? grouped : `${grouped}.${fracPart}`;
+	return negative ? `-${result}` : result;
+}
+
+/** Formats a floating-point value following the Data Explorer FormatOptions. */
+export function formatFloat(value: number, opts: FormatOptions): string {
+	const sciLimit = Math.pow(10, opts.max_integral_digits);
+	let formatted: string;
+	const abs = Math.abs(value);
+	if (abs !== 0 && abs >= sciLimit) {
+		return value.toExponential(opts.large_num_digits);
+	} else if (abs !== 0 && abs < 1) {
+		formatted = value.toFixed(opts.small_num_digits);
+	} else {
+		formatted = value.toFixed(opts.large_num_digits);
+	}
+	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
+}
+
+/**
+ * Whether a value is an exact integer literal in canonical form: either a bare `0`, or an optionally
+ * negated digit run with no leading zero. A DECIMAL(n,0) arrives in this form, and it is only safe to
+ * print such a string as-is when it is already exactly how the number should read.
+ *
+ * The non-canonical shapes are deliberately excluded so they keep going through `Number` and come out
+ * normalized rather than printed raw: `formatInteger` only stringifies its argument, so a `'+42'` or
+ * a `'007'` reaching it would display verbatim, and a zero-padded literal would even be grouped into
+ * something like `00,000,000,000,000,001`. Anything else -- an exponent, a decimal point, stray text
+ * -- is excluded for the same reason.
+ */
+export function isIntegerLiteral(value: unknown): value is string {
+	return typeof value === 'string' && /^(0|-?[1-9]\d*)$/.test(value);
+}
+
+/**
+ * Formats an integer value, optionally with a thousands separator. Accepts an exact digit string
+ * alongside number and bigint so a wide DECIMAL(n,0) keeps every digit: the body only stringifies its
+ * argument, and `applyThousandsSep` groups the digits textually, so no step here narrows the value to
+ * a JS number.
+ */
+export function formatInteger(value: number | bigint | string, opts: FormatOptions): string {
+	const formatted = value.toString();
+	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
+}
+
+/**
+ * Whether a value is an exact decimal literal: an optionally signed run of digits with an optional
+ * fractional part. A DECIMAL/NUMERIC arrives in this form from the drivers that preserve precision,
+ * and `formatDecimal` can only work on the plain positional notation -- anything else (an exponent,
+ * Postgres' 'NaN' and 'Infinity' numerics, stray text) has to go through `Number` and `formatFloat`.
+ */
+export function isDecimalLiteral(value: unknown): value is string {
+	return typeof value === 'string' && /^[+-]?(\d+(\.\d*)?|\.\d+)$/.test(value);
+}
+
+/**
+ * Formats an exact decimal literal following the Data Explorer FormatOptions, without ever
+ * converting it to a JS number.
+ *
+ * A DECIMAL/NUMERIC reaches the driver as a digit string precisely because a double cannot hold it:
+ * `Number()` loses the whole-number digits past 2^53, and it also shifts the rounding at the digit
+ * limit, because the double nearest the literal can fall on the other side of a half-way digit
+ * (`Number('1.005').toFixed(2)` is `1.00`, not `1.01`). Every step below is therefore textual: the
+ * digits are split, rounded half away from zero, and grouped as strings.
+ *
+ * The result matches `formatFloat` for any value a double represents exactly, including its choice
+ * of notation: exponential at or above 10^max_integral_digits, `small_num_digits` for a magnitude
+ * below 1, and `large_num_digits` otherwise. Like `formatFloat`, the notation is chosen from the
+ * unrounded magnitude, so a carry out of the rounding widens the result rather than pushing it into
+ * exponential form, and exponential results are not given a thousands separator.
+ */
+export function formatDecimal(value: string, opts: FormatOptions): string {
+	const { negative, integral, fraction } = splitDecimalLiteral(value);
+	const isZero = !/[1-9]/.test(integral + fraction);
+	// A negative zero prints unsigned, matching `(-0).toFixed(2)`, but a value that merely rounds to
+	// zero keeps its sign, matching `(-0.00001).toFixed(4)`.
+	const sign = negative && !isZero ? '-' : '';
+
+	// `integral` carries no leading zeros, so its digit count is the value's magnitude: the value is
+	// at or above 10^max_integral_digits exactly when it has more than that many integral digits.
+	if (!isZero && integral.length > opts.max_integral_digits) {
+		return sign + toExponentialDigits(integral, fraction, opts.large_num_digits);
+	}
+
+	const digits = !isZero && integral === '0' ? opts.small_num_digits : opts.large_num_digits;
+	const formatted = sign + toFixedDigits(integral, fraction, digits);
+	return opts.thousands_sep ? applyThousandsSep(formatted, opts.thousands_sep) : formatted;
+}
+
+/**
+ * Formats a raw numeric summary statistic, keeping an exact decimal exact. A statistic read straight
+ * out of the data -- a median, a minimum -- is a DECIMAL/NUMERIC digit string when its column is one,
+ * and formatting it textually is the difference between reporting the value that is in the table and
+ * reporting the nearest double. A statistic that is computed instead (a mean, a standard deviation)
+ * is a double by construction and takes the numeric path.
+ *
+ * A missing statistic passes through as undefined, which is how the protocol represents "there is no
+ * value here" (an empty column has no median).
+ */
+export function formatNumericStat(value: unknown, opts: FormatOptions): string | undefined {
+	if (value === null || value === undefined) {
+		return undefined;
+	}
+	return isDecimalLiteral(value) ? formatDecimal(value, opts) : formatFloat(Number(value), opts);
+}
+
+/** Truncates a string to the configured maximum formatted length. */
+export function truncate(value: string, opts: FormatOptions): string {
+	return value.length > opts.max_value_length ? value.slice(0, opts.max_value_length) : value;
+}
+
+/**
+ * Splits a decimal literal into its sign and its integral and fractional digits. The integral digits
+ * are stripped of leading zeros so their count is the value's magnitude, keeping a single `0` when
+ * the value is below 1 so there is still an integral part to print.
+ */
+function splitDecimalLiteral(value: string): { negative: boolean; integral: string; fraction: string } {
+	const negative = value.startsWith('-');
+	const body = negative || value.startsWith('+') ? value.slice(1) : value;
+	const pointIndex = body.indexOf('.');
+	const integral = pointIndex < 0 ? body : body.slice(0, pointIndex);
+	const fraction = pointIndex < 0 ? '' : body.slice(pointIndex + 1);
+	return { negative, integral: integral.replace(/^0+(?=\d)/, '') || '0', fraction };
+}
+
+/**
+ * Renders digit strings in positional notation with exactly `digits` fractional digits, rounding half
+ * away from zero. This is the textual equivalent of `Number.prototype.toFixed`, which rounds the same
+ * way for any value a double represents exactly.
+ */
+function toFixedDigits(integral: string, fraction: string, digits: number): string {
+	let intDigits = integral;
+	let fracDigits = fraction.slice(0, digits).padEnd(digits, '0');
+	if (fraction.length > digits && fraction[digits] >= '5') {
+		// Round up by incrementing the digits as one integer, so a carry can ripple out of the
+		// fraction and into the integral part (0.999 at two digits becomes 1.00).
+		const carried = incrementDigits(intDigits + fracDigits);
+		intDigits = carried.slice(0, carried.length - digits);
+		fracDigits = carried.slice(carried.length - digits);
+	}
+	return digits > 0 ? `${intDigits}.${fracDigits}` : intDigits;
+}
+
+/**
+ * Renders digit strings in exponential notation with exactly `digits` mantissa fraction digits,
+ * matching `Number.prototype.toExponential`. Only called for a magnitude at or above
+ * 10^max_integral_digits, so the integral part is non-zero and the exponent is positive.
+ */
+function toExponentialDigits(integral: string, fraction: string, digits: number): string {
+	const significant = integral + fraction;
+	let exponent = integral.length - 1;
+	let mantissa = significant.slice(0, digits + 1).padEnd(digits + 1, '0');
+	if (significant.length > digits + 1 && significant[digits + 1] >= '5') {
+		mantissa = incrementDigits(mantissa);
+		if (mantissa.length > digits + 1) {
+			// The carry added a digit (9.99 became 10.00), so renormalize to a single integral digit.
+			exponent += 1;
+			mantissa = mantissa.slice(0, digits + 1);
+		}
+	}
+	const rendered = digits > 0 ? `${mantissa[0]}.${mantissa.slice(1)}` : mantissa;
+	return `${rendered}e+${exponent}`;
+}
+
+/** Adds one to a string of digits, growing the string by a digit when the carry runs off the end. */
+function incrementDigits(digits: string): string {
+	const chars = digits.split('');
+	for (let i = chars.length - 1; i >= 0; i--) {
+		if (chars[i] === '9') {
+			chars[i] = '0';
+		} else {
+			chars[i] = String.fromCharCode(chars[i].charCodeAt(0) + 1);
+			return chars.join('');
+		}
+	}
+	return `1${chars.join('')}`;
+}

--- a/extensions/positron-data-explorer-formatting/tsconfig.json
+++ b/extensions/positron-data-explorer-formatting/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "nodenext",
+		"target": "ES2020",
+		"moduleResolution": "nodenext",
+		"outDir": "out",
+		"rootDir": "src",
+		"lib": [
+			"ES2020"
+		],
+		"declaration": true,
+		"sourceMap": true,
+		"strict": false,
+		"skipLibCheck": true,
+		// Pure string/number formatting with no ambient dependencies. Without this, the compiler picks
+		// up every @types package in the repository root, which this package's older TypeScript cannot
+		// parse.
+		"types": []
+	},
+	"include": [
+		"src/**/*"
+	]
+}


### PR DESCRIPTION
Fixes #15366

### Summary

`_formatValue` coerced `Decimal` values through `Number()` before formatting them. That is correct for `Floating`, where the value really is a double, but a `DECIMAL`/`NUMERIC` arrives as an exact digit string precisely because a double cannot represent it, and the coercion threw that away.

This implements option 1 from the issue: a string-based decimal formatter. `formatDecimal` splits sign, integral, and fractional digits, rounds half away from zero on the digit string, chooses notation from the unrounded magnitude, and groups with the separator. No new dependency, and no arithmetic on a JS number anywhere in the path.

### In scope, and delivered here

**Exact decimal formatting for the backends that can deliver an exact string.** PostgreSQL and Redshift (`pg` returns `numeric` as a string) and Databricks (`preserveBigNumericPrecision`). These are the three the issue named.

**A single home for the formatting helpers.** The issue asked for this or a recorded decision, since `formatFloat`, `formatInteger`, `applyThousandsSep`, and `truncate` were copy-pasted across seven table views and had already drifted -- three carried the earlier `Integer` fix, four did not. They now live in a new build-time-only package, `positron-data-explorer-formatting`, mirroring the existing `positron-data-explorer-protocol` and `positron-data-explorer-duckdb` packages: bundled by esbuild, excluded from packaging, and registered in `build/gulpfile.extensions.ts`, `build/lib/extensions.ts`, `build/npm/dirs.ts`, and the test-tag paths map. All seven table views import from it, and the four that lacked the `Integer` exact-string fix pick it up.

**The median in the summary panel.** `_summaryStatsFromRow` had the same coercion. `_quantile` now returns the raw cell value, its histogram callers coerce explicitly (a bin width is approximate either way), and every median goes through `formatNumericStat`. Min and max already used `String(...)` and were exact.

**The SQLite and DuckDB audit the issue asked for.** Both are on the shared helpers now, and both were checked: neither can deliver exact digits, so the guard is inert in both. DuckDB's `getRowObjectsJS()` yields a JS number for a `DECIMAL` -- a `DECIMAL(38,2)` holding `9007199254740993.01` arrives already collapsed to `9007199254740992` -- and SQLite's `NUMERIC` affinity converts an inserted literal to `REAL` at write time, so the digits never reach the file. Comments at each site record the mechanism.

**A tightening of `isIntegerLiteral`, from code review.** Its doc comment claimed non-canonical strings "still go through `Number` so it is normalized rather than printed raw," but `/^[+-]?\d+$/` admitted them and `formatInteger` prints its argument verbatim, so `'007'` displayed as `'007'` and `'00000000000000001'` was grouped into `'00,000,000,000,000,001'`. Now `/^(0|-?[1-9]\d*)$/`, so only canonical form takes the exact path. This quirk shipped in #15337 for three drivers and this PR was extending it to four more; the fix covers all seven. It does change `Integer` display for a driver that hands back a non-canonical digit string -- realistically only ODBC, since sqlite, snowflake, and duckdb return numbers or bigints.

**Integer summary statistics, from review.** `formatNumericStat` had no integer branch, so an integer column's median went through `Number()` and was formatted as a decimal. Two consequences: a `BIGINT` median past 2^53 lost digits (the same coercion this PR exists to remove, currently masked by exponential notation), and since `min_value`/`max_value` are stringified directly, an integer column reported three formats at once -- min `1`, max `5`, median `3.00`. `formatNumericStat` now takes the column's display type and routes integer columns to `formatInteger`.

The display type is the discriminator rather than the value's shape, because a `NUMERIC(38,0)` median arrives as `'42'` and looks like an integer while its column renders cells as `42.00`; routing on shape would just invert the inconsistency. It also carries a whole-value guard, since Databricks, Redshift, and Snowflake compute the median with `percentile_cont`, which returns a `DOUBLE` and can legitimately be `1.5` on an integer column.

This is `Integer`, which the issue lists as out of scope, so it was nearly split out. It is folded in because `formatNumericStat` is introduced by this PR and does not exist on `main` -- a separate PR would have had to stack on this branch or wait for merge, shipping a new shared helper with a known gap in the meantime.

### Out of scope, and where it went

**DuckDB exact delivery -- #15885.** The precision is available and discarded: `getRowObjects()` returns a `DuckDBDecimalValue` with an exact `toString()`, but the worker calls `getRowObjectsJS()` so rows can cross the IPC boundary as plain JS. Fixing it means a per-column conversion in the worker, which is a change to the worker protocol boundary rather than to formatting.

**Snowflake exact delivery -- #15887.** `snowflake-sdk` yields a JS number for `NUMBER` columns. The fix is either `fetchAsString: ['Number']` (small diff, but all-or-nothing across every numeric type) or a `TO_VARCHAR` cast scoped to decimal columns (smaller blast radius, bigger diff). The issue itself deferred this: "worth its own issue."

**The display cap -- #15888.** This is the one to read before reviewing the table below. `FormatOptions` is hard-coded at `max_integral_digits: 7`, so any value past seven integral digits renders in exponential notation regardless of what the backend delivers, and the exact and coerced paths agree on those three significant digits. The digit-preservation half of this PR is implemented and tested but is **not observable at the shipped options** -- a wide value still displays as `1.23e+29`, byte-identical to before. The issue listed changing the digit limit as out of scope, so it stays out here, but it is what gates the visible payoff of this PR and of #15885 and #15887.

**SQLite -- not filed, and deliberately so.** Unlike DuckDB and Snowflake this is a dead end rather than a deferred fix: the conversion happens at write time, so there are no exact digits in the file to recover at read time. Recorded in #15885 so nobody files a hopeful ticket.

**Mean and standard deviation.** Computed from SQL `sum()` over a float cast and approximate by construction. The issue called this a separate design choice.

### What actually changes on screen

Given the cap above, the user-visible change in cells is the rounding, not the digit count:

| Stored value | Before | After |
| --- | --- | --- |
| `1.005` | `1.00` | `1.01` |
| `-1.005` | `-1.00` | `-1.01` |
| `2.675` | `2.67` | `2.68` |
| `1234567.005` | `1234567.00` | `1234567.01` |
| `9999999.995` | `9999999.99` | `10000000.00` |

The double nearest each of these sits on the far side of the half-way digit, which is exactly the case a financial column hits. If `max_integral_digits` is ever raised, the old path renders a 30-digit `NUMERIC(38,2)` as `1.2345678901234568e+29` and the new one renders all 30 digits.

In the summary panel, an integer column's median changes shape: a column with min `10` and max `40` used to report a median of `20.00` and now reports `20`. Three existing tests asserted the old value and were updated -- those assertions were the inconsistency, written down.

Exports are unaffected: `stringifyExportCell` already passed strings through unchanged, so CSV and TSV of a wide decimal were always exact.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed `DECIMAL` and `NUMERIC` values being rounded through a floating-point number before display in the Data Explorer, which rounded the wrong way at the digit limit and lost whole-number digits beyond 2^53 (#15366)
- Fixed integer columns reporting a median formatted as a decimal, inconsistent with their own minimum and maximum (#15366)

### QA Notes

One known coverage gap, called out rather than papered over: nothing covers the `_quantile` path in the postgresql, sqlite, odbc, or duckdb drivers, so this PR's signature change there and its two `Number(... ?? 0)` call sites are untested. That path had no coverage before either. The scalar-row median used by databricks, redshift, and snowflake *is* covered by an existing test.

### Validation Steps

@:connections @:data-explorer

Unit coverage runs with `npm run test-extension -- -l positron-data-driver-databricks`, which exercises the shared formatter directly (wide integral parts, values near 2^53, negatives, rounding at the digit limit, exponential thresholds, the thousands separator, canonical integer literals, integer and fractional summary statistics, and parity with `formatFloat` on every value a double holds exactly) plus the cell path through `DatabricksTableView`.

To verify by hand, PostgreSQL is the vehicle, since `pg` returns `numeric` as a string. Create a table with an unconstrained `numeric` column -- unconstrained so the digit string is exactly the literal inserted, where a `numeric(p,s)` column would pad to its scale -- holding `1.005`, `-1.005`, `2.675`, `1234567.005`, and `9999999.995`. Open it in the Data Explorer and confirm the five values render as `1.01`, `-1.01`, `2.68`, `1234567.01`, and `10000000.00`. Then check the summary panel on a column whose median is `1234567.005` and confirm it reads `1,234,567.01`.

Check the summary panel on an integer column too: its median should now read as an integer, matching the format of its own minimum and maximum rather than carrying a `.00`.

Confirm `Floating` is unchanged: a `double precision` column holding `1.005` should still render `1.00`, because that column genuinely does not hold `1.005`.

Regression surface worth a look: `NULL`, `NaN`, `Infinity`, and `-Infinity` numerics should still render as `NULL`, `NaN`, `INF`, and `-INF`; integer columns should be unaffected in their cells apart from wide `DECIMAL(n,0)` values in sqlite, snowflake, odbc, and duckdb now keeping their digits; a zero-padded or plus-signed integer string should render normalized rather than verbatim; and a `DECIMAL` column whose median happens to be a whole number should still show its fractional digits (`42.00`, not `42`).