### PR TITLE
Restore getEnvironmentContributions contract

### DIFF
--- a/extensions/positron-r/src/r-process-environment.ts
+++ b/extensions/positron-r/src/r-process-environment.ts
@@ -171,7 +171,10 @@ function toEnvVarAction(type: vscode.EnvironmentVariableMutatorType): EnvVarActi
  * @returns The contributed mutations, in no particular order.
  */
 async function getContributedMutations(): Promise<EnvVarMutation[]> {
-	const contributions = await positron.environment.getEnvironmentContributions();
+	// This process is spawned directly (no shell integration), like a kernel, so
+	// request only contributions applied at process creation.
+	const contributions = await positron.environment.getEnvironmentContributions(
+		positron.EnvironmentContributionFilter.ProcessCreation);
 	const mutations: EnvVarMutation[] = [];
 	for (const [extensionId, actions] of Object.entries(contributions)) {
 		for (const action of actions) {

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -300,8 +300,8 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 		// R interpreter's module environment into other-language kernels). Kernels
 		// get their module environment from the startup command instead; these
 		// contributions are for interactive terminals only. See
-		// getEnvironmentContributions in mainThreadEnvironment.ts, which skips
-		// mutators that opt out of process creation.
+		// getEnvironmentContributions in mainThreadEnvironment.ts: callers that
+		// spawn processes pass the ProcessCreation filter to skip these mutators.
 		const options = { applyAtProcessCreation: false, applyAtShellIntegration: true };
 		for (const v of captured) {
 			switch (v.action) {

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -314,8 +314,12 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			value: vscode.env.uiKind === vscode.UIKind.Desktop ? 'desktop' : 'server'
 		});
 
-		// Start with the environment variables from any extension's contributions.
-		const contributedVars = await positron.environment.getEnvironmentContributions();
+		// Start with the environment variables from any extension's
+		// contributions. Kernels are spawned processes, so request only
+		// contributions applied at process creation; shell-integration-only
+		// contributions belong to interactive terminals.
+		const contributedVars = await positron.environment.getEnvironmentContributions(
+			positron.EnvironmentContributionFilter.ProcessCreation);
 		for (const [extensionId, actions] of Object.entries(contributedVars)) {
 
 			if (restart && extensionId === 'ms-python.python') {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/positron/environment.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/positron/environment.test.ts
@@ -69,14 +69,19 @@ suite('positron API - environment', () => {
 
 		// Without a filter, terminal-like consumers see it.
 		const all = await positron.environment.getEnvironmentContributions();
-		assert.ok(
-			all['vscode.vscode-api-tests'].some(a => a.name === 'shellOnly'),
-			'Shell-integration-only contribution should be returned without a filter'
-		);
 
 		// With the process-creation filter, spawned-process consumers do not.
 		const processOnly = await positron.environment.getEnvironmentContributions(
 			positron.EnvironmentContributionFilter.ProcessCreation);
+
+		// Remove the entry so it doesn't leak into other tests sharing the
+		// collection, then assert on the captured results.
+		collection.delete('shellOnly');
+
+		assert.ok(
+			all['vscode.vscode-api-tests'].some(a => a.name === 'shellOnly'),
+			'Shell-integration-only contribution should be returned without a filter'
+		);
 		assert.ok(
 			!processOnly['vscode.vscode-api-tests'].some(a => a.name === 'shellOnly'),
 			'Shell-integration-only contribution should be excluded by the process-creation filter'

--- a/extensions/vscode-api-tests/src/singlefolder-tests/positron/environment.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/positron/environment.test.ts
@@ -56,4 +56,30 @@ suite('positron API - environment', () => {
 		assert.strictEqual(contributedActions[2].name, 'test3', 'Third action name should be "test3"');
 		assert.strictEqual(contributedActions[2].value, 'value3', 'Third action value should be "value3"');
 	});
+
+	test('process creation filter excludes shell-integration-only contributions', async () => {
+		const collection = extensionContext.environmentVariableCollection;
+
+		// A contribution applied only via shell integration, e.g. a bundled
+		// binary an extension puts on PATH (as the Air extension does).
+		collection.prepend('shellOnly', '/bundled/bin:', {
+			applyAtProcessCreation: false,
+			applyAtShellIntegration: true,
+		});
+
+		// Without a filter, terminal-like consumers see it.
+		const all = await positron.environment.getEnvironmentContributions();
+		assert.ok(
+			all['vscode.vscode-api-tests'].some(a => a.name === 'shellOnly'),
+			'Shell-integration-only contribution should be returned without a filter'
+		);
+
+		// With the process-creation filter, spawned-process consumers do not.
+		const processOnly = await positron.environment.getEnvironmentContributions(
+			positron.EnvironmentContributionFilter.ProcessCreation);
+		assert.ok(
+			!processOnly['vscode.vscode-api-tests'].some(a => a.name === 'shellOnly'),
+			'Shell-integration-only contribution should be excluded by the process-creation filter'
+		);
+	});
 });

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -3493,13 +3493,30 @@ declare module 'positron' {
 		value: string;
 	}
 
+	/**
+	 * Selects which environment variable contributions
+	 * {@link environment.getEnvironmentContributions} returns.
+	 */
+	export enum EnvironmentContributionFilter {
+		/**
+		 * Only contributions that are applied at process creation. These are
+		 * inherited by spawned child processes such as language kernels;
+		 * contributions applied only via shell integration are excluded.
+		 */
+		ProcessCreation = 'processCreation',
+	}
+
 	namespace environment {
 		/**
 		 * Get the environment variable contributions for the current session.
 		 *
+		 * @param filter Optional filter selecting which contributions to
+		 *   return. When omitted, all contributions are returned, including
+		 *   those applied only via shell integration.
+		 *
 		 * @returns A map of extension IDs to arrays of environment variable actions.
 		 */
-		export function getEnvironmentContributions(): Thenable<Record<string, EnvironmentVariableAction[]>>;
+		export function getEnvironmentContributions(filter?: EnvironmentContributionFilter): Thenable<Record<string, EnvironmentVariableAction[]>>;
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadEnvironment.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadEnvironment.ts
@@ -7,6 +7,7 @@ import { MainPositronContext, MainThreadEnvironmentShape } from '../../common/po
 import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensions/common/extHostCustomers.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { IEnvironmentVariableService } from '../../../contrib/terminal/common/environmentVariable.js';
+import { EnvironmentContributionFilter } from '../../common/positron/extHostTypes.positron.js';
 
 interface IEnvironmentVariableAction {
 	/** The action to take */
@@ -29,7 +30,7 @@ export class MainThreadEnvironment implements MainThreadEnvironmentShape {
 	) {
 	}
 
-	async $getEnvironmentContributions(): Promise<Record<string, IEnvironmentVariableAction[]>> {
+	async $getEnvironmentContributions(filter?: EnvironmentContributionFilter): Promise<Record<string, IEnvironmentVariableAction[]>> {
 		// Get environment variable collections from the environment service
 		const collections = this._environmentService.collections;
 
@@ -40,13 +41,14 @@ export class MainThreadEnvironment implements MainThreadEnvironmentShape {
 		for (const [extensionIdentifier, collection] of collections.entries()) {
 			const actions: IEnvironmentVariableAction[] = [];
 			for (const [variable, mutator] of collection.map) {
-				// Skip mutators that opt out of process creation. These are
-				// contributed for interactive terminals only (applied via shell
-				// integration) and must not be inherited by spawned runtime
-				// processes such as kernels. The default is to apply at process
-				// creation, so only explicit opt-outs are excluded and existing
-				// contributions are unaffected.
-				if (mutator.options?.applyAtProcessCreation === false) {
+				// When filtering to process creation, skip mutators that opt out
+				// of it. These are contributed for interactive terminals only
+				// (applied via shell integration) and must not be inherited by
+				// spawned runtime processes such as kernels. Without a filter,
+				// every contribution is returned so terminal-like consumers can
+				// replay shell-integration-only variables too.
+				if (filter === EnvironmentContributionFilter.ProcessCreation &&
+					mutator.options?.applyAtProcessCreation === false) {
 					continue;
 				}
 				actions.push({

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -399,8 +399,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			 *
 			 * @returns A map of environment variable actions, keyed by the extension ID.
 			 */
-			getEnvironmentContributions(): Thenable<Record<string, positron.EnvironmentVariableAction[]>> {
-				return extHostEnvironment.getEnvironmentContributions();
+			getEnvironmentContributions(filter?: positron.EnvironmentContributionFilter): Thenable<Record<string, positron.EnvironmentVariableAction[]>> {
+				return extHostEnvironment.getEnvironmentContributions(filter);
 			}
 		};
 
@@ -721,6 +721,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			notebooks,
 			workspace,
 			CodeAttributionSource: extHostTypes.CodeAttributionSource,
+			EnvironmentContributionFilter: extHostTypes.EnvironmentContributionFilter,
 			PositronLanguageModelType: extHostTypes.PositronLanguageModelType,
 			PositronChatAgentLocation: extHostTypes.PositronChatAgentLocation,
 			PositronOutputLocation: extHostTypes.PositronOutputLocation,

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -14,7 +14,7 @@ import { IPackageRepositoryRequest, IPackageRepositoryResponse } from '../../../
 import { RuntimeClientType, LanguageRuntimeSessionChannel } from './extHostTypes.positron.js';
 import { IRange } from '../../../../editor/common/core/range.js';
 import { INotebookContextDTO, NotebookCellType } from '../../../common/positron/notebookAssistant.js';
-import { ActiveRuntimeSessionMetadata, EnvironmentVariableAction, LanguageRuntimeDynState, LanguageRuntimePackage, PackageSpec, RuntimeConsoleError, RuntimeMissingPackage, RuntimeMissingPackagesTarget, RuntimeSessionMetadata, type notebooks } from 'positron';
+import { ActiveRuntimeSessionMetadata, EnvironmentContributionFilter, EnvironmentVariableAction, LanguageRuntimeDynState, LanguageRuntimePackage, PackageSpec, RuntimeConsoleError, RuntimeMissingPackage, RuntimeMissingPackagesTarget, RuntimeSessionMetadata, type notebooks } from 'positron';
 import { IDriverMetadata, Input } from '../../../services/positronConnections/common/interfaces/positronConnectionsDriver.js';
 import { IAvailableDriverMethods } from '../../browser/positron/mainThreadConnections.js';
 import { IChatRequestData, IGenerateAssistantPromptRequest, IPositronChatContext, IPositronLanguageModelConfig, IPositronLanguageModelSource, IShowLanguageModelConfigOptions } from '../../../contrib/positronAssistant/common/interfaces/positronAssistantService.js';
@@ -384,7 +384,7 @@ export interface ExtHostDataExplorerShape {
 }
 
 export interface MainThreadEnvironmentShape extends IDisposable {
-	$getEnvironmentContributions(): Promise<Record<string, EnvironmentVariableAction[]>>;
+	$getEnvironmentContributions(filter?: EnvironmentContributionFilter): Promise<Record<string, EnvironmentVariableAction[]>>;
 }
 
 export interface ExtHostEnvironmentShape { }

--- a/src/vs/workbench/api/common/positron/extHostEnvironment.ts
+++ b/src/vs/workbench/api/common/positron/extHostEnvironment.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EnvironmentVariableAction } from 'positron';
+import { EnvironmentContributionFilter, EnvironmentVariableAction } from 'positron';
 import * as extHostProtocol from './extHost.positron.protocol.js';
 
 export class ExtHostEnvironment implements extHostProtocol.ExtHostEnvironmentShape {
@@ -16,8 +16,8 @@ export class ExtHostEnvironment implements extHostProtocol.ExtHostEnvironmentSha
 		this._proxy = mainContext.getProxy(extHostProtocol.MainPositronContext.MainThreadEnvironment);
 	}
 
-	public async getEnvironmentContributions(): Promise<Record<string, EnvironmentVariableAction[]>> {
-		const contributions = await this._proxy.$getEnvironmentContributions();
+	public async getEnvironmentContributions(filter?: EnvironmentContributionFilter): Promise<Record<string, EnvironmentVariableAction[]>> {
+		const contributions = await this._proxy.$getEnvironmentContributions(filter);
 		return contributions;
 	}
 }

--- a/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
+++ b/src/vs/workbench/api/common/positron/extHostTypes.positron.ts
@@ -443,6 +443,14 @@ export enum PositronChatAgentLocation {
 }
 
 /**
+ * Selects which environment variable contributions
+ * getEnvironmentContributions returns.
+ */
+export enum EnvironmentContributionFilter {
+	ProcessCreation = 'processCreation',
+}
+
+/**
  * Code attribution sources for code executed in the Console.
  */
 export enum CodeAttributionSource {


### PR DESCRIPTION
Fixes #15884

`positron.environment.getEnvironmentContributions()` was changed in #15501 to silently drop any contribution that opts out of process creation (`applyAtProcessCreation: false`). Those contributions are meant for interactive terminals, so hiding them was correct for kernels but wrong for the API's other consumers: an extension replaying contributions into a spawned shell (like Posit Assistant's shell tool) could no longer see the Air extension's bundled `air` binary, or Quarto, or anything else contributed with shell-integration-only semantics.

This restores the original contract. By default the method returns every contribution again.

<img width="361" height="341" alt="image" src="https://github.com/user-attachments/assets/aa5c6f46-e508-4199-a803-70c71995a736" />

A new optional `filter` parameter lets callers that spawn a plain process opt into the narrower set:

- `getEnvironmentContributions()` returns all contributions (terminal-like consumers).
- `getEnvironmentContributions(EnvironmentContributionFilter.ProcessCreation)` returns only what a spawned process inherits.

The kernel supervisor and the R test-runner process now pass `ProcessCreation`, so their behavior is unchanged.

### Validation Steps

@:environment-modules

The core behavior is covered by an extension-host test:

```
npm run test-extension -- -l vscode-api-tests --grep "positron API - environment"
```

Manual check on a Linux host with an environment module providing R or Python (same setup as #15501):

1. Select a module-based interpreter and confirm the console and a new terminal both resolve to the module's interpreter.
2. Confirm a kernel does not double-apply the module environment (no regression from the filter).
3. With the Air extension installed, confirm an extension that replays `getEnvironmentContributions()` into a spawned shell (e.g. Posit Assistant's shell tool) can find `air` on PATH.
