### PR TITLE
ci: raise the unit job timeout to 75m for fully-cold cache runs

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -35,11 +35,15 @@ jobs:
   unit-tests:
     name: unit
     runs-on: ubuntu-latest-4x
-    # The job takes ~37m when the npm caches hit, so 40m left no headroom: an
-    # evicted npm-extensions-stable entry adds ~4m (cold extension install plus
-    # the extra cache save) and the run got cancelled part-way through the
-    # browser tests. 60m absorbs a cold cache while still capping a hung run.
-    timeout-minutes: 60
+    # The three test steps only account for ~5m; almost all of the wall clock is
+    # npm install plus the cache save, and both scale with how many npm caches
+    # missed. A warm-ish run lands at ~35m, but a run that misses all three npm
+    # caches (e.g. run 33655268940) pays ~14m of cold install *and* ~30m of
+    # cache save (npm-core 8m, extensions-volatile 4m, extensions-stable 18m),
+    # reaching the Electron tests at ~57m. 60m cancelled that run 3m into the
+    # first test step. 75m covers the fully-cold ~62m path with headroom while
+    # still capping a genuinely hung run.
+    timeout-minutes: 75
     # Run inside the shared CI image, which bakes in the system dependencies,
     # Node (matching .nvmrc), and R 4.5.2 + test-files deps that this
     # job used to install at runtime. Built from docker/images/ubuntu24_04.


### PR DESCRIPTION
The unit job hit its 60m ceiling on main and was cancelled three minutes into
the Electron test step ([run 33655268940](https://github.com/posit-dev/positron/actions/runs/33655268940/job/100332144576)).

It wasn't a hung test -- the job never got to spend time on tests. That run
missed all three npm caches, and the breakdown was:

| step | duration |
|---|---|
| container init + checkout + restore | 4m |
| Install node dependencies (all 3 npm caches missed) | 14m |
| Vitest | 5.5m |
| compile + electron + prelaunch | 2m |
| 💾 Save caches (npm-core 8m17s, extensions-volatile 4m15s, extensions-stable 18m04s) | **30.5m** |
| xvfb + license + DESCRIPTION | 0.5m |
| Electron tests | cancelled 3m in |

The three test steps only account for ~5m of the job. Nearly all of the wall
clock is install plus save, and both scale with how many npm caches missed: a
warm-ish comparison run ([33646061750](https://github.com/posit-dev/positron/actions/runs/33646061750),
success in 35m) had the same 14m install but only a 4m save. The fully-cold
path is ~62m end to end, so this raises the ceiling to 75m -- enough headroom
for that path while still capping a genuinely hung run.

The comment above `timeout-minutes` is rewritten with the real numbers; the
previous one blamed a single evicted cache entry for ~4m, which is off by an
order of magnitude.

### Follow-up, not fixed here

The underlying cost is the cache save, not the tests. `extensions-stable`
alone took 18m to save on a cold run vs seconds when it's a hit, and since only
main saves caches, that 30m lands squarely on the merge workflow -- PRs never
see it. If unit keeps brushing the ceiling, the fix is to stop paying
install + save + test serially in one job (split the save into its own job, or
compress/shard the stable extensions cache) rather than raising the timeout
again.

Both runs that missed all three npm caches missed on `npm-core-v7` /
`npm-extensions-stable-v7` keys, which points at a recent key bump or an
eviction wave rather than steady state. Worth a look if it recurs, since a
permanently cold main would make every merge run a ~62m run.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

CI-only change to a workflow's `timeout-minutes`; no product code is touched.
Validated by reading step-level timings from the cancelled run and from a
successful run of the same job. The change takes effect on this PR's own unit
job -- it should pass as usual (this PR restores from main's caches rather than
saving, so it exercises the warm path, not the 62m one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)