### PR TITLE
Add a Workbench e2e lane on openSUSE Leap 15.6

### DIFF
--- a/.github/actions/setup-workbench-docker/action.yml
+++ b/.github/actions/setup-workbench-docker/action.yml
@@ -3,7 +3,7 @@ description: 'Start Docker Compose services and install Workbench in container'
 
 inputs:
   os:
-    description: 'Host OS for the test container: "ubuntu24" or "rocky9"'
+    description: 'Host OS for the test container: "ubuntu24", "rocky9" or "opensuse15"'
     required: false
     default: 'ubuntu24'
   install-mode:
@@ -61,7 +61,7 @@ runs:
         # seconds, instead of surfacing as a confusing package error mid-install.
         source docker/environments/wb-local/workbench-local-lib.sh
         if ! WB_TEST_IMAGE="$(wb_os_image "${{ inputs.os }}")"; then
-          echo "::error::Unknown os input '${{ inputs.os }}' (expected ubuntu24 or rocky9)"
+          echo "::error::Unknown os input '${{ inputs.os }}' (expected one of: ${WB_OS_CHOICES})"
           exit 1
         fi
         echo "WB_TEST_IMAGE=${WB_TEST_IMAGE}" >> "$GITHUB_ENV"
@@ -137,7 +137,22 @@ runs:
           rm -rf /usr/lib/rstudio-server/bin/positron-server/new &&
           # Install our custom build
           cp -r vscode-reh-web-pwb-linux-x64 /usr/lib/rstudio-server/bin/positron-server/new &&
-          chown -R rstudio-server:rstudio-server /usr/lib/rstudio-server/bin/positron-server/new &&
-          # Restart so rserver re-scans installs and picks up our build
-          sudo rstudio-server restart
+          chown -R rstudio-server:rstudio-server /usr/lib/rstudio-server/bin/positron-server/new
         "
+
+        # Restart so rserver picks up our build, then confirm Workbench is still
+        # serving. The init script's exit status is not a reliable signal on
+        # either rpm OS: EL9's status check uses `pidof -c` and SUSE's uses
+        # `checkproc`, and neither sees rserver inside a container -- so a
+        # restart that worked can still print "failed", and on SUSE exit
+        # non-zero, which would fail this step for no reason. Ask :8787 instead,
+        # which is the thing the tests actually depend on.
+        docker exec test /bin/bash -c '
+          sudo rstudio-server restart || true
+          for i in $(seq 1 60); do
+            curl -sf -o /dev/null http://localhost:8787 && exit 0
+            sleep 1
+          done
+          echo "Workbench is not serving on :8787 after the build swap" >&2
+          exit 1
+        '

--- a/.github/actions/setup-workbench-docker/action.yml
+++ b/.github/actions/setup-workbench-docker/action.yml
@@ -147,6 +147,13 @@ runs:
         # restart that worked can still print "failed", and on SUSE exit
         # non-zero, which would fail this step for no reason. Ask :8787 instead,
         # which is the thing the tests actually depend on.
+        #
+        # On failure, dump state rather than just the verdict. A bare ":8787 never
+        # answered" is close to undiagnosable after the fact, and the container is
+        # gone by the time anyone looks. The HTTP code is the discriminator worth
+        # having: 502 means an orphaned rserver-http is still holding the port with
+        # no rserver behind it, connection-refused means nothing is listening at
+        # all, and those point at different bugs.
         docker exec test /bin/bash -c '
           sudo rstudio-server restart || true
           for i in $(seq 1 60); do
@@ -154,5 +161,19 @@ runs:
             sleep 1
           done
           echo "Workbench is not serving on :8787 after the build swap" >&2
+          echo "--- curl (code 000 = nothing listening) ---"
+          curl -s -o /dev/null -w "http_code=%{http_code}\n" --max-time 5 http://localhost:8787 || true
+          echo "--- listeners on :8787 ---"
+          (ss -lntp 2>/dev/null || netstat -lntp 2>/dev/null) | grep 8787 || echo "(none)"
+          echo "--- rserver processes ---"
+          ps -eo pid,ppid,etime,comm | grep -E "rserver|rstudio" || echo "(none)"
+          echo "--- launcher socket ---"
+          ls -la /var/run/rstudio-server/rserver-launcher.socket 2>&1 || true
+          echo "--- rserver.log (tail) ---"
+          sudo tail -n 60 /var/log/rstudio/rstudio-server/rserver.log 2>/dev/null || echo "(absent)"
+          echo "--- rserver-http-error.log (tail) ---"
+          sudo tail -n 30 /var/log/rstudio/rstudio-server/rserver-http-error.log 2>/dev/null || echo "(absent)"
+          echo "--- launcher logs (tail) ---"
+          sudo tail -n 30 /var/log/rstudio/launcher/* 2>/dev/null || echo "(absent)"
           exit 1
         '

--- a/.github/workflows/test-e2e-workbench-linux.yml
+++ b/.github/workflows/test-e2e-workbench-linux.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       os:
         required: false
-        description: "Host OS for the test container: 'ubuntu24' or 'rocky9'. Both run on the same Ubuntu runner -- the OS under test is the container's, not the runner's."
+        description: "Host OS for the test container: 'ubuntu24', 'rocky9' or 'opensuse15'. All run on the same Ubuntu runner -- the OS under test is the container's, not the runner's."
         default: "ubuntu24"
         type: string
       grep:
@@ -56,10 +56,11 @@ permissions:
 
 jobs:
   # Emit the shard matrix as JSON, because a matrix cannot be shrunk
-  # conditionally in place. The Rocky lane runs the `default` shard only: the
-  # managed-credential shards exercise OS-independent plumbing, so running them
-  # on a second OS would triple live cloud-auth usage for no new signal. Add them
-  # later only if a Rocky-specific credential bug shows up.
+  # conditionally in place. Only the Ubuntu lane runs the managed-credential
+  # shards; the second-OS lanes (Rocky, openSUSE) run the `default` shard only.
+  # Those shards exercise OS-independent plumbing, so running them per OS would
+  # multiply live cloud-auth usage for no new signal. Add them to an OS only if a
+  # credential bug specific to it shows up.
   shards:
     name: ${{ inputs.display_name || 'e2e-workbench' }} (shards)
     runs-on: ubuntu-latest
@@ -72,10 +73,13 @@ jobs:
         run: |
           DEFAULT='{"name":"default","credentials":"","grep":"@:workbench","grep_invert":"@:workbench-(snowflake|databricks|azure)"}'
           CREDS='{"name":"snowflake","credentials":"snowflake","grep":"@:workbench-snowflake","grep_invert":""},{"name":"databricks","credentials":"databricks","grep":"@:workbench-databricks","grep_invert":""},{"name":"azure","credentials":"azure","grep":"@:workbench-azure","grep_invert":""}'
-          if [ "${{ inputs.os }}" = "rocky9" ]; then
-            MATRIX="[${DEFAULT}]"
-          else
+          # Match on the Ubuntu default rather than listing the other OSes, so a
+          # future OS gets the conservative (default-shard-only) treatment
+          # automatically instead of silently opting into live cloud auth.
+          if [ "${{ inputs.os }}" = "ubuntu24" ]; then
             MATRIX="[${DEFAULT},${CREDS}]"
+          else
+            MATRIX="[${DEFAULT}]"
           fi
           # Fail loudly on malformed JSON rather than letting fromJSON blow up in
           # the consuming job, where the error points at the matrix, not at here.

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -69,6 +69,11 @@ on:
         required: false
         default: false
         type: boolean
+      run_e2e_workbench_suse:
+        description: "E2E Tests / Workbench (openSUSE Leap 15.6)"
+        required: false
+        default: false
+        type: boolean
       run_e2e_pyrefly:
         description: "E2E Tests / Pyrefly (Ubuntu)"
         required: false
@@ -341,7 +346,7 @@ jobs:
   build-workbench:
     name: build
     needs: [validate-commit]
-    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench || inputs.run_e2e_workbench_stable || inputs.run_e2e_workbench_rocky) }}
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench || inputs.run_e2e_workbench_stable || inputs.run_e2e_workbench_rocky || inputs.run_e2e_workbench_suse) }}
     uses: ./.github/workflows/build-workbench-linux.yml
     secrets: inherit
     with:
@@ -393,6 +398,25 @@ jobs:
       os: "rocky9"
       grep: "@:workbench"
       display_name: "workbench-rocky"
+      install_license: false
+      upload_logs: false
+      allow_soft_fail: false
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  # Same test set again, on an openSUSE Leap 15.6 container. `grep` is pinned to
+  # "@:workbench" for the same reason as the Rocky lane above: @:workbench-suse
+  # selects the lane, never individual tests, so no test carries it.
+  e2e-workbench-suse:
+    name: e2e
+    needs: [build-workbench]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_workbench_suse) }}
+    uses: ./.github/workflows/test-e2e-workbench-linux.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      os: "opensuse15"
+      grep: "@:workbench"
+      display_name: "workbench-suse"
       install_license: false
       upload_logs: false
       allow_soft_fail: false
@@ -500,7 +524,7 @@ jobs:
   slack-notify:
     if: always()
     needs:
-      [validate-commit, e2e-electron, e2e-windows, e2e-macos-arm64, e2e-macos-x64, e2e-chromium, e2e-chromium-rocky, e2e-chromium-suse, e2e-chromium-sles, e2e-chromium-debian, e2e-workbench, e2e-workbench-stable, e2e-workbench-rocky, e2e-pyrefly, e2e-connect, e2e-jupyter, e2e-remote-ssh, unit-tests, ext-host-tests]
+      [validate-commit, e2e-electron, e2e-windows, e2e-macos-arm64, e2e-macos-x64, e2e-chromium, e2e-chromium-rocky, e2e-chromium-suse, e2e-chromium-sles, e2e-chromium-debian, e2e-workbench, e2e-workbench-stable, e2e-workbench-rocky, e2e-workbench-suse, e2e-pyrefly, e2e-connect, e2e-jupyter, e2e-remote-ssh, unit-tests, ext-host-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -406,6 +406,8 @@ jobs:
   # Same test set again, on an openSUSE Leap 15.6 container. `grep` is pinned to
   # "@:workbench" for the same reason as the Rocky lane above: @:workbench-suse
   # selects the lane, never individual tests, so no test carries it.
+  # @:workbench-all sets this lane's flag too (see scripts/pr-tags-parse.sh),
+  # which is why there is no separate condition for it here.
   e2e-workbench-suse:
     name: e2e
     needs: [build-workbench]

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -31,6 +31,7 @@ jobs:
       workbench_tag_found: ${{ steps.pr-tags.outputs.workbench_tag_found }}
       workbench_stable_tag_found: ${{ steps.pr-tags.outputs.workbench_stable_tag_found }}
       workbench_rocky_tag_found: ${{ steps.pr-tags.outputs.workbench_rocky_tag_found }}
+      workbench_suse_tag_found: ${{ steps.pr-tags.outputs.workbench_suse_tag_found }}
       jupyter_tag_found: ${{ steps.pr-tags.outputs.jupyter_tag_found }}
       remote_ssh_tag_found: ${{ steps.pr-tags.outputs.remote_ssh_tag_found }}
       connect_tag_found: ${{ steps.pr-tags.outputs.connect_tag_found }}
@@ -240,7 +241,7 @@ jobs:
 
   build-workbench:
     needs: pr-tags
-    if: ${{ needs.pr-tags.outputs.workbench_tag_found == 'true' || needs.pr-tags.outputs.workbench_stable_tag_found == 'true' || needs.pr-tags.outputs.workbench_rocky_tag_found == 'true' }}
+    if: ${{ needs.pr-tags.outputs.workbench_tag_found == 'true' || needs.pr-tags.outputs.workbench_stable_tag_found == 'true' || needs.pr-tags.outputs.workbench_rocky_tag_found == 'true' || needs.pr-tags.outputs.workbench_suse_tag_found == 'true' }}
     name: build
     uses: ./.github/workflows/build-workbench-linux.yml
     secrets: inherit
@@ -285,6 +286,23 @@ jobs:
       os: "rocky9"
       grep: "@:workbench"
       display_name: "workbench-rocky"
+      install_license: false
+      upload_logs: false
+      allow_soft_fail: false
+    secrets: inherit
+
+  # Same test set again, on an openSUSE Leap 15.6 container. `grep` is pinned to
+  # "@:workbench" for the same reason as the Rocky lane above: @:workbench-suse
+  # selects the lane, never individual tests, so no test carries it.
+  e2e-workbench-suse:
+    needs: [pr-tags, build-workbench]
+    if: ${{ needs.pr-tags.outputs.workbench_suse_tag_found == 'true' }}
+    name: e2e
+    uses: ./.github/workflows/test-e2e-workbench-linux.yml
+    with:
+      os: "opensuse15"
+      grep: "@:workbench"
+      display_name: "workbench-suse"
       install_license: false
       upload_logs: false
       allow_soft_fail: false

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -294,6 +294,8 @@ jobs:
   # Same test set again, on an openSUSE Leap 15.6 container. `grep` is pinned to
   # "@:workbench" for the same reason as the Rocky lane above: @:workbench-suse
   # selects the lane, never individual tests, so no test carries it.
+  # @:workbench-all sets this lane's flag too (see scripts/pr-tags-parse.sh),
+  # which is why there is no separate condition for it here.
   e2e-workbench-suse:
     needs: [pr-tags, build-workbench]
     if: ${{ needs.pr-tags.outputs.workbench_suse_tag_found == 'true' }}

--- a/docker/environments/wb-local/README.md
+++ b/docker/environments/wb-local/README.md
@@ -120,11 +120,19 @@ The stack runs on Ubuntu 24 by default. Pass `--os=` (or set `WB_OS` in `.env`)
 to run the same Workbench + Positron install on one of the other OSes the e2e
 lanes cover:
 
-| `--os=` | OS | e2e lane |
-| --- | --- | --- |
-| `ubuntu24` | Ubuntu 24.04 | `workbench` (default), `workbench-stable` |
-| `rocky9` | Rocky Linux 9 | `workbench-rocky` |
-| `opensuse15` | openSUSE Leap 15.6 | `workbench-suse` |
+| `--os=` | OS | e2e lane | PR tag |
+| --- | --- | --- | --- |
+| `ubuntu24` | Ubuntu 24.04 | `workbench` (default) | `@:workbench` |
+| `ubuntu24` | Ubuntu 24.04, last stable Workbench | `workbench-stable` | `@:workbench-stable` |
+| `rocky9` | Rocky Linux 9 | `workbench-rocky` | `@:workbench-rocky` |
+| `opensuse15` | openSUSE Leap 15.6 | `workbench-suse` | `@:workbench-suse` |
+
+`@:workbench-all` is shorthand for the three OS lanes at once (Ubuntu + Rocky +
+openSUSE) when a change warrants full platform coverage. It supersedes those
+three tags rather than adding to them, so a PR carrying both `@:workbench-all`
+and, say, `@:workbench-rocky` reports just `@:workbench-all`. It does **not**
+imply `@:workbench-stable`, which varies the Workbench version rather than the
+OS.
 
 ```bash
 npm run pwb -- --os=rocky9     --workbench=daily --positron=daily

--- a/docker/environments/wb-local/README.md
+++ b/docker/environments/wb-local/README.md
@@ -68,7 +68,7 @@ Two things behave differently than on macOS or Linux:
 | `npm run pwb -- status` | Containers, installed versions, and URLs. |
 | `npm run pwb -- logs [svc]` | Tail logs: `rserver` (default), `connect`, or a container name. |
 | `npm run pwb -- shell [svc]` | Open a shell in a container: `test` (default), `postgres`, or `connect`. |
-| `npm run pwb -- --os=<os>` | Host OS for the test container: `ubuntu24` (default) or `rocky9`. |
+| `npm run pwb -- --os=<os>` | Host OS for the test container: `ubuntu24` (default), `rocky9` or `opensuse15`. |
 | `npm run pwb -- stop` | Pause the stack (containers stopped, volumes kept). |
 | `npm run pwb -- down` | Tear the stack down (removes containers and volumes). |
 
@@ -116,20 +116,40 @@ test fails on a missing UI element rather than anything real.
 
 ## Choosing the OS
 
-The stack runs on Ubuntu 24 by default. Pass `--os=rocky9` (or set `WB_OS` in
-`.env`) to run the same Workbench + Positron install on Rocky Linux 9 instead --
-the OS used by the Rocky e2e lane:
+The stack runs on Ubuntu 24 by default. Pass `--os=` (or set `WB_OS` in `.env`)
+to run the same Workbench + Positron install on one of the other OSes the e2e
+lanes cover:
+
+| `--os=` | OS | e2e lane |
+| --- | --- | --- |
+| `ubuntu24` | Ubuntu 24.04 | `workbench` (default), `workbench-stable` |
+| `rocky9` | Rocky Linux 9 | `workbench-rocky` |
+| `opensuse15` | openSUSE Leap 15.6 | `workbench-suse` |
 
 ```bash
-npm run pwb -- --os=rocky9 --workbench=daily --positron=daily
+npm run pwb -- --os=rocky9     --workbench=daily --positron=daily
+npm run pwb -- --os=opensuse15 --workbench=daily --positron=daily
 ```
 
-The two OSes differ in more than the base image, and all of it is handled for
-you: Rocky installs an `.rpm` (from the feed's `rhel9` entries) with `dnf`
-instead of a `.deb` with `apt`. The Workbench rpm's postinst installs systemd
-units, and this container has no systemd, so the installer copies the SysV init
-scripts it ships into `/etc/init.d/` and starts the session launcher directly --
-the launcher script Posit ships is unusable on EL9.
+The OSes differ in more than the base image, and all of it is handled for you.
+Both rpm OSes install a `.rpm` instead of a `.deb` with `apt` -- Rocky from the
+feed's `rhel9` entries with `dnf`, openSUSE from its `opensuse15` entries with
+`zypper`. Each rpm's postinst installs systemd units, and these containers have
+no systemd, so the installer copies the SysV init scripts the package ships (from
+`extras/init.d/<family>/`) into `/etc/init.d/` and starts the session launcher
+directly -- the launcher script Posit ships is unusable on EL9.
+
+### openSUSE runs emulated on Apple Silicon
+
+Posit publishes the openSUSE 15 Workbench package for **x86_64 only** (both the
+daily and stable feeds), unlike `rhel9` and `noble`, which have arm64 builds. So
+on an Apple Silicon Mac `--os=opensuse15` forces the `test` container to
+`linux/amd64` and runs it under emulation. The run says so up front. It works,
+and it is what CI runs natively, but expect the install and the tests to be
+noticeably slower than the other two OSes. Asking for an arm64 openSUSE build
+fails fast with an explicit message rather than silently downloading the x86 rpm.
+
+### Switching OS reinstalls
 
 `--os` changes the compose `image:`, which makes Compose recreate the `test`
 container. That wipes the in-container install, so **switching OS always

--- a/docker/environments/wb-local/docker-compose.workbench.yml
+++ b/docker/environments/wb-local/docker-compose.workbench.yml
@@ -9,6 +9,12 @@ services:
     # workbench-local-lib.sh). The default keeps a bare `docker compose up` and
     # the CI action, which do not set it, on Ubuntu.
     image: ${WB_TEST_IMAGE:-ghcr.io/posit-dev/positron-ubuntu24:24.18.0}
+    # Normally empty, which Compose drops entirely so the multi-arch resolution
+    # above still applies. workbench-local.sh sets it (to linux/amd64) only for
+    # an OS with no Workbench package for this machine's arch -- openSUSE 15,
+    # which Posit builds for x86_64 only, so on Apple Silicon the local loop has
+    # to be emulated. See wb_os_platform in workbench-local-lib.sh.
+    platform: ${WB_TEST_PLATFORM:-}
     container_name: test
     init: true
     ports:

--- a/docker/environments/wb-local/get-latest-wb-url.sh
+++ b/docker/environments/wb-local/get-latest-wb-url.sh
@@ -4,8 +4,8 @@
 # and architecture.
 #
 # Usage: ./get-latest-wb-url.sh <os> [arch]
-#   os:   ubuntu24 or rocky9
-#   arch: amd64 (default) or arm64
+#   os:   ubuntu24, rocky9 or opensuse15
+#   arch: amd64 (default) or arm64 (not every OS has both -- see wb_os_arches)
 #
 # This runs inside the test container (copied to /tmp alongside the installer),
 # so it is a thin wrapper over workbench-local-lib.sh rather than its own copy of

--- a/docker/environments/wb-local/install-workbench.sh
+++ b/docker/environments/wb-local/install-workbench.sh
@@ -178,9 +178,40 @@ LAUNCHER_SOCKET=/var/run/rstudio-server/rserver-launcher.socket
 # it -- see the same note in workbench-local.sh.
 LAUNCHER_PGREP='[/]usr/lib/rstudio-server/bin/rstudio-launcher'
 
+# Create the runtime directory the launcher binds its socket in, owned by the
+# user the launcher runs as.
+#
+# rserver creates /var/run/rstudio-server itself at startup and gives it to the
+# server-user -- but we have to start the LAUNCHER first, because rserver shuts
+# itself down if the launcher socket is missing. The launcher drops privileges to
+# that same server-user before binding, so on a fresh container it finds a
+# root-owned (or absent) directory and dies immediately:
+#
+#   ERROR system error 13 (Permission denied)
+#     [stream: /var/run/rstudio-server/rserver-launcher.socket]
+#
+# and then rserver has no socket to connect to, so :8787 never comes up at all.
+# Nothing else creates this directory in a container: the rpm ships no
+# tmpfiles.d config, and neither the systemd units nor the SysV scripts make it
+# -- the same class of gap as the missing init scripts.
+#
+# Mode 1777 and the ownership are what a successful rserver start produces, so
+# this is not a loosening; it is doing early what rserver would have done later.
+# Reads server-user from launcher.conf rather than assuming, since it has to
+# match what rserver uses.
+prepare_runtime_dir() {
+    local server_user
+    server_user="$(awk -F= '/^server-user=/{print $2}' /etc/rstudio/launcher.conf 2>/dev/null | tr -d '[:space:]')"
+    server_user="${server_user:-rstudio-server}"
+    if ! sudo install -d -m 1777 -o "${server_user}" -g "${server_user}" /var/run/rstudio-server; then
+        log_error "Failed to prepare /var/run/rstudio-server for ${server_user}"
+    fi
+}
+
 start_workbench() {
     local i
     if [ "${WB_FAMILY}" != "debian" ]; then
+        prepare_runtime_dir
         # How the launcher gets started depends on the family, because only one of
         # the two rpm init scripts is usable in this container. Keep this in step
         # with wb_ensure_workbench in workbench-local.sh, which has to make the

--- a/docker/environments/wb-local/install-workbench.sh
+++ b/docker/environments/wb-local/install-workbench.sh
@@ -181,35 +181,65 @@ LAUNCHER_PGREP='[/]usr/lib/rstudio-server/bin/rstudio-launcher'
 start_workbench() {
     local i
     if [ "${WB_FAMILY}" != "debian" ]; then
-        # The rstudio-launcher script the rpm ships is unusable on EL9: its
-        # install guard tests $rserver, which that script never defines (so start
-        # silently exits 0); it passes --name/--pidfiles/--stop to `daemon`, none
-        # of which EL9's initscripts supports; and the launcher does not
-        # self-daemonize the way rserver does, so a plain `daemon` call would
-        # block forever. Start it directly instead.
-        #
-        # The SUSE script is better written (startproc/killproc, both pidfile
-        # based) but is started the same way here on purpose: one code path means
-        # the installer's first start and wb_ensure_workbench's restart cannot
-        # diverge, and it costs nothing, because the wait below is on the socket
-        # actually appearing rather than on a fixed delay.
+        # How the launcher gets started depends on the family, because only one of
+        # the two rpm init scripts is usable in this container. Keep this in step
+        # with wb_ensure_workbench in workbench-local.sh, which has to make the
+        # same choice from the host side.
         if ! pgrep -f "${LAUNCHER_PGREP}" >/dev/null 2>&1; then
             echo "Starting rstudio-launcher..."
             sudo rm -f "${LAUNCHER_SOCKET}"
-            sudo nohup setsid /usr/lib/rstudio-server/bin/rstudio-launcher \
-                >/var/log/rstudio-launcher.stdout.log 2>&1 &
+            if [ "${WB_FAMILY}" = "suse" ]; then
+                # SUSE's script works: `startproc -s -q` on the launcher binary,
+                # which brings the socket up in about a second. Use the packaged
+                # path rather than hand-detaching the binary -- an earlier
+                # revision of this ran the redhat branch below on SUSE too, "for
+                # one code path", and the socket never appeared at all on the CI
+                # runner while working locally. Whatever the direct start needs
+                # that it did not get there, the init script does not need it.
+                #
+                # `|| true` because startproc's exit status is as unreliable here
+                # as the rest: it reports failure whenever it cannot match the
+                # process through /proc/<pid>/exe (which is how it behaves under
+                # Rosetta) while having started the launcher perfectly well. The
+                # socket check below is the real verdict.
+                sudo /etc/init.d/rstudio-launcher start || true
+            else
+                # The rstudio-launcher script the rpm ships is unusable on EL9:
+                # its install guard tests $rserver, which that script never
+                # defines (so start silently exits 0); it passes
+                # --name/--pidfiles/--stop to `daemon`, none of which EL9's
+                # initscripts supports; and the launcher does not self-daemonize
+                # the way rserver does, so a plain `daemon` call would block
+                # forever. Start it directly instead.
+                sudo nohup setsid /usr/lib/rstudio-server/bin/rstudio-launcher \
+                    >/var/log/rstudio-launcher.stdout.log 2>&1 &
+            fi
         fi
-        # Generous cap because this exits as soon as the socket shows up: on a
-        # native amd64 runner it is a second or two, but an emulated container
-        # (openSUSE on Apple Silicon, which has no arm64 Workbench package) has
-        # been measured taking over 30s, and timing out here made the install
-        # report a failure it had not actually had.
+        # Generous cap because this exits as soon as the socket shows up: a couple
+        # of seconds natively, longer in an emulated container (openSUSE on Apple
+        # Silicon, which has no arm64 Workbench package).
         for i in $(seq 1 90); do
             [ -S "${LAUNCHER_SOCKET}" ] && break
             sleep 1
         done
         if [ ! -S "${LAUNCHER_SOCKET}" ]; then
+            # Fatal, not accumulated: rserver calls LauncherClient::initialize()
+            # at startup and shuts itself down with ENOENT when this socket is
+            # missing, so everything after this point is guaranteed to fail. It
+            # used to be a log_error, and the install went on to "complete" with a
+            # warning -- then the real damage surfaced minutes later as a bare
+            # ":8787 never answered" from a different step, which is a much harder
+            # thing to read. Dump what we know before giving up.
             log_error "rstudio-launcher socket never appeared at ${LAUNCHER_SOCKET}"
+            echo "--- rstudio-launcher processes ---"
+            pgrep -af "${LAUNCHER_PGREP}" || echo "(none running)"
+            echo "--- /var/log/rstudio-launcher.stdout.log ---"
+            sudo tail -50 /var/log/rstudio-launcher.stdout.log 2>/dev/null || echo "(absent)"
+            echo "--- /var/log/rstudio/launcher ---"
+            sudo tail -n 50 /var/log/rstudio/launcher/* 2>/dev/null || echo "(absent)"
+            echo ""
+            echo "Aborting: rserver cannot start without the launcher socket."
+            exit 1
         fi
     fi
     # Judge the start by whether rserver is running, not by the init script's

--- a/docker/environments/wb-local/install-workbench.sh
+++ b/docker/environments/wb-local/install-workbench.sh
@@ -117,6 +117,32 @@ source "$(dirname "${BASH_SOURCE[0]}")/ensure-connect-token.sh"
 # URL resolution here is the same code the host-side picker runs.
 source "$(dirname "${BASH_SOURCE[0]}")/workbench-local-lib.sh"
 
+# Every zypper call goes through this, and the PATH override is the whole point.
+#
+# The openSUSE image puts /opt/conda/bin first on PATH (its Dockerfile needs
+# conda's python on PATH for the interpreter tests). zypper shells out to
+# `repo2solv` *by name* to build its metadata cache, and conda ships its own
+# libsolv whose repo2solv is compiled without rpm-md support -- so conda's is the
+# one zypper finds, and every `zypper refresh` fails with:
+#
+#   repo2solv ... rpmmd repo type is not supported
+#   Skipping repository '...' because of the above error.
+#
+# which reads like a broken mirror rather than a shadowed binary. zypper then has
+# no package names at all, so every install afterwards fails with the equally
+# misleading "'jq' not found in package names". Putting the system bin
+# directories first is the entire fix; verified against this image.
+#
+# --force-resolution because sysvinit-tools, which supplies the startproc and
+# killproc the SUSE init scripts call, conflicts with the
+# busybox-sysvinit-tools the image ships. Nothing on the image requires the
+# busybox variant and it provides a strict subset (pidof, killall5, fsync,
+# usleep -- no startproc), so having zypper resolve the conflict by replacing it
+# is the outcome we want, not one we are tolerating.
+wb_zypper() {
+    sudo env PATH="/usr/sbin:/usr/bin:/sbin:/bin" zypper --non-interactive "$@"
+}
+
 # Stop rserver and *verify* it exited. Do not trust `rstudio-server stop`'s exit
 # status: on EL9 the init script's status check uses `pidof -c`, which cannot see
 # rserver inside a container, so the stop short-circuits to a silent no-op and
@@ -153,21 +179,32 @@ LAUNCHER_SOCKET=/var/run/rstudio-server/rserver-launcher.socket
 LAUNCHER_PGREP='[/]usr/lib/rstudio-server/bin/rstudio-launcher'
 
 start_workbench() {
-    if [ "${WB_OS}" = "rocky9" ]; then
+    local i
+    if [ "${WB_FAMILY}" != "debian" ]; then
         # The rstudio-launcher script the rpm ships is unusable on EL9: its
         # install guard tests $rserver, which that script never defines (so start
         # silently exits 0); it passes --name/--pidfiles/--stop to `daemon`, none
         # of which EL9's initscripts supports; and the launcher does not
         # self-daemonize the way rserver does, so a plain `daemon` call would
         # block forever. Start it directly instead.
+        #
+        # The SUSE script is better written (startproc/killproc, both pidfile
+        # based) but is started the same way here on purpose: one code path means
+        # the installer's first start and wb_ensure_workbench's restart cannot
+        # diverge, and it costs nothing, because the wait below is on the socket
+        # actually appearing rather than on a fixed delay.
         if ! pgrep -f "${LAUNCHER_PGREP}" >/dev/null 2>&1; then
             echo "Starting rstudio-launcher..."
             sudo rm -f "${LAUNCHER_SOCKET}"
             sudo nohup setsid /usr/lib/rstudio-server/bin/rstudio-launcher \
                 >/var/log/rstudio-launcher.stdout.log 2>&1 &
         fi
-        local i
-        for i in $(seq 1 30); do
+        # Generous cap because this exits as soon as the socket shows up: on a
+        # native amd64 runner it is a second or two, but an emulated container
+        # (openSUSE on Apple Silicon, which has no arm64 Workbench package) has
+        # been measured taking over 30s, and timing out here made the install
+        # report a failure it had not actually had.
+        for i in $(seq 1 90); do
             [ -S "${LAUNCHER_SOCKET}" ] && break
             sleep 1
         done
@@ -175,9 +212,20 @@ start_workbench() {
             log_error "rstudio-launcher socket never appeared at ${LAUNCHER_SOCKET}"
         fi
     fi
-    if ! sudo rstudio-server start; then
-        log_error "Failed to start RStudio server"
-    fi
+    # Judge the start by whether rserver is running, not by the init script's
+    # exit status, which is not trustworthy in a container on either rpm OS:
+    # EL9's checks with `pidof -c` and SUSE's with `checkproc`, and neither can
+    # see rserver here. On openSUSE this was observed printing
+    # "Starting rstudio-server ..failed" and exiting non-zero while rserver was
+    # up and :8787 was serving 302 -- checkproc matches through
+    # /proc/<pid>/exe, which is not readable for a process running under
+    # Rosetta. `pgrep -x` reads comm instead and is correct in both cases.
+    sudo rstudio-server start || true
+    for i in $(seq 1 30); do
+        pgrep -x rserver >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    log_error "Failed to start RStudio server (rserver is not running)"
 }
 
 # Initial parameter setup - auto-detect architecture if not set
@@ -190,14 +238,20 @@ if [ -z "${ARCH_SUFFIX:-}" ]; then
 fi
 POSITRON_TAG=${POSITRON_TAG:-""}  # Empty default will get the latest release
 GITHUB_TOKEN=${GITHUB_TOKEN:-"myToken"}
-# Host OS of this container: ubuntu24 (apt/.deb) or rocky9 (dnf/.rpm). Every
-# OS-specific step below branches on it. Same vocabulary the --os flag and the
-# compose image use -- see workbench-local-lib.sh.
+# Host OS of this container: ubuntu24 (apt/.deb), rocky9 (dnf/.rpm) or
+# opensuse15 (zypper/.rpm). Same vocabulary the --os flag and the compose image
+# use -- see workbench-local-lib.sh.
 WB_OS=${WB_OS:-"ubuntu24"}
 if ! wb_os_valid "${WB_OS}"; then
     exit 1
 fi
 WB_PKG_EXT="$(wb_os_pkg_ext "${WB_OS}")"
+# The OS-specific steps below branch on the *family* (debian|redhat|suse), not
+# the OS. Both rpm families need the same handling in most places and differ in
+# only a few, so a family branch keeps each step to the distinctions that are
+# real. It is also the name of the extras/init.d/<family> directory the package
+# ships, which the SysV install below relies on.
+WB_FAMILY="$(wb_os_family "${WB_OS}")"
 
 # User configuration with defaults that can be overridden by environment variables
 Q_USER=${Q_USER:-"user1"}
@@ -208,28 +262,46 @@ WB_PASSWORD=${WB_PASSWORD:-"testpassword"}
 
 # Install required packages early so we have jq for URL fetching
 echo "Installing required packages (${WB_OS})..."
-if [ "${WB_OS}" = "rocky9" ]; then
-    # initscripts provides /etc/rc.d/init.d/functions, which the SysV scripts the
-    # Workbench rpm ships in extras/init.d/redhat/ source on line 8. The rpm's
-    # postinst installs systemd units instead of those scripts, and this container
-    # has no systemd, so we copy them in by hand after the install below.
-    if ! sudo dnf install -y acl jq curl initscripts; then
-        log_error "Failed to install required packages (acl, jq, curl, initscripts)"
-    fi
-else
-    if ! sudo apt-get update; then
-        log_error "Failed to update package lists"
-    fi
-    if ! sudo add-apt-repository -y universe; then
-        log_error "Failed to add universe repository"
-    fi
-    if ! sudo apt-get update; then
-        log_error "Failed to update package lists after adding universe"
-    fi
-    if ! sudo apt-get install -y acl jq curl; then
-        log_error "Failed to install required packages (acl, jq, curl)"
-    fi
-fi
+case "${WB_FAMILY}" in
+    redhat)
+        # initscripts provides /etc/rc.d/init.d/functions, which the SysV scripts
+        # the Workbench rpm ships in extras/init.d/redhat/ source on line 8. The
+        # rpm's postinst installs systemd units instead of those scripts, and this
+        # container has no systemd, so we copy them in by hand after the install
+        # below.
+        if ! sudo dnf install -y acl jq curl initscripts; then
+            log_error "Failed to install required packages (acl, jq, curl, initscripts)"
+        fi
+        ;;
+    suse)
+        # Same reason as redhat, different providers: the SysV scripts in
+        # extras/init.d/suse/ source /etc/rc.status (from aaa_base, already on the
+        # image) and call startproc/killproc, which come from sysvinit-tools. The
+        # image ships neither acl (setfacl, needed below) nor jq (needed by the
+        # URL resolution above), so both are real installs here rather than the
+        # no-op reinstalls the other two OSes get.
+        if ! wb_zypper --gpg-auto-import-keys refresh; then
+            log_error "Failed to refresh zypper repositories"
+        fi
+        if ! wb_zypper install --force-resolution acl jq curl sysvinit-tools; then
+            log_error "Failed to install required packages (acl, jq, curl, sysvinit-tools)"
+        fi
+        ;;
+    *)
+        if ! sudo apt-get update; then
+            log_error "Failed to update package lists"
+        fi
+        if ! sudo add-apt-repository -y universe; then
+            log_error "Failed to add universe repository"
+        fi
+        if ! sudo apt-get update; then
+            log_error "Failed to update package lists after adding universe"
+        fi
+        if ! sudo apt-get install -y acl jq curl; then
+            log_error "Failed to install required packages (acl, jq, curl)"
+        fi
+        ;;
+esac
 
 # Now we can fetch the WB_URL if it wasn't provided
 if [ -z "${WB_URL}" ]; then
@@ -310,20 +382,43 @@ fi
 
 # Install Workbench
 echo "Installing Workbench..."
-if [ "${WB_OS}" = "rocky9" ]; then
-    if ! sudo dnf install -y "./workbench.${WB_PKG_EXT}"; then
-        log_error "Failed to install Workbench package"
-    fi
-    # The rpm's postinst installs systemd units, so /etc/init.d stays empty and
-    # `rstudio-server start` has nothing to run. The SysV scripts it ships are
-    # the ones the Ubuntu .deb installs for us; copy them into place so the
-    # start/stop paths below (and wb_ensure_workbench) work on both OSes.
-    if [ -d /usr/lib/rstudio-server/extras/init.d/redhat ]; then
-        sudo cp /usr/lib/rstudio-server/extras/init.d/redhat/rstudio-server /etc/init.d/
-        sudo cp /usr/lib/rstudio-server/extras/init.d/redhat/rstudio-launcher /etc/init.d/
+case "${WB_FAMILY}" in
+    redhat)
+        if ! sudo dnf install -y "./workbench.${WB_PKG_EXT}"; then
+            log_error "Failed to install Workbench package"
+        fi
+        ;;
+    suse)
+        # --allow-unsigned-rpm because the downloaded package carries no key this
+        # container trusts, and --no-gpg-checks so resolving its dependencies out
+        # of the image's repos does not stop on the same question. `zypper
+        # install <path>`, not `rpm -i`, so those dependencies get pulled rather
+        # than reported as unmet.
+        if ! wb_zypper --no-gpg-checks install --allow-unsigned-rpm "./workbench.${WB_PKG_EXT}"; then
+            log_error "Failed to install Workbench package"
+        fi
+        ;;
+    *)
+        if ! sudo apt install -y "./workbench.${WB_PKG_EXT}"; then
+            log_error "Failed to install Workbench package"
+        fi
+        ;;
+esac
+
+if [ "${WB_FAMILY}" != "debian" ]; then
+    # Both rpm packages' postinst installs systemd units, so /etc/init.d stays
+    # empty and `rstudio-server start` has nothing to run. Each package also
+    # ships the SysV scripts the Ubuntu .deb installs for us, in a directory
+    # named for the family (verified: extras/init.d/{debian,redhat,suse} all
+    # exist); copy those into place so the start/stop paths below (and
+    # wb_ensure_workbench) work on every OS.
+    INIT_SRC="/usr/lib/rstudio-server/extras/init.d/${WB_FAMILY}"
+    if [ -d "${INIT_SRC}" ]; then
+        sudo cp "${INIT_SRC}/rstudio-server" /etc/init.d/
+        sudo cp "${INIT_SRC}/rstudio-launcher" /etc/init.d/
         sudo chmod +x /etc/init.d/rstudio-server /etc/init.d/rstudio-launcher
     else
-        log_error "Workbench rpm did not ship extras/init.d/redhat (no SysV scripts to install)"
+        log_error "Workbench rpm did not ship ${INIT_SRC} (no SysV scripts to install)"
     fi
     # Without this the launcher warns that HOME is unset and that plugins may
     # inherit an incorrect one.
@@ -335,9 +430,10 @@ if [ "${WB_OS}" = "rocky9" ]; then
     # rserver launches sessions through PAM, which builds a fresh environment
     # rather than inheriting the container's -- so the image's `ENV PATH` never
     # reaches a session, and putting a directory on PATH in the Dockerfile does
-    # not help. `pam_env` (in /etc/pam.d/system-auth on EL9) reads
-    # /etc/environment for that PATH; Debian/Ubuntu ship a populated one, EL9
-    # ships it empty. The result on Rocky was a session PATH without
+    # not help. `pam_env` (/etc/pam.d/system-auth on EL9, /etc/pam.d/common-session
+    # on openSUSE) reads /etc/environment for that PATH; Debian/Ubuntu ship a
+    # populated one and neither rpm distro does. The result on Rocky was a
+    # session PATH without
     # /usr/local/bin, which is where the image installs quarto -- so Posit
     # Publisher's `quarto inspect` (spawned by name) failed, it fell back to a
     # hardcoded version with no engines, and Connect then declined to provision R
@@ -349,10 +445,6 @@ if [ "${WB_OS}" = "rocky9" ]; then
         printf 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\n' \
             | sudo tee -a /etc/environment > /dev/null
         sudo chmod 644 /etc/environment
-    fi
-else
-    if ! sudo apt install -y "./workbench.${WB_PKG_EXT}"; then
-        log_error "Failed to install Workbench package"
     fi
 fi
 
@@ -459,19 +551,32 @@ start_workbench
 # Ensure (fetch once) + export CONNECT_TOKEN for subsequent steps/tests
 ensure_connect_token || true
 
-# Setup environment modules. Both images bake the package in, so this is a
-# no-op reinstall on a normal run; it stays as a safety net for an image that
-# predates it.
+# Setup environment modules. The Ubuntu and Rocky images bake the package in, so
+# there this is a no-op reinstall (and a safety net for an image that predates
+# it). The openSUSE image does not ship it, so there it is a real install --
+# worth adding to that image's package list eventually, but it costs seconds and
+# keeping it here means the lane does not wait on an image rebuild.
 echo "Setting up environment modules..."
-if [ "${WB_OS}" = "rocky9" ]; then
-    if ! sudo dnf install -y environment-modules; then
-        log_error "Failed to install environment-modules"
-    fi
-else
-    if ! sudo apt install -y environment-modules; then
-        log_error "Failed to install environment-modules"
-    fi
-fi
+case "${WB_FAMILY}" in
+    redhat)
+        if ! sudo dnf install -y environment-modules; then
+            log_error "Failed to install environment-modules"
+        fi
+        ;;
+    suse)
+        # openSUSE names the same project's package "Modules", not
+        # "environment-modules". It drops the same /etc/profile.d/modules.sh the
+        # other two do, which is what the profile.d snippet below sources.
+        if ! wb_zypper install Modules; then
+            log_error "Failed to install Modules (environment-modules)"
+        fi
+        ;;
+    *)
+        if ! sudo apt install -y environment-modules; then
+            log_error "Failed to install environment-modules"
+        fi
+        ;;
+esac
 # The session user (not root) resolves these modulefiles, so the tree has to be
 # world-readable. State the modes rather than inheriting the ambient umask: a
 # sourced helper leaking `umask 077` once made these 0700/0600, which hid both

--- a/docker/environments/wb-local/workbench-local-lib.sh
+++ b/docker/environments/wb-local/workbench-local-lib.sh
@@ -3,16 +3,19 @@
 # in the _wb_fetch_* seams (and wb_url_reachable) so tests can stub them with
 # fixtures -- see scripts/test/workbench-local-lib-test.sh.
 #
-# OS vocabulary: there is exactly one, "ubuntu24" | "rocky9", and it is the same
-# string the user types (--os=), the compose image is named after, and the
-# installer branches on. Posit's download feeds spell the same two OSes "noble"
-# and "rhel9"; that is confined to wb_os_feed below and must not leak out of it,
-# because a second vocabulary in the middle layers is exactly how the wrong
-# package gets resolved for the right container.
+# OS vocabulary: there is exactly one, "ubuntu24" | "rocky9" | "opensuse15", and
+# it is the same string the user types (--os=), the compose image is named after,
+# and the installer branches on. Posit's download feeds spell the first two
+# "noble" and "rhel9"; that is confined to wb_os_feed below and must not leak out
+# of it, because a second vocabulary in the middle layers is exactly how the
+# wrong package gets resolved for the right container. (opensuse15 happens to
+# spell the same in both vocabularies -- do not read that as permission to skip
+# wb_os_feed for it.)
 #
-# Everything else that differs between the two OSes (package format, filename
-# stem, the arch token in feed keys, the container image) is a wb_os_* helper, so
-# adding an OS means editing those helpers and nothing else.
+# Everything else that differs between the OSes (package format, filename stem,
+# the arch token in feed keys, the container image, which architectures exist at
+# all) is a wb_os_* helper, so adding an OS means editing those helpers and
+# nothing else.
 
 wb_detect_arch() {
 	local m="${1:-$(uname -m)}"
@@ -26,11 +29,11 @@ wb_detect_arch() {
 
 # --- OS facts -----------------------------------------------------------------
 
-WB_OS_CHOICES='ubuntu24 rocky9'
+WB_OS_CHOICES='ubuntu24 rocky9 opensuse15'
 
 wb_os_valid() {
 	case "${1:-}" in
-		ubuntu24|rocky9) return 0 ;;
+		ubuntu24|rocky9|opensuse15) return 0 ;;
 		*) echo "Unsupported OS: '${1:-}' (expected one of: ${WB_OS_CHOICES})" >&2; return 1 ;;
 	esac
 }
@@ -40,14 +43,16 @@ wb_os_valid() {
 # (platforms["<feed>-<arch>"]). The ONLY place the feed vocabulary is allowed.
 wb_os_feed() {
 	case "${1:-}" in
-		ubuntu24) printf noble ;;
-		rocky9)   printf rhel9 ;;
+		ubuntu24)   printf noble ;;
+		rocky9)     printf rhel9 ;;
+		opensuse15) printf opensuse15 ;;
 		*) return 1 ;;
 	esac
 }
 
-# Container image the test stack runs for this OS. Both are multi-arch manifest
-# lists, so Docker picks amd64/arm64 itself.
+# Container image the test stack runs for this OS. All three are multi-arch
+# manifest lists, so Docker picks amd64/arm64 itself -- except where
+# wb_os_platform overrides it because the OS has no arm64 Workbench package.
 #
 # Keep the ubuntu24 tag in step with the `image:` default in
 # docker-compose.workbench.yml. They are two independent copies of the same
@@ -58,27 +63,32 @@ wb_os_feed() {
 # failure disagree for no visible reason.
 wb_os_image() {
 	case "${1:-}" in
-		ubuntu24) printf 'ghcr.io/posit-dev/positron-ubuntu24:24.18.0' ;;
-		rocky9)   printf 'ghcr.io/posit-dev/positron-rocky9:24.18.0' ;;
+		ubuntu24)   printf 'ghcr.io/posit-dev/positron-ubuntu24:24.18.0' ;;
+		rocky9)     printf 'ghcr.io/posit-dev/positron-rocky9:24.18.0' ;;
+		# The same image test-e2e-suse.yml runs, so the Workbench lane and the
+		# electron SUSE lane share one openSUSE definition.
+		opensuse15) printf 'ghcr.io/posit-dev/positron-opensuse156:24.18.0' ;;
 		*) return 1 ;;
 	esac
 }
 
-# Package format: deb (Ubuntu) or rpm (RHEL family).
+# Package format: deb (Ubuntu) or rpm (RHEL family, SUSE).
 wb_os_pkg_ext() {
 	case "${1:-}" in
-		ubuntu24) printf deb ;;
-		rocky9)   printf rpm ;;
+		ubuntu24)          printf deb ;;
+		rocky9|opensuse15) printf rpm ;;
 		*) return 1 ;;
 	esac
 }
 
 # Package filename prefix, everything ahead of the version. The RHEL packages
-# carry an extra "-rhel" segment, so this is not derivable from the extension.
+# carry an extra "-rhel" segment and the openSUSE ones do not, so this is
+# derivable from neither the extension nor the package format.
 wb_os_pkg_stem() {
 	case "${1:-}" in
-		ubuntu24) printf 'rstudio-workbench-' ;;
-		rocky9)   printf 'rstudio-workbench-rhel-' ;;
+		ubuntu24)   printf 'rstudio-workbench-' ;;
+		rocky9)     printf 'rstudio-workbench-rhel-' ;;
+		opensuse15) printf 'rstudio-workbench-' ;;
 		*) return 1 ;;
 	esac
 }
@@ -91,12 +101,67 @@ wb_os_pkg_stem() {
 # wb_resolve_stable_url).
 wb_os_key_arch() {
 	case "${1:-}:${2:-}" in
-		ubuntu24:amd64) printf amd64 ;;
-		ubuntu24:arm64) printf arm64 ;;
-		rocky9:amd64)   printf x86_64 ;;
-		rocky9:arm64)   printf arm64 ;;
+		ubuntu24:amd64)   printf amd64 ;;
+		ubuntu24:arm64)   printf arm64 ;;
+		rocky9:amd64)     printf x86_64 ;;
+		rocky9:arm64)     printf arm64 ;;
+		opensuse15:amd64) printf x86_64 ;;
+		# No opensuse15:arm64 on purpose -- see wb_os_arches.
 		*) return 1 ;;
 	esac
+}
+
+# Init-script / package-manager family. Doubles as the name of the
+# extras/init.d/<family> directory the Workbench package ships (verified against
+# the real packages: debian, redhat and suse all exist), which is what the
+# installer copies into /etc/init.d on the two OSes whose package installs
+# systemd units instead. Branching the installer on the family rather than on the
+# OS is what keeps a third OS from adding a third arm to every case statement.
+wb_os_family() {
+	case "${1:-}" in
+		ubuntu24)   printf debian ;;
+		rocky9)     printf redhat ;;
+		opensuse15) printf suse ;;
+		*) return 1 ;;
+	esac
+}
+
+# Architectures Posit publishes a Workbench package for, per OS. Not cosmetic:
+# openSUSE 15 is x86_64-only on both channels -- the dailies feed has an
+# "opensuse15-x86_64" key and no arm64 one, and downloads.json publishes only the
+# x86_64 rpm -- so unlike rhel9 there is no arm64 artifact for an arm64 URL to be
+# rewritten to. Resolution has to refuse rather than hand an x86 package to an
+# arm64 container, which is a failure that would otherwise surface as an opaque
+# zypper error minutes into an install.
+wb_os_arches() {
+	case "${1:-}" in
+		ubuntu24|rocky9) printf 'amd64 arm64' ;;
+		opensuse15)      printf 'amd64' ;;
+		*) return 1 ;;
+	esac
+}
+
+# True if this OS has a Workbench package for this arch. Prints the reason when
+# it does not, so callers can `|| return 1` and say nothing themselves.
+wb_os_supports_arch() {
+	local os="${1:-}" arch="${2:-}" a
+	wb_os_valid "$os" || return 1
+	for a in $(wb_os_arches "$os"); do
+		[ "$a" = "$arch" ] && return 0
+	done
+	echo "No ${arch} Workbench package exists for ${os} (Posit publishes: $(wb_os_arches "$os"))." >&2
+	return 1
+}
+
+# Docker platform to force the test container to, or empty to let Docker pick
+# from the multi-arch manifest. Non-empty only when this machine's architecture
+# has no Workbench package for the chosen OS: on Apple Silicon, --os=opensuse15
+# runs an emulated amd64 container, because the alternative is no local loop at
+# all. Emulated is slow but correct; the CI runners are amd64 and never hit this.
+wb_os_platform() {
+	local os="${1:-}" arch="${2:-}"
+	wb_os_supports_arch "$os" "$arch" 2>/dev/null && return 0
+	printf 'linux/amd64'
 }
 
 # --- Package URL parsing ------------------------------------------------------
@@ -104,6 +169,7 @@ wb_os_key_arch() {
 # Extract the Workbench version (incl .proN) from a package URL/filename:
 #   .../rstudio-workbench-2026.05.1-225.pro10-amd64.deb      -> 2026.05.1-225.pro10
 #   .../rstudio-workbench-rhel-2026.08.0-187.pro5-x86_64.rpm -> 2026.08.0-187.pro5
+#   .../rstudio-workbench-2026.09.0-166.pro8-x86_64.rpm      -> 2026.09.0-166.pro8
 # Non-zero (and prints nothing) when the name isn't a Workbench package, so
 # callers' `|| echo unavailable` fallback fires.
 wb_pkg_version() {
@@ -111,10 +177,18 @@ wb_pkg_version() {
 	[ -n "$url" ] || return 1
 	base="$(basename "$url")"
 	case "$base" in
-		# The rpm stem is a superset of the deb stem, so strip by extension
-		# rather than trying both prefixes.
 		*.deb) base="${base#"$(wb_os_pkg_stem ubuntu24)"}"; base="${base%-*.deb}" ;;
-		*.rpm) base="${base#"$(wb_os_pkg_stem rocky9)"}";   base="${base%-*.rpm}" ;;
+		# Two stems share the .rpm extension: rhel9 carries the "-rhel" segment
+		# and opensuse15 does not. The rhel stem is a strict superset of the
+		# plain one, so strip the longer first and let the shorter fall through
+		# -- whichever matched, the other is then a no-op. Getting this wrong is
+		# silent: it leaves the stem on the front of the "version" and only ever
+		# shows up as a mangled label in the picker menu.
+		*.rpm)
+			base="${base#"$(wb_os_pkg_stem rocky9)"}"
+			base="${base#"$(wb_os_pkg_stem opensuse15)"}"
+			base="${base%-*.rpm}"
+			;;
 		*) return 1 ;;
 	esac
 	[ -n "$base" ] || return 1
@@ -154,12 +228,17 @@ wb_url_reachable() { curl -fsIL --max-time 15 "$1" >/dev/null 2>&1; }
 wb_resolve_stable_url() {
 	local os="${1:-}" wb_arch="${2:-}" feed url dir base
 	wb_os_valid "$os" || return 1
+	# Before touching the network: an OS/arch pair Posit does not build has no
+	# URL to resolve, and the arm64 rewrite below would otherwise pass the x86
+	# URL through untouched and look like a success.
+	wb_os_supports_arch "$os" "$wb_arch" || return 1
 	feed="$(wb_os_feed "$os")"
 	url="$(_wb_fetch_downloads_json | jq -r --arg os "$feed" '.rstudio.pro.stable.server.installer[$os].url // empty')"
 	[ -n "$url" ] && [ "$url" != "null" ] || { echo "Failed to resolve stable URL for ${os} (feed key '${feed}')" >&2; return 1; }
-	# The feed publishes only the x86 installer for both OSes. The arm64 build is
-	# released at the same path with the arch tokens swapped (both rewrites
-	# verified reachable against the live feed).
+	# The feed publishes only the x86 installer for every OS. Where an arm64 build
+	# exists it is released at the same path with the arch tokens swapped (both
+	# rewrites verified reachable against the live feed). opensuse15 never reaches
+	# here: it has no arm64 build, and wb_os_supports_arch above rejected it.
 	if [ "$wb_arch" = "arm64" ]; then
 		case "$os" in
 			ubuntu24) url="${url//amd64/arm64}" ;;
@@ -183,6 +262,7 @@ wb_resolve_stable_url() {
 wb_resolve_daily_url() {
 	local os="${1:-}" wb_arch="${2:-}" key url
 	wb_os_valid "$os" || return 1
+	wb_os_supports_arch "$os" "$wb_arch" || return 1
 	key="$(wb_os_key_arch "$os" "$wb_arch")" || { echo "Unsupported architecture: ${wb_arch}" >&2; return 1; }
 	key="$(wb_os_feed "$os")-${key}"
 	# Use the "workbench" product (Pro), not "server" (open-source RStudio Server).

--- a/docker/environments/wb-local/workbench-local.sh
+++ b/docker/environments/wb-local/workbench-local.sh
@@ -210,6 +210,14 @@ wb_ensure_workbench() {
 		# the path beside it. That mistake silently skipped the start and left the
 		# stale socket in place, which the wait below then accepted. Removing the
 		# socket first is what makes that wait mean something.
+		# Same prerequisite the installer's prepare_runtime_dir handles: the
+		# launcher binds its socket as the server-user, and nothing in a
+		# container creates this directory with that ownership. Needed here too
+		# because a container restart can leave it reset.
+		docker exec test bash -c '
+			su="$(awk -F= "/^server-user=/{print \$2}" /etc/rstudio/launcher.conf 2>/dev/null | tr -d "[:space:]")"
+			sudo install -d -m 1777 -o "${su:-rstudio-server}" -g "${su:-rstudio-server}" /var/run/rstudio-server
+		' >/dev/null 2>&1 || true
 		if [ "$launcher" != 1 ]; then
 			if [ "$family" = "suse" ]; then
 				docker exec test bash -c "

--- a/docker/environments/wb-local/workbench-local.sh
+++ b/docker/environments/wb-local/workbench-local.sh
@@ -12,9 +12,9 @@ WB_SCRIPTS_DIR="${SCRIPT_DIR}"
 # container rather than duplicating the URL-resolution rules.
 WB_SCRIPTS=(install-workbench.sh ensure-connect-token.sh positronDownload.sh get-latest-wb-url.sh workbench-local-lib.sh configure-datasources.sh)
 
-# Host OS of the test container: ubuntu24 or rocky9. Set by --os= (or WB_OS in
-# .env) and threaded into the compose image, the installer, and the service
-# restart below. See wb_os_* in workbench-local-lib.sh.
+# Host OS of the test container: ubuntu24, rocky9 or opensuse15. Set by --os=
+# (or WB_OS in .env) and threaded into the compose image, the installer, and the
+# service restart below. See wb_os_* in workbench-local-lib.sh.
 WB_OS="${WB_OS:-ubuntu24}"
 
 wb_compose() { docker compose -f "${COMPOSE_FILE}" "$@"; }
@@ -190,7 +190,11 @@ wb_ensure_workbench() {
 		sudo pkill -KILL -x rserver 2>/dev/null || true
 	' >/dev/null 2>&1 || true
 	local i
-	if [ "${WB_OS}" = "rocky9" ]; then
+	# Branch on the family, exactly as install-workbench.sh does. These two must
+	# agree: the installer's first start and this restart-after-container-stop
+	# path have to bring the launcher up the same way, or a stack that installed
+	# fine comes back broken after `npm run pwb -- stop && npm run pwb`.
+	if [ "$(wb_os_family "${WB_OS}")" != "debian" ]; then
 		# The rpm's rstudio-launcher init script is broken on EL9 (see
 		# install-workbench.sh), so start the binary directly and wait for its
 		# socket -- rserver shuts itself down if the socket is missing.
@@ -495,6 +499,25 @@ cmd_up() {
 	# the test container, which wipes the in-container install, so switching OS
 	# always costs a reinstall (reported below rather than left to look spurious).
 	WB_TEST_IMAGE="$(wb_os_image "${WB_OS}")"; export WB_TEST_IMAGE
+	# Force the container's platform when this machine's architecture has no
+	# Workbench package for the chosen OS -- openSUSE 15 is x86_64-only, so on
+	# Apple Silicon the only way to run it at all is an emulated amd64 container.
+	# Empty for every supported pair, which Compose drops so multi-arch
+	# resolution still applies.
+	#
+	# Re-detecting the arch from the forced platform is the point of doing this
+	# here rather than in the compose file: ARCH_SUFFIX drives the in-container
+	# Positron download and the Workbench URL resolution, and both must follow
+	# the container, not the host. Leaving it at arm64 would download an arm64
+	# Positron tarball into an amd64 container -- an install that "succeeds" and
+	# then serves nothing.
+	WB_TEST_PLATFORM="$(wb_os_platform "${WB_OS}" "${WB_ARCH}")"; export WB_TEST_PLATFORM
+	if [ -n "${WB_TEST_PLATFORM}" ]; then
+		echo "Note: no ${WB_ARCH} Workbench package exists for ${WB_OS}, so the test container"
+		echo "      runs emulated ${WB_TEST_PLATFORM}. Everything works; expect it to be slow."
+		wb_detect_arch "${WB_TEST_PLATFORM#linux/}"
+		export ARCH_SUFFIX="${WB_ARCH}"
+	fi
 	# Sources .env first (may set GITHUB_TOKEN), then fills auth gaps from gh and
 	# logs into ghcr.io -- must run before the image pull below.
 	wb_ensure_auth
@@ -717,10 +740,12 @@ USAGE
                              Already installed: (re)start the stack and show status.
                              Auto-stops after 60 min; resets each time you run it.
   npm run pwb -- --reinstall  Re-run the version pickers and reinstall (switch versions).
-  npm run pwb -- --os=<os>    Host OS for the test container: ubuntu24 (default) or
-                             rocky9. Switching recreates the container, so it always
-                             reinstalls. WB_OS in .env does the same. Once a stack
-                             exists, a bare 'npm run pwb' stays on its OS.
+  npm run pwb -- --os=<os>    Host OS for the test container: ubuntu24 (default),
+                             rocky9 or opensuse15. Switching recreates the container,
+                             so it always reinstalls. WB_OS in .env does the same. Once
+                             a stack exists, a bare 'npm run pwb' stays on its OS.
+                             opensuse15 is x86_64-only upstream, so on Apple Silicon it
+                             runs as an emulated amd64 container (slow, but correct).
   npm run pwb -- --credentials=<type>
                              Install with a managed data source: databricks, snowflake,
                              or azure (set the provider's vars in .env first).
@@ -735,7 +760,7 @@ USAGE
 VERSION PICKERS
   Positron:  Release / Daily channel, then choose a version.
   Workbench: Release / Daily (current build each), or a Custom URL to pin a
-             specific n-1/n-2 build (.deb on ubuntu24, .rpm on rocky9).
+             specific n-1/n-2 build (.deb on ubuntu24, .rpm on rocky9/opensuse15).
 
 NON-INTERACTIVE (no TTY: agents, CI, piped runs)
   Skip both pickers by naming the builds up front:

--- a/docker/environments/wb-local/workbench-local.sh
+++ b/docker/environments/wb-local/workbench-local.sh
@@ -189,28 +189,40 @@ wb_ensure_workbench() {
 		for _ in $(seq 1 15); do pgrep -x rserver >/dev/null 2>&1 || exit 0; sleep 1; done
 		sudo pkill -KILL -x rserver 2>/dev/null || true
 	' >/dev/null 2>&1 || true
-	local i
-	# Branch on the family, exactly as install-workbench.sh does. These two must
-	# agree: the installer's first start and this restart-after-container-stop
+	local i family
+	family="$(wb_os_family "${WB_OS}")"
+	# Branch exactly as install-workbench.sh's start_workbench does. These two
+	# must agree: the installer's first start and this restart-after-container-stop
 	# path have to bring the launcher up the same way, or a stack that installed
-	# fine comes back broken after `npm run pwb -- stop && npm run pwb`.
-	if [ "$(wb_os_family "${WB_OS}")" != "debian" ]; then
-		# The rpm's rstudio-launcher init script is broken on EL9 (see
-		# install-workbench.sh), so start the binary directly and wait for its
-		# socket -- rserver shuts itself down if the socket is missing.
-		# Reuse $launcher from above rather than re-checking here. This command
-		# string necessarily contains the launcher's real path (to start it), and
-		# a pgrep in the SAME string would match this very wrapper shell -- the
-		# bracket trick only hides the pattern's own text, not a second, literal
-		# copy of the path beside it. That mistake silently skipped the start and
-		# left the stale socket in place, which the wait below then accepted.
-		# Removing the socket first is what makes that wait mean something.
+	# fine comes back broken after `npm run pwb -- stop && npm run pwb`. They
+	# diverged once (this side used the init script on SUSE while the installer
+	# hand-detached the binary), and it cost a CI run to notice.
+	if [ "$family" != "debian" ]; then
+		# EL9's packaged rstudio-launcher script is broken (see
+		# install-workbench.sh), so there the binary is started directly. SUSE's
+		# works, so use it. Either way wait for the socket, not the process --
+		# rserver shuts itself down if the socket is missing.
+		#
+		# Reuse $launcher from above rather than re-checking here. The direct-start
+		# command string necessarily contains the launcher's real path, and a pgrep
+		# in the SAME string would match this very wrapper shell -- the bracket
+		# trick only hides the pattern's own text, not a second, literal copy of
+		# the path beside it. That mistake silently skipped the start and left the
+		# stale socket in place, which the wait below then accepted. Removing the
+		# socket first is what makes that wait mean something.
 		if [ "$launcher" != 1 ]; then
-			docker exec test bash -c "
-				sudo rm -f ${WB_LAUNCHER_SOCKET}
-				sudo nohup setsid /usr/lib/rstudio-server/bin/rstudio-launcher \
-					>/var/log/rstudio-launcher.stdout.log 2>&1 &
-			" >/dev/null 2>&1 || true
+			if [ "$family" = "suse" ]; then
+				docker exec test bash -c "
+					sudo rm -f ${WB_LAUNCHER_SOCKET}
+					sudo /etc/init.d/rstudio-launcher start
+				" >/dev/null 2>&1 || true
+			else
+				docker exec test bash -c "
+					sudo rm -f ${WB_LAUNCHER_SOCKET}
+					sudo nohup setsid /usr/lib/rstudio-server/bin/rstudio-launcher \
+						>/var/log/rstudio-launcher.stdout.log 2>&1 &
+				" >/dev/null 2>&1 || true
+			fi
 		fi
 		for i in $(seq 1 30); do
 			docker exec test bash -c "test -S ${WB_LAUNCHER_SOCKET}" >/dev/null 2>&1 && break

--- a/docker/images/README.md
+++ b/docker/images/README.md
@@ -20,6 +20,14 @@ This repository contains Docker images used for Positron continuous integration 
     local loop (Posit publishes no arm64 Workbench package for RHEL 8)
   - See the [Rocky 9 README](rocky_9/README.md) for detailed information
 
+- `openSUSE15_6/` - Docker configurations for openSUSE Leap 15.6 environments
+  - Supports both AMD64 and ARM64 architectures
+  - Used by both the Chromium e2e SUSE lane and the Workbench e2e SUSE lane
+  - Unlike the Rocky lane, the Workbench lane here has **no native arm64 local
+    loop**: Posit publishes the openSUSE Workbench package for x86_64 only, so
+    `npm run pwb -- --os=opensuse15` forces an emulated amd64 container on Apple
+    Silicon. CI runners are amd64 and run it natively
+
 ## Purpose
 
 These Docker images provide consistent testing environments for Positron across different architectures. They include:

--- a/extensions/positron-data-driver-odbc/src/odbcinst.ts
+++ b/extensions/positron-data-driver-odbc/src/odbcinst.ts
@@ -169,10 +169,17 @@ function isReservedSection(name: string): boolean {
 /**
  * Candidate directories for the machine-wide ini files when `ODBCSYSINI` is unset. unixODBC bakes
  * its SYSCONFDIR in at compile time, so the right directory depends on how it was installed:
- * `/etc` for a distribution package (and for the Workbench `rstudio-drivers` install), and the
- * Homebrew prefixes on macOS. All of them are checked, nearest-first, rather than guessing one.
+ * `/etc` for a Debian/Ubuntu or RHEL-family package (and for the Workbench `rstudio-drivers`
+ * install), `/etc/unixODBC` for the SUSE-family one, and the Homebrew prefixes on macOS. All of
+ * them are checked, nearest-first, rather than guessing one.
+ *
+ * `/etc/unixODBC` is not hypothetical: openSUSE Leap 15.6 ships unixODBC built that way, so
+ * `odbcinst -j` there reports `/etc/unixODBC/odbc.ini` as the system data sources file. Without it
+ * in this list, a DSN an admin defined in the place their platform actually reads is invisible to
+ * the pane -- and, worse, a stray `/etc/odbc.ini` is offered instead even though the driver manager
+ * will never resolve it, producing a connection that appears and then cannot open.
  */
-const SYSTEM_CONFIG_DIRS = ['/etc', '/usr/local/etc', '/opt/homebrew/etc'];
+const SYSTEM_CONFIG_DIRS = ['/etc', '/etc/unixODBC', '/usr/local/etc', '/opt/homebrew/etc'];
 
 /**
  * Resolves the ini files to read on a unix-like platform, in the order their entries should be

--- a/extensions/positron-data-driver-odbc/src/test/odbcinst.test.ts
+++ b/extensions/positron-data-driver-odbc/src/test/odbcinst.test.ts
@@ -88,8 +88,10 @@ suite('resolveUnixConfigPaths', () => {
 		const paths = resolveUnixConfigPaths(createTestHost({ home: '/home/brian' }));
 
 		assert.deepStrictEqual(paths, {
-			systemDrivers: ['/etc/odbcinst.ini', '/usr/local/etc/odbcinst.ini', '/opt/homebrew/etc/odbcinst.ini'],
-			systemDsns: ['/etc/odbc.ini', '/usr/local/etc/odbc.ini', '/opt/homebrew/etc/odbc.ini'],
+			// /etc/unixODBC is the SUSE-family SYSCONFDIR; openSUSE Leap ships unixODBC built
+			// that way, so omitting it hides every system DSN on that platform.
+			systemDrivers: ['/etc/odbcinst.ini', '/etc/unixODBC/odbcinst.ini', '/usr/local/etc/odbcinst.ini', '/opt/homebrew/etc/odbcinst.ini'],
+			systemDsns: ['/etc/odbc.ini', '/etc/unixODBC/odbc.ini', '/usr/local/etc/odbc.ini', '/opt/homebrew/etc/odbc.ini'],
 			userDrivers: ['/home/brian/.odbcinst.ini'],
 			userDsns: ['/home/brian/.odbc.ini'],
 		});

--- a/scripts/lib/pr-tags-lib.sh
+++ b/scripts/lib/pr-tags-lib.sh
@@ -241,6 +241,33 @@ union_csv_tags() {
 		| awk 'NF && !seen[$0]++' | paste -sd, -
 }
 
+# collapse_workbench_all_tags <csv>
+# @:workbench-all is a shorthand for "run every Workbench OS lane", so when it is
+# present the three lane selectors it stands for -- @:workbench (Ubuntu),
+# @:workbench-rocky and @:workbench-suse -- are redundant. Echoes <csv> with
+# those removed, order-stable; echoes <csv> unchanged when @:workbench-all is
+# absent.
+#
+# This is presentation, not selection: pr-tags-parse.sh sets the three lane flags
+# from @:workbench-all directly, so removing the tags here cannot stop a lane from
+# running. The point is that the PR comment lists what will run without also
+# listing three tags that say the same thing again.
+#
+# Deliberately does NOT touch @:workbench-stable (a different axis -- the last
+# stable Workbench release, still on Ubuntu, not an OS lane) or the
+# @:workbench-{snowflake,databricks,azure} credential tags (test tags consumed by
+# the Ubuntu lane's shard matrix, not lane selectors).
+collapse_workbench_all_tags() {
+	local csv="$1"
+	case ",${csv}," in
+		*",@:workbench-all,"*) ;;
+		*) printf '%s' "$csv"; return 0 ;;
+	esac
+	printf '%s\n' "${csv//,/$'\n'}" \
+		| awk 'NF && $0 != "@:workbench" && $0 != "@:workbench-rocky" && $0 != "@:workbench-suse"' \
+		| paste -sd, -
+}
+
 # positron_dir_of <path>
 # THE single source of truth for "which mappable Positron dir does a path belong
 # to". Echoes the path truncated to its FIRST positron* segment with a trailing

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -104,6 +104,21 @@ if echo "$PR_BODY" | grep -q "@:workbench-suse"; then
 	echo "Found workbench-suse tag in PR body. Setting to run workbench tests on openSUSE."
 	echo "workbench_suse_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
+# One tag for full platform coverage. Sets the three OS lane flags directly
+# rather than being a fourth flag the workflows have to know about, so every
+# existing `if:` keeps working and there is one less place for the lane list to
+# go stale.
+#
+# Note the bare-@:workbench matcher above does NOT fire on "@:workbench-all"
+# (the boundary class excludes '-'), which is why the Ubuntu flag is set here
+# explicitly. Deliberately not workbench_stable: that lane is a different axis
+# (the last stable Workbench release, still Ubuntu), not an OS.
+if echo "$PR_BODY" | grep -q "@:workbench-all"; then
+	echo "Found workbench-all tag in PR body. Setting to run workbench tests on Ubuntu, Rocky Linux and openSUSE."
+	echo "workbench_tag_found=true" >> "$GITHUB_OUTPUT"
+	echo "workbench_rocky_tag_found=true" >> "$GITHUB_OUTPUT"
+	echo "workbench_suse_tag_found=true" >> "$GITHUB_OUTPUT"
+fi
 if echo "$PR_BODY" | grep -q "@:jupyter"; then
 	echo "Found jupyter tag in PR body. Setting to run jupyter tests."
 	echo "jupyter_tag_found=true" >> "$GITHUB_OUTPUT"
@@ -139,6 +154,14 @@ else
 	# @:no-auto-tags is an opt-out signal (detected separately below), not a real
 	# tag -- strip it so it never pollutes the grep string or the log line.
 	TAGS=$(printf '%s' "$TAGS" | tr ',' '\n' | grep -v '^@:no-auto-tags$' | paste -sd, -)
+
+	# Drop the per-OS lane tags @:workbench-all already stands for, so the PR
+	# comment reports "@:workbench-all" once instead of it plus the three tags
+	# that mean the same thing. Runs before the AUTHOR_TAGS snapshot below, so the
+	# superseded tags are gone from the comment entirely rather than showing up
+	# attributed to the PR description. Lane selection is unaffected -- the flags
+	# above are already set.
+	TAGS="$(collapse_workbench_all_tags "$TAGS")"
 
 	# Validate author-typed tags against the real TestTags enum. A typo (e.g.
 	# @:consle) would otherwise silently become a dead --grep alternative that

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -113,7 +113,13 @@ fi
 # (the boundary class excludes '-'), which is why the Ubuntu flag is set here
 # explicitly. Deliberately not workbench_stable: that lane is a different axis
 # (the last stable Workbench release, still Ubuntu), not an OS.
-if echo "$PR_BODY" | grep -q "@:workbench-all"; then
+#
+# Boundary-matched, unlike the per-OS tags above, because "all" is a live prefix:
+# a plain substring match fires on "@:workbench-allowlist" or
+# "@:workbench-all-the-things" and starts three lanes. The enum validation later
+# would drop such a tag from the comment as a typo, but these flags are set
+# before it runs, so the lanes would go anyway.
+if echo "$PR_BODY" | grep -qE "@:workbench-all([^a-zA-Z0-9_-]|\$)"; then
 	echo "Found workbench-all tag in PR body. Setting to run workbench tests on Ubuntu, Rocky Linux and openSUSE."
 	echo "workbench_tag_found=true" >> "$GITHUB_OUTPUT"
 	echo "workbench_rocky_tag_found=true" >> "$GITHUB_OUTPUT"

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -100,6 +100,10 @@ if echo "$PR_BODY" | grep -q "@:workbench-rocky"; then
 	echo "Found workbench-rocky tag in PR body. Setting to run workbench tests on Rocky Linux."
 	echo "workbench_rocky_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
+if echo "$PR_BODY" | grep -q "@:workbench-suse"; then
+	echo "Found workbench-suse tag in PR body. Setting to run workbench tests on openSUSE."
+	echo "workbench_suse_tag_found=true" >> "$GITHUB_OUTPUT"
+fi
 if echo "$PR_BODY" | grep -q "@:jupyter"; then
 	echo "Found jupyter tag in PR body. Setting to run jupyter tests."
 	echo "jupyter_tag_found=true" >> "$GITHUB_OUTPUT"

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -347,6 +347,54 @@ assert_eq "union with empty b" "@:critical" "$(union_csv_tags "@:critical" "")"
 assert_eq "union collapses internal dup" "@:critical,@:ark,@:debug" \
 	"$(union_csv_tags "@:critical,@:ark,@:debug,@:ark" "")"
 
+# --- collapse_workbench_all_tags ---
+# @:workbench-all triggers the three OS lanes on its own (pr-tags-parse.sh sets
+# the flags), so listing them alongside it in the PR comment says the same thing
+# four times. These pin WHICH tags it absorbs -- the interesting part is what it
+# leaves alone.
+assert_eq "collapse absorbs the per-OS lane tags" "@:critical,@:workbench-all" \
+	"$(collapse_workbench_all_tags "@:critical,@:workbench,@:workbench-all,@:workbench-rocky,@:workbench-suse")"
+assert_eq "collapse keeps order and unrelated tags" "@:workbench-all,@:console" \
+	"$(collapse_workbench_all_tags "@:workbench-all,@:workbench-rocky,@:console")"
+# A different axis (Workbench version, still Ubuntu), so @:workbench-all does not
+# imply it and must not hide it -- doing so would silently drop a lane the author
+# asked for from the comment.
+assert_eq "collapse keeps @:workbench-stable" "@:workbench-all,@:workbench-stable" \
+	"$(collapse_workbench_all_tags "@:workbench-all,@:workbench,@:workbench-stable")"
+# Credential tags are real test tags consumed by the Ubuntu lane's shard matrix,
+# not lane selectors, so they are not @:workbench-all's to absorb either.
+assert_eq "collapse keeps the credential tags" "@:workbench-all,@:workbench-snowflake,@:workbench-azure" \
+	"$(collapse_workbench_all_tags "@:workbench-all,@:workbench-snowflake,@:workbench-azure")"
+# No-op unless @:workbench-all is actually present: the three OS tags on their
+# own each select exactly one lane and all belong in the comment.
+assert_eq "collapse is a no-op without @:workbench-all" "@:critical,@:workbench,@:workbench-rocky" \
+	"$(collapse_workbench_all_tags "@:critical,@:workbench,@:workbench-rocky")"
+# Substring safety: the check is on whole comma-delimited fields, so neither of
+# these contains the tag.
+assert_eq "collapse ignores a lookalike tag" "@:workbench,@:workbench-allowlist" \
+	"$(collapse_workbench_all_tags "@:workbench,@:workbench-allowlist")"
+assert_eq "collapse of an empty list is empty" "" "$(collapse_workbench_all_tags "")"
+# @:workbench-all alone must survive its own collapse.
+assert_eq "collapse leaves @:workbench-all itself" "@:workbench-all" \
+	"$(collapse_workbench_all_tags "@:workbench-all")"
+
+# @:workbench-all has to be a real enum tag, or pr-tags-parse.sh's validation
+# drops it as a typo and the comment never mentions it. It also has to sit
+# OUTSIDE FeatureTags: a lane selector in that block would become eligible for
+# auto test-change derivation, which is how you end up spending three OS lanes on
+# an unrelated PR.
+REAL_ENUM_WBALL="$HERE/../../test/e2e/infra/test-runner/test-tags.ts"
+if printf '%s\n' "$(valid_enum_tags "$REAL_ENUM_WBALL")" | grep -qxF "@:workbench-all"; then
+	echo "PASS: real TestTags includes @:workbench-all"
+else
+	echo "FAIL: real TestTags should include @:workbench-all"; fail=1
+fi
+if printf '%s\n' "$(feature_enum_tags "$REAL_ENUM_WBALL")" | grep -qxF "@:workbench-all"; then
+	echo "FAIL: @:workbench-all must not be in FeatureTags (it is a lane selector)"; fail=1
+else
+	echo "PASS: real FeatureTags excludes @:workbench-all"
+fi
+
 # --- valid_enum_tags / split_valid_invalid_tags ---
 ENUM="$(mktemp)"
 cat > "$ENUM" <<'TS'

--- a/scripts/test/pr-tags-lib-test.sh
+++ b/scripts/test/pr-tags-lib-test.sh
@@ -31,19 +31,19 @@ assert_eq() {
 MAP="$(mktemp)"
 cat > "$MAP" <<'JSON'
 {
-  "src/vs/workbench/contrib/positronConsole/": ["@:console"],
-  "extensions/positron-assistant/": ["@:assistant"],
-  "extensions/positron-supervisor/": ["@:sessions", "@:console", "@:interpreter"],
-  "extensions/positron-python/": ["@:interpreter", "@:console", "@:packages-pane"],
-  "extensions/positron-python/src/client/positron/packages/": ["@:packages-pane"],
-  "extensions/positron-python/python_files/posit/positron/": ["@:console", "@:interpreter"],
-  "extensions/positron-python/python_files/posit/positron/matplotlib_backend": ["@:plots"],
-  "extensions/positron-python/python_files/posit/positron/data_explorer": ["@:data-explorer"],
-  "extensions/positron-python/python_files/posit/positron/variables": ["@:variables"],
-  "extensions/positron-python/python_files/posit/positron/_vendor/": [],
-  "src/vs/workbench/contrib/positronTelemetry/": [],
-  "src/vs/workbench/contrib/upstreamThing/": [],
-  "src/vs/workbench/contrib/upstreamThing/browser/positronBit.ts": ["@:welcome"]
+	"src/vs/workbench/contrib/positronConsole/": ["@:console"],
+	"extensions/positron-assistant/": ["@:assistant"],
+	"extensions/positron-supervisor/": ["@:sessions", "@:console", "@:interpreter"],
+	"extensions/positron-python/": ["@:interpreter", "@:console", "@:packages-pane"],
+	"extensions/positron-python/src/client/positron/packages/": ["@:packages-pane"],
+	"extensions/positron-python/python_files/posit/positron/": ["@:console", "@:interpreter"],
+	"extensions/positron-python/python_files/posit/positron/matplotlib_backend": ["@:plots"],
+	"extensions/positron-python/python_files/posit/positron/data_explorer": ["@:data-explorer"],
+	"extensions/positron-python/python_files/posit/positron/variables": ["@:variables"],
+	"extensions/positron-python/python_files/posit/positron/_vendor/": [],
+	"src/vs/workbench/contrib/positronTelemetry/": [],
+	"src/vs/workbench/contrib/upstreamThing/": [],
+	"src/vs/workbench/contrib/upstreamThing/browser/positronBit.ts": ["@:welcome"]
 }
 JSON
 
@@ -448,8 +448,8 @@ fi
 STALE_MAP="$(mktemp)"
 cat > "$STALE_MAP" <<'JSON'
 {
-  "scripts/lib/pr-tags-lib.sh": [],
-  "definitely/not/a/real/path/": []
+	"scripts/lib/pr-tags-lib.sh": [],
+	"definitely/not/a/real/path/": []
 }
 JSON
 if MAP_FILE="$STALE_MAP" bash "$HERE/../check-test-tag-map.sh" --tags-only >/dev/null 2>&1; then
@@ -476,8 +476,8 @@ fi
 JSON_MAP="$(mktemp)"
 cat > "$JSON_MAP" <<'JSON'
 {
-  "scripts/lib/pr-tags-lib.sh": [],
-  "definitely/not/a/real/path/": ["@:not-a-real-tag"]
+	"scripts/lib/pr-tags-lib.sh": [],
+	"definitely/not/a/real/path/": ["@:not-a-real-tag"]
 }
 JSON
 JSON_OUTPUT="$(MAP_FILE="$JSON_MAP" bash "$HERE/../check-test-tag-map.sh" --json 2>&1)"
@@ -596,9 +596,9 @@ assert_eq "dir_of: positron file inside positron dir -> the dir" "src/vs/workben
 MAP2="$(mktemp)"
 cat > "$MAP2" <<'JSON'
 {
-  "src/vs/workbench/contrib/positronConsole/": ["@:console"],
-  "src/vs/workbench/contrib/positronTelemetry/": [],
-  "src/vs/workbench/services/positronConsole/": ["@:console"]
+	"src/vs/workbench/contrib/positronConsole/": ["@:console"],
+	"src/vs/workbench/contrib/positronTelemetry/": [],
+	"src/vs/workbench/services/positronConsole/": ["@:console"]
 }
 JSON
 # A mapped dir (incl. a [] entry) is NOT flagged; an unmapped positron dir IS.
@@ -648,14 +648,14 @@ assert_eq "owner_root_dir_of: non-src/extensions -> empty" "" \
 POSIT_FILE="$(mktemp)"
 cat > "$POSIT_FILE" <<'HDR'
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
- *--------------------------------------------------------------------------------------------*/
+	*  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+	*--------------------------------------------------------------------------------------------*/
 HDR
 MSFT_FILE="$(mktemp)"
 cat > "$MSFT_FILE" <<'HDR'
 /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------------------------------------------*/
+	*  Copyright (c) Microsoft Corporation. All rights reserved.
+	*--------------------------------------------------------------------------------------------*/
 HDR
 assert_eq "is_posit_owned_file: Posit header" "true" "$(is_posit_owned_file "$POSIT_FILE")"
 assert_eq "is_posit_owned_file: Microsoft header" "false" "$(is_posit_owned_file "$MSFT_FILE")"
@@ -692,13 +692,13 @@ FALLBACK_ROOT="$(mktemp -d)"
 mkdir -p "$FALLBACK_ROOT/src/vs/workbench/contrib/legacyRuntime" "$FALLBACK_ROOT/src/vs/workbench/contrib/upstreamThing"
 cat > "$FALLBACK_ROOT/src/vs/workbench/contrib/legacyRuntime/x.ts" <<'HDR'
 /*
- *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
- */
+	*  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+	*/
 HDR
 cat > "$FALLBACK_ROOT/src/vs/workbench/contrib/upstreamThing/y.ts" <<'HDR'
 /*
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- */
+	*  Copyright (c) Microsoft Corporation. All rights reserved.
+	*/
 HDR
 EMPTY_MAP="$(mktemp)"
 echo '{}' > "$EMPTY_MAP"
@@ -746,11 +746,11 @@ APPLY_SCRIPT="$HERE/../apply-test-tag-map-fixes.mjs"
 APPLY_DIR="$(mktemp -d)"
 cat > "$APPLY_DIR/map.json" <<'JSON'
 {
-  "src/vs/workbench/contrib/positronConsole/": ["@:console"],
-  "src/vs/workbench/contrib/positronPlots/": ["@:plots"],
+	"src/vs/workbench/contrib/positronConsole/": ["@:console"],
+	"src/vs/workbench/contrib/positronPlots/": ["@:plots"],
 
-  "extensions/positron-gone/": [],
-  "extensions/positron-real/": ["@:reticulate"]
+	"extensions/positron-gone/": [],
+	"extensions/positron-real/": ["@:reticulate"]
 }
 JSON
 echo '["extensions/positron-gone/"]' > "$APPLY_DIR/stale.json"
@@ -798,10 +798,10 @@ fi
 # refuse to write rather than corrupt the map.
 cat > "$APPLY_DIR/bad-map.json" <<'JSON'
 {
-  "src/vs/workbench/contrib/positronConsole/": [
-    "@:console"
-  ],
-  "extensions/positron-real/": ["@:reticulate"]
+	"src/vs/workbench/contrib/positronConsole/": [
+		"@:console"
+	],
+	"extensions/positron-real/": ["@:reticulate"]
 }
 JSON
 cp "$APPLY_DIR/bad-map.json" "$APPLY_DIR/bad-map.orig.json"
@@ -822,10 +822,10 @@ fi
 # while reporting success), the script must fail loudly.
 cat > "$APPLY_DIR/multiline-map.json" <<'JSON'
 {
-  "src/vs/workbench/contrib/positronConsole/": ["@:console"],
-  "extensions/positron-gone/": [
-    "@:reticulate"
-  ]
+	"src/vs/workbench/contrib/positronConsole/": ["@:console"],
+	"extensions/positron-gone/": [
+		"@:reticulate"
+	]
 }
 JSON
 cp "$APPLY_DIR/multiline-map.json" "$APPLY_DIR/multiline-map.orig.json"
@@ -968,84 +968,84 @@ DERIVE_DIR="$(mktemp -d)"
 # real minimization.
 cat > "$DERIVE_DIR/list.json" <<'JSON'
 {
-  "suites": [
-    {
-      "file": "tests/viewer/viewer.test.ts",
-      "suites": [
-        {
-          "file": "tests/viewer/viewer.test.ts",
-          "specs": [
-            { "title": "Python - opens", "tags": [":viewer", ":console"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "R - opens", "tags": [":viewer", ":console", ":web"], "tests": [{ "expectedStatus": "passed" }] }
-          ]
-        }
-      ]
-    },
-    {
-      "file": "tests/plots/plots.test.ts",
-      "suites": [
-        {
-          "file": "tests/plots/plots.test.ts",
-          "specs": [
-            { "title": "Python plot", "tags": [":plots", ":editor"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "R plot", "tags": [":plots", ":editor", ":ark"], "tests": [{ "expectedStatus": "passed" }] }
-          ]
-        }
-      ]
-    },
-    {
-      "file": "tests/console/console-untagged.test.ts",
-      "suites": [
-        {
-          "file": "tests/console/console-untagged.test.ts",
-          "specs": [
-            { "title": "no tags here", "tags": [], "tests": [{ "expectedStatus": "passed" }] }
-          ]
-        }
-      ]
-    },
-    {
-      "file": "tests/console/console-skipped.test.ts",
-      "suites": [
-        {
-          "file": "tests/console/console-skipped.test.ts",
-          "specs": [
-            { "title": "statically skipped", "tags": [":console"], "tests": [{ "expectedStatus": "skipped" }] }
-          ]
-        }
-      ]
-    },
-    {
-      "file": "tests/console/console-other.test.ts",
-      "suites": [
-        {
-          "file": "tests/console/console-other.test.ts",
-          "specs": [
-            { "title": "other console test 0", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "other console test 1", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "other console test 2", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "other console test 3", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "other console test 4", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] }
-          ]
-        }
-      ]
-    },
-    {
-      "file": "tests/editor/editor-other.test.ts",
-      "suites": [
-        {
-          "file": "tests/editor/editor-other.test.ts",
-          "specs": [
-            { "title": "other editor test 0", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "other editor test 1", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "other editor test 2", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "other editor test 3", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "other editor test 4", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] }
-          ]
-        }
-      ]
-    }
-  ]
+	"suites": [
+		{
+			"file": "tests/viewer/viewer.test.ts",
+			"suites": [
+				{
+					"file": "tests/viewer/viewer.test.ts",
+					"specs": [
+						{ "title": "Python - opens", "tags": [":viewer", ":console"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "R - opens", "tags": [":viewer", ":console", ":web"], "tests": [{ "expectedStatus": "passed" }] }
+					]
+				}
+			]
+		},
+		{
+			"file": "tests/plots/plots.test.ts",
+			"suites": [
+				{
+					"file": "tests/plots/plots.test.ts",
+					"specs": [
+						{ "title": "Python plot", "tags": [":plots", ":editor"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "R plot", "tags": [":plots", ":editor", ":ark"], "tests": [{ "expectedStatus": "passed" }] }
+					]
+				}
+			]
+		},
+		{
+			"file": "tests/console/console-untagged.test.ts",
+			"suites": [
+				{
+					"file": "tests/console/console-untagged.test.ts",
+					"specs": [
+						{ "title": "no tags here", "tags": [], "tests": [{ "expectedStatus": "passed" }] }
+					]
+				}
+			]
+		},
+		{
+			"file": "tests/console/console-skipped.test.ts",
+			"suites": [
+				{
+					"file": "tests/console/console-skipped.test.ts",
+					"specs": [
+						{ "title": "statically skipped", "tags": [":console"], "tests": [{ "expectedStatus": "skipped" }] }
+					]
+				}
+			]
+		},
+		{
+			"file": "tests/console/console-other.test.ts",
+			"suites": [
+				{
+					"file": "tests/console/console-other.test.ts",
+					"specs": [
+						{ "title": "other console test 0", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "other console test 1", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "other console test 2", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "other console test 3", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "other console test 4", "tags": [":console"], "tests": [{ "expectedStatus": "passed" }] }
+					]
+				}
+			]
+		},
+		{
+			"file": "tests/editor/editor-other.test.ts",
+			"suites": [
+				{
+					"file": "tests/editor/editor-other.test.ts",
+					"specs": [
+						{ "title": "other editor test 0", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "other editor test 1", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "other editor test 2", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "other editor test 3", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "other editor test 4", "tags": [":editor"], "tests": [{ "expectedStatus": "passed" }] }
+					]
+				}
+			]
+		}
+	]
 }
 JSON
 
@@ -1070,24 +1070,24 @@ assert_eq "two touched files, no shared tag: picks one cheap tag per file" "$(pr
 # result must be the single shared tag rather than the two per-file tags.
 cat > "$DERIVE_DIR/shared-list.json" <<'JSON'
 {
-  "suites": [
-    { "file": "tests/aaa/a.test.ts", "suites": [ { "file": "tests/aaa/a.test.ts", "specs": [
-      { "title": "a1", "tags": [":common", ":feat-a"], "tests": [{ "expectedStatus": "passed" }] }
-    ] } ] },
-    { "file": "tests/bbb/b.test.ts", "suites": [ { "file": "tests/bbb/b.test.ts", "specs": [
-      { "title": "b1", "tags": [":common", ":feat-b"], "tests": [{ "expectedStatus": "passed" }] }
-    ] } ] },
-    { "file": "tests/aaa/a-other.test.ts", "suites": [ { "file": "tests/aaa/a-other.test.ts", "specs": [
-      { "title": "ao0", "tags": [":feat-a"], "tests": [{ "expectedStatus": "passed" }] },
-      { "title": "ao1", "tags": [":feat-a"], "tests": [{ "expectedStatus": "passed" }] },
-      { "title": "ao2", "tags": [":feat-a"], "tests": [{ "expectedStatus": "passed" }] }
-    ] } ] },
-    { "file": "tests/bbb/b-other.test.ts", "suites": [ { "file": "tests/bbb/b-other.test.ts", "specs": [
-      { "title": "bo0", "tags": [":feat-b"], "tests": [{ "expectedStatus": "passed" }] },
-      { "title": "bo1", "tags": [":feat-b"], "tests": [{ "expectedStatus": "passed" }] },
-      { "title": "bo2", "tags": [":feat-b"], "tests": [{ "expectedStatus": "passed" }] }
-    ] } ] }
-  ]
+	"suites": [
+		{ "file": "tests/aaa/a.test.ts", "suites": [ { "file": "tests/aaa/a.test.ts", "specs": [
+			{ "title": "a1", "tags": [":common", ":feat-a"], "tests": [{ "expectedStatus": "passed" }] }
+		] } ] },
+		{ "file": "tests/bbb/b.test.ts", "suites": [ { "file": "tests/bbb/b.test.ts", "specs": [
+			{ "title": "b1", "tags": [":common", ":feat-b"], "tests": [{ "expectedStatus": "passed" }] }
+		] } ] },
+		{ "file": "tests/aaa/a-other.test.ts", "suites": [ { "file": "tests/aaa/a-other.test.ts", "specs": [
+			{ "title": "ao0", "tags": [":feat-a"], "tests": [{ "expectedStatus": "passed" }] },
+			{ "title": "ao1", "tags": [":feat-a"], "tests": [{ "expectedStatus": "passed" }] },
+			{ "title": "ao2", "tags": [":feat-a"], "tests": [{ "expectedStatus": "passed" }] }
+		] } ] },
+		{ "file": "tests/bbb/b-other.test.ts", "suites": [ { "file": "tests/bbb/b-other.test.ts", "specs": [
+			{ "title": "bo0", "tags": [":feat-b"], "tests": [{ "expectedStatus": "passed" }] },
+			{ "title": "bo1", "tags": [":feat-b"], "tests": [{ "expectedStatus": "passed" }] },
+			{ "title": "bo2", "tags": [":feat-b"], "tests": [{ "expectedStatus": "passed" }] }
+		] } ] }
+	]
 }
 JSON
 printf '%s\n%s\n' "test/e2e/tests/aaa/a.test.ts" "test/e2e/tests/bbb/b.test.ts" > "$DERIVE_DIR/changed-shared.txt"
@@ -1130,45 +1130,45 @@ fi
 # widens the run without enabling its own lane.
 cat > "$DERIVE_DIR/plat-list.json" <<'JSON'
 {
-  "suites": [
-    {
-      "file": "tests/plat/plat.test.ts",
-      "suites": [
-        {
-          "file": "tests/plat/plat.test.ts",
-          "specs": [
-            { "title": "cross-browser search thing", "tags": [":cross-browser", ":search"], "tests": [{ "expectedStatus": "passed" }] }
-          ]
-        }
-      ]
-    },
-    {
-      "file": "tests/search/search-other.test.ts",
-      "suites": [
-        {
-          "file": "tests/search/search-other.test.ts",
-          "specs": [
-            { "title": "s0", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "s1", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "s2", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "s3", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] },
-            { "title": "s4", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] }
-          ]
-        }
-      ]
-    },
-    {
-      "file": "tests/webonly/webonly.test.ts",
-      "suites": [
-        {
-          "file": "tests/webonly/webonly.test.ts",
-          "specs": [
-            { "title": "web only", "tags": [":web"], "tests": [{ "expectedStatus": "passed" }] }
-          ]
-        }
-      ]
-    }
-  ]
+	"suites": [
+		{
+			"file": "tests/plat/plat.test.ts",
+			"suites": [
+				{
+					"file": "tests/plat/plat.test.ts",
+					"specs": [
+						{ "title": "cross-browser search thing", "tags": [":cross-browser", ":search"], "tests": [{ "expectedStatus": "passed" }] }
+					]
+				}
+			]
+		},
+		{
+			"file": "tests/search/search-other.test.ts",
+			"suites": [
+				{
+					"file": "tests/search/search-other.test.ts",
+					"specs": [
+						{ "title": "s0", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "s1", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "s2", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "s3", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] },
+						{ "title": "s4", "tags": [":search"], "tests": [{ "expectedStatus": "passed" }] }
+					]
+				}
+			]
+		},
+		{
+			"file": "tests/webonly/webonly.test.ts",
+			"suites": [
+				{
+					"file": "tests/webonly/webonly.test.ts",
+					"specs": [
+						{ "title": "web only", "tags": [":web"], "tests": [{ "expectedStatus": "passed" }] }
+					]
+				}
+			]
+		}
+	]
 }
 JSON
 

--- a/scripts/test/workbench-local-lib-test.sh
+++ b/scripts/test/workbench-local-lib-test.sh
@@ -36,10 +36,16 @@ assert_fails() {
 
 # --- Fixtures -----------------------------------------------------------------
 # Trimmed to the keys the lib reads, but the values are verbatim from the live
-# feeds (captured 2026-08-09) -- the arch tokens are the whole point of these
-# tests, so they must not be idealized. Note the two feeds disagree about how to
-# spell arm64 for rhel9: the platform *key* says arm64, the *filename* says
-# aarch64. Several assertions below exist only to pin that asymmetry.
+# feeds (rhel9/noble captured 2026-08-09, opensuse15 2026-09-02) -- the arch
+# tokens are the whole point of these tests, so they must not be idealized. Note
+# the two feeds disagree about how to spell arm64 for rhel9: the platform *key*
+# says arm64, the *filename* says aarch64. Several assertions below exist only to
+# pin that asymmetry.
+#
+# There is deliberately no "opensuse15-arm64" key and no arm64 rpm in the stable
+# fixture: the live feeds publish neither, which is why wb_os_arches lists
+# opensuse15 as amd64-only. Adding a fake arm64 key here would make the tests
+# pass on a URL that 404s in reality.
 
 _wb_fetch_downloads_json() {
 	cat <<'JSON'
@@ -47,7 +53,8 @@ _wb_fetch_downloads_json() {
 	"rstudio": { "pro": { "stable": { "server": { "installer": {
 		"noble": { "url": "https://download2.rstudio.org/server/jammy/amd64/rstudio-workbench-2026.07.1-147.pro6-amd64.deb" },
 		"rhel9": { "url": "https://download2.rstudio.org/server/rocky9/x86_64/rstudio-workbench-rhel-2026.07.1-147.pro6-x86_64.rpm" },
-		"rhel8": { "url": "https://download2.rstudio.org/server/rhel8/x86_64/rstudio-workbench-rhel-2026.07.1-147.pro6-x86_64.rpm" }
+		"rhel8": { "url": "https://download2.rstudio.org/server/rhel8/x86_64/rstudio-workbench-rhel-2026.07.1-147.pro6-x86_64.rpm" },
+		"opensuse15": { "url": "https://download2.rstudio.org/server/opensuse15/x86_64/rstudio-workbench-2026.08.2-200.pro1-x86_64.rpm" }
 	} } } } }
 }
 JSON
@@ -61,7 +68,8 @@ _wb_fetch_dailies_json() {
 		"noble-arm64":  { "link": "https://dl.dailies.rstudio.com/server/jammy/arm64/rstudio-workbench-2026.08.0-187.pro5-arm64.deb" },
 		"rhel9-x86_64": { "link": "https://dl.dailies.rstudio.com/server/rocky9/x86_64/rstudio-workbench-rhel-2026.08.0-187.pro5-x86_64.rpm" },
 		"rhel9-arm64":  { "link": "https://dl.dailies.rstudio.com/server/rocky9/arm64/rstudio-workbench-rhel-2026.08.0-187.pro5-aarch64.rpm" },
-		"rhel8-x86_64": { "link": "https://dl.dailies.rstudio.com/server/rhel8/x86_64/rstudio-workbench-rhel-2026.08.0-187.pro5-x86_64.rpm" }
+		"rhel8-x86_64": { "link": "https://dl.dailies.rstudio.com/server/rhel8/x86_64/rstudio-workbench-rhel-2026.08.0-187.pro5-x86_64.rpm" },
+		"opensuse15-x86_64": { "link": "https://dl.dailies.rstudio.com/server/opensuse15/x86_64/rstudio-workbench-2026.09.0-166.pro8-x86_64.rpm" }
 	} } }
 }
 JSON
@@ -82,6 +90,7 @@ assert_fails "detect_arch rejects an unknown machine type" wb_detect_arch ppc64l
 
 assert_ok    "os_valid accepts ubuntu24" wb_os_valid ubuntu24
 assert_ok    "os_valid accepts rocky9" wb_os_valid rocky9
+assert_ok    "os_valid accepts opensuse15" wb_os_valid opensuse15
 # The feed names are NOT accepted as input -- one vocabulary, checked at the door.
 assert_fails "os_valid rejects the feed name noble" wb_os_valid noble
 assert_fails "os_valid rejects the feed name rhel9" wb_os_valid rhel9
@@ -91,15 +100,51 @@ assert_fails "os_valid rejects an empty OS"         wb_os_valid ""
 # the contract that keeps "rhel9"/"noble" out of the rest of the codebase.
 assert_eq "feed name ubuntu24 -> noble" "noble" "$(wb_os_feed ubuntu24)"
 assert_eq "feed name rocky9 -> rhel9"   "rhel9" "$(wb_os_feed rocky9)"
+# opensuse15 is the one OS whose token and feed name coincide. Asserted so the
+# coincidence is a checked fact rather than a reason to skip wb_os_feed.
+assert_eq "feed name opensuse15 -> opensuse15" "opensuse15" "$(wb_os_feed opensuse15)"
 assert_fails "feed name rejects a feed name fed back in" wb_os_feed noble
 assert_eq "image ubuntu24" "ghcr.io/posit-dev/positron-ubuntu24:24.18.0" "$(wb_os_image ubuntu24)"
 assert_eq "image rocky9"   "ghcr.io/posit-dev/positron-rocky9:24.18.0"   "$(wb_os_image rocky9)"
+assert_eq "image opensuse15" "ghcr.io/posit-dev/positron-opensuse156:24.18.0" "$(wb_os_image opensuse15)"
 assert_fails "image rejects an unknown OS" wb_os_image plan9
 
 assert_eq "pkg_ext ubuntu24"  "deb" "$(wb_os_pkg_ext ubuntu24)"
 assert_eq "pkg_ext rocky9"  "rpm" "$(wb_os_pkg_ext rocky9)"
+assert_eq "pkg_ext opensuse15" "rpm" "$(wb_os_pkg_ext opensuse15)"
 assert_eq "pkg_stem ubuntu24" "rstudio-workbench-"      "$(wb_os_pkg_stem ubuntu24)"
 assert_eq "pkg_stem rocky9" "rstudio-workbench-rhel-" "$(wb_os_pkg_stem rocky9)"
+# Same extension as rocky9, different stem: the openSUSE rpm has no "-rhel"
+# segment. This pair is what wb_pkg_version's two-step strip depends on.
+assert_eq "pkg_stem opensuse15" "rstudio-workbench-" "$(wb_os_pkg_stem opensuse15)"
+
+assert_eq "family ubuntu24"   "debian" "$(wb_os_family ubuntu24)"
+assert_eq "family rocky9"     "redhat" "$(wb_os_family rocky9)"
+assert_eq "family opensuse15" "suse"   "$(wb_os_family opensuse15)"
+assert_fails "family rejects an unknown OS" wb_os_family plan9
+
+# --- wb_os_arches / wb_os_supports_arch / wb_os_platform ----------------------
+# Posit publishes no arm64 Workbench for openSUSE 15 on either channel, so this
+# is a fact about the feeds, not a policy choice. Everything downstream (URL
+# resolution refusing, the local stack forcing an emulated amd64 container)
+# hangs off these three.
+
+assert_eq "arches ubuntu24"   "amd64 arm64" "$(wb_os_arches ubuntu24)"
+assert_eq "arches rocky9"     "amd64 arm64" "$(wb_os_arches rocky9)"
+assert_eq "arches opensuse15" "amd64"       "$(wb_os_arches opensuse15)"
+
+assert_ok    "supports_arch ubuntu24/arm64"   wb_os_supports_arch ubuntu24 arm64
+assert_ok    "supports_arch opensuse15/amd64" wb_os_supports_arch opensuse15 amd64
+assert_fails "supports_arch rejects opensuse15/arm64" wb_os_supports_arch opensuse15 arm64
+assert_fails "supports_arch rejects an unknown arch"  wb_os_supports_arch rocky9 ppc64le
+assert_fails "supports_arch rejects an unknown OS"    wb_os_supports_arch plan9 amd64
+
+# Empty means "let Docker resolve the multi-arch manifest"; non-empty is the
+# emulation escape hatch, and it must fire ONLY for a pair with no package.
+assert_eq "platform ubuntu24/arm64 is unset"     "" "$(wb_os_platform ubuntu24 arm64)"
+assert_eq "platform rocky9/arm64 is unset"       "" "$(wb_os_platform rocky9 arm64)"
+assert_eq "platform opensuse15/amd64 is unset"   "" "$(wb_os_platform opensuse15 amd64)"
+assert_eq "platform opensuse15/arm64 forces amd64" "linux/amd64" "$(wb_os_platform opensuse15 arm64)"
 
 assert_eq "key_arch ubuntu24/amd64"  "amd64"   "$(wb_os_key_arch ubuntu24 amd64)"
 assert_eq "key_arch ubuntu24/arm64"  "arm64"   "$(wb_os_key_arch ubuntu24 arm64)"
@@ -107,6 +152,8 @@ assert_eq "key_arch rocky9/amd64"  "x86_64"  "$(wb_os_key_arch rocky9 amd64)"
 # The feed key says arm64 where the filename says aarch64. Pinned here so
 # "fixing" the key to match the filename fails loudly rather than 404ing.
 assert_eq "key_arch rocky9/arm64 is arm64, not aarch64" "arm64" "$(wb_os_key_arch rocky9 arm64)"
+assert_eq "key_arch opensuse15/amd64" "x86_64" "$(wb_os_key_arch opensuse15 amd64)"
+assert_fails "key_arch has no opensuse15/arm64" wb_os_key_arch opensuse15 arm64
 assert_fails "key_arch rejects an unknown arch" wb_os_key_arch rocky9 ppc64le
 
 # --- wb_pkg_version -----------------------------------------------------------
@@ -123,6 +170,14 @@ assert_eq "pkg_version from an aarch64 .rpm" "2026.07.1-147.pro6" \
 	"$(wb_pkg_version "https://download2.rstudio.org/server/rocky9/arm64/rstudio-workbench-rhel-2026.07.1-147.pro6-aarch64.rpm")"
 assert_eq "pkg_version from a bare filename" "2026.08.0-187.pro5" \
 	"$(wb_pkg_version "rstudio-workbench-rhel-2026.08.0-187.pro5-x86_64.rpm")"
+# The openSUSE rpm shares rocky9's extension but uses ubuntu24's stem, so a
+# version parser that picks its strip by extension alone leaves "rstudio-
+# workbench-" glued to the front. Both directions are asserted because the fix
+# is order-dependent: strip the longer stem first, then the shorter.
+assert_eq "pkg_version from an openSUSE .rpm (plain stem, rpm extension)" "2026.09.0-166.pro8" \
+	"$(wb_pkg_version "https://dl.dailies.rstudio.com/server/opensuse15/x86_64/rstudio-workbench-2026.09.0-166.pro8-x86_64.rpm")"
+assert_eq "pkg_version still strips the rhel stem, not just the plain one" "2026.08.0-187.pro5" \
+	"$(wb_pkg_version "rstudio-workbench-rhel-2026.08.0-187.pro5-aarch64.rpm")"
 # The menu labels render `$(wb_pkg_version "$url" || echo unavailable)`, so the
 # non-zero exit on junk is load-bearing, not cosmetic.
 assert_eq "pkg_version of an empty URL falls back" "unavailable" \
@@ -161,6 +216,16 @@ assert_eq "stable rocky9/amd64 is the published URL verbatim" \
 assert_eq "stable rocky9/arm64 rewrites the path and the filename differently" \
 	"https://download2.rstudio.org/server/rocky9/arm64/rstudio-workbench-rhel-2026.07.1-147.pro6-aarch64.rpm" \
 	"$(wb_resolve_stable_url rocky9 arm64)"
+assert_eq "stable opensuse15/amd64 is the published URL verbatim" \
+	"https://download2.rstudio.org/server/opensuse15/x86_64/rstudio-workbench-2026.08.2-200.pro1-x86_64.rpm" \
+	"$(wb_resolve_stable_url opensuse15 amd64)"
+# The refusal matters more than the success: without it the arm64 rewrite below
+# would fall through its case statement and hand back the x86_64 rpm unchanged,
+# which looks exactly like a successful resolution.
+assert_fails "stable refuses opensuse15/arm64 rather than returning the x86 URL" \
+	wb_resolve_stable_url opensuse15 arm64
+assert_eq "stable prints no URL for opensuse15/arm64" "" \
+	"$(wb_resolve_stable_url opensuse15 arm64 2>/dev/null)"
 assert_fails "stable rejects an unsupported OS" wb_resolve_stable_url plan9 amd64
 
 _wb_orig_downloads="$(declare -f _wb_fetch_downloads_json)"
@@ -207,6 +272,10 @@ assert_eq "daily rocky9/amd64 uses the x86_64 platform key" \
 assert_eq "daily rocky9/arm64 uses the arm64 platform key" \
 	"https://dl.dailies.rstudio.com/server/rocky9/arm64/rstudio-workbench-rhel-2026.08.0-187.pro5-aarch64.rpm" \
 	"$(wb_resolve_daily_url rocky9 arm64)"
+assert_eq "daily opensuse15/amd64 uses the x86_64 platform key" \
+	"https://dl.dailies.rstudio.com/server/opensuse15/x86_64/rstudio-workbench-2026.09.0-166.pro8-x86_64.rpm" \
+	"$(wb_resolve_daily_url opensuse15 amd64)"
+assert_fails "daily refuses opensuse15/arm64" wb_resolve_daily_url opensuse15 arm64
 assert_fails "daily rejects an unsupported OS"   wb_resolve_daily_url plan9 amd64
 assert_fails "daily rejects an unsupported arch" wb_resolve_daily_url rocky9 ppc64le
 
@@ -216,13 +285,17 @@ assert_fails "daily fails when the platform key is absent" wb_resolve_daily_url 
 eval "$_wb_orig_dailies"
 
 # --- Round trip ---------------------------------------------------------------
-# The property that actually protects the Rocky lane: whatever a resolver hands
-# back must parse back to the architecture that was asked for. A wrong rewrite
-# rule (e.g. leaving -x86_64.rpm on an arm64 URL) fails here even if the string
-# assertions above were updated to match the bug.
+# The property that actually protects the non-Ubuntu lanes: whatever a resolver
+# hands back must parse back to the architecture that was asked for. A wrong
+# rewrite rule (e.g. leaving -x86_64.rpm on an arm64 URL) fails here even if the
+# string assertions above were updated to match the bug.
+#
+# Driven off wb_os_arches rather than a hardcoded arch list, so adding an OS
+# extends the property automatically and an amd64-only OS is not asked for a
+# URL that does not exist.
 
-for _os in ubuntu24 rocky9; do
-	for _arch in amd64 arm64; do
+for _os in $WB_OS_CHOICES; do
+	for _arch in $(wb_os_arches "$_os"); do
 		assert_eq "round trip: stable ${_os}/${_arch} parses back to ${_arch}" "$_arch" \
 			"$(wb_pkg_arch "$(wb_resolve_stable_url "$_os" "$_arch")")"
 		assert_eq "round trip: daily ${_os}/${_arch} parses back to ${_arch}" "$_arch" \
@@ -240,6 +313,8 @@ assert_ok "validate accepts a matching ubuntu24/amd64 .deb" \
 	wb_validate_wb_url "https://dl.dailies.rstudio.com/server/jammy/amd64/rstudio-workbench-2026.08.0-187.pro5-amd64.deb" ubuntu24 amd64
 assert_ok "validate accepts a matching rocky9/arm64 .rpm" \
 	wb_validate_wb_url "https://dl.dailies.rstudio.com/server/rocky9/arm64/rstudio-workbench-rhel-2026.08.0-187.pro5-aarch64.rpm" rocky9 arm64
+assert_ok "validate accepts a matching opensuse15/amd64 .rpm" \
+	wb_validate_wb_url "https://dl.dailies.rstudio.com/server/opensuse15/x86_64/rstudio-workbench-2026.09.0-166.pro8-x86_64.rpm" opensuse15 amd64
 # The mistake this guards is pasting the URL you had in your scrollback from the
 # other lane: right arch, wrong package format for the container.
 assert_fails "validate rejects a .deb when the OS installs rpms" \

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -113,13 +113,26 @@ export enum PlatformTags {
 	WEB = '@:web',
 	WEB_ONLY = '@:web-only',
 	WIN = '@:win',
+	// The Workbench suite. This one IS applied to individual tests -- it is what
+	// the e2e-workbench project greps for -- and it doubles as the trigger for the
+	// Ubuntu 24 lane, which is the default OS. The tags below select a different
+	// lane for this same set of tests; none of them go on a test.
 	WORKBENCH = '@:workbench',
+	// Ubuntu 24 as well, but against the last STABLE Workbench release instead of
+	// the daily. A Workbench-version axis, not an OS one -- which is why
+	// @:workbench-all does not imply it. Lane trigger only.
 	WORKBENCH_STABLE = '@:workbench-stable',
 	// Lane trigger only: runs the same @:workbench test set on Rocky Linux 9.
 	// Never applied to an individual test.
 	WORKBENCH_ROCKY = '@:workbench-rocky',
 	// Same idea on openSUSE Leap 15.6. Also a lane trigger only.
 	WORKBENCH_SUSE = '@:workbench-suse',
+	// Shorthand for all three OS lanes at once (Ubuntu + Rocky + openSUSE), for a
+	// change that warrants full platform coverage. Supersedes @:workbench,
+	// @:workbench-rocky and @:workbench-suse rather than adding to them -- see
+	// collapse_workbench_all_tags in scripts/lib/pr-tags-lib.sh. Not
+	// @:workbench-stable, per the note above. Lane trigger only.
+	WORKBENCH_ALL = '@:workbench-all',
 	WORKBENCH_SNOWFLAKE = '@:workbench-snowflake',
 	WORKBENCH_DATABRICKS = '@:workbench-databricks',
 	WORKBENCH_AZURE = '@:workbench-azure',

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -118,6 +118,8 @@ export enum PlatformTags {
 	// Lane trigger only: runs the same @:workbench test set on Rocky Linux 9.
 	// Never applied to an individual test.
 	WORKBENCH_ROCKY = '@:workbench-rocky',
+	// Same idea on openSUSE Leap 15.6. Also a lane trigger only.
+	WORKBENCH_SUSE = '@:workbench-suse',
 	WORKBENCH_SNOWFLAKE = '@:workbench-snowflake',
 	WORKBENCH_DATABRICKS = '@:workbench-databricks',
 	WORKBENCH_AZURE = '@:workbench-azure',

--- a/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
+++ b/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
@@ -49,13 +49,29 @@ test.use({
 // The Workbench host container from docker/environments/wb-local.
 const CONTAINER = 'test';
 
-// Where the Pro Drivers land, and the unixODBC files that make them usable. `/etc` is the config
-// directory the ODBC driver extension reads and watches on Linux (see `SYSTEM_CONFIG_DIRS` in
-// extensions/positron-data-driver-odbc/src/odbcinst.ts).
+// Where the Pro Drivers land.
 const DRIVERS_DIR = '/opt/rstudio-drivers';
 const POSTGRES_DRIVER_SO = `${DRIVERS_DIR}/postgresql/bin/lib/libpostgresqlodbc_sb64.so`;
-const ODBCINST_PATH = '/etc/odbcinst.ini';
-const ODBCINI_PATH = '/etc/odbc.ini';
+
+// The unixODBC files that make the drivers usable. NOT constants, because unixODBC bakes its
+// SYSCONFDIR in at compile time and distros build it differently: `/etc` on Debian/Ubuntu and the
+// RHEL family, `/etc/unixODBC` on the SUSE family. `beforeAll` asks unixODBC itself via
+// `odbcinst -j`; these defaults only cover a teardown that runs before that resolution.
+//
+// Writing to the wrong pair is silent and confusing rather than loud: the driver never gets
+// registered, so the DSN cannot connect -- but the pane still *lists* it, because the ODBC driver
+// extension reads its own candidate directories (`SYSTEM_CONFIG_DIRS` in
+// extensions/positron-data-driver-odbc/src/odbcinst.ts). The connection then appears in the tree
+// and expands to nothing, which is what this suite hit on openSUSE.
+let odbcinstPath = '/etc/odbcinst.ini';
+let odbcIniPath = '/etc/odbc.ini';
+
+/**
+ * Shell that prints unixODBC's system driver file and system DSN file, one per line, as
+ * `odbcinst -j` reports them. Asking the driver manager is the only reliable way: the paths are
+ * compile-time, not conventional.
+ */
+const RESOLVE_ODBC_PATHS = `odbcinst -j | sed -n 's/^DRIVERS[^:]*: *//p; s/^SYSTEM DATA SOURCES[^:]*: *//p'`;
 
 // Suffix for the backups of the two config files, restored on teardown. Named for the suite so a
 // stray backup is traceable to what left it behind.
@@ -191,6 +207,18 @@ test.describe('Workbench: Posit Pro Drivers', {
 
 		const pkg = packageCommands(manager as PackageManager);
 
+		// Resolve where this distro's unixODBC actually reads its configuration, before writing any
+		// of it. On openSUSE these come back under /etc/unixODBC, not /etc.
+		const odbcPaths = await runDockerCommand(
+			`docker exec ${CONTAINER} bash -lc '${RESOLVE_ODBC_PATHS}'`,
+			'Resolve the unixODBC configuration paths'
+		);
+		const [resolvedInst, resolvedIni] = odbcPaths.stdout.trim().split('\n').map(line => line.trim());
+		expect(resolvedInst, 'odbcinst -j did not report a system driver file').toBeTruthy();
+		expect(resolvedIni, 'odbcinst -j did not report a system DSN file').toBeTruthy();
+		odbcinstPath = resolvedInst;
+		odbcIniPath = resolvedIni;
+
 		await test.step('Install the Pro Drivers', async () => {
 			await runDockerCommand(
 				`docker exec ${CONTAINER} bash -lc "${pkg.addRepo}"`,
@@ -211,11 +239,11 @@ test.describe('Workbench: Posit Pro Drivers', {
 			// already defines [PostgreSQL] (see the file header).
 			await runDockerCommand(
 				`docker exec ${CONTAINER} bash -lc '` + [
-					`for f in ${ODBCINST_PATH} ${ODBCINI_PATH}; do`,
+					`for f in ${odbcinstPath} ${odbcIniPath}; do`,
 					`  if [ -f "$f" ] && [ ! -f "$f${BACKUP_SUFFIX}" ]; then sudo cp "$f" "$f${BACKUP_SUFFIX}"; fi`,
 					`done`,
-					`sudo cp ${DRIVERS_DIR}/odbcinst.ini.sample ${ODBCINST_PATH}`,
-					`sudo chmod 0644 ${ODBCINST_PATH}`,
+					`sudo cp ${DRIVERS_DIR}/odbcinst.ini.sample ${odbcinstPath}`,
+					`sudo chmod 0644 ${odbcinstPath}`,
 				].join('\n') + `'`,
 				'Install odbcinst.ini from the drivers sample'
 			);
@@ -233,10 +261,10 @@ test.describe('Workbench: Posit Pro Drivers', {
 			expect(so.stdout.trim(), `expected ${POSTGRES_DRIVER_SO} on disk`).toBe('found');
 
 			const registered = await runDockerCommand(
-				`docker exec ${CONTAINER} bash -lc 'grep -c "^\\[PostgreSQL\\]" ${ODBCINST_PATH} || true'`,
+				`docker exec ${CONTAINER} bash -lc 'grep -c "^\\[PostgreSQL\\]" ${odbcinstPath} || true'`,
 				'Check the PostgreSQL driver is registered exactly once in odbcinst.ini'
 			);
-			expect(registered.stdout.trim(), `expected exactly one [PostgreSQL] stanza in ${ODBCINST_PATH}`).toBe('1');
+			expect(registered.stdout.trim(), `expected exactly one [PostgreSQL] stanza in ${odbcinstPath}`).toBe('1');
 		});
 
 		await test.step('Define the DSNs', async () => {
@@ -249,7 +277,7 @@ test.describe('Workbench: Posit Pro Drivers', {
 					'Copy odbc.ini into the container'
 				);
 				await runDockerCommand(
-					`docker exec ${CONTAINER} bash -lc 'sudo mv /tmp/odbc.ini ${ODBCINI_PATH} && sudo chmod 0644 ${ODBCINI_PATH}'`,
+					`docker exec ${CONTAINER} bash -lc 'sudo mv /tmp/odbc.ini ${odbcIniPath} && sudo chmod 0644 ${odbcIniPath}'`,
 					'Install odbc.ini'
 				);
 			} finally {
@@ -287,7 +315,7 @@ test.describe('Workbench: Posit Pro Drivers', {
 				`sudo rm -f ${pkg.repoFiles.join(' ')}`,
 				// Restore rather than truncate: the original is empty on Ubuntu but carries the
 				// distro's driver templates on the rpm hosts.
-				`for f in ${ODBCINST_PATH} ${ODBCINI_PATH}; do`,
+				`for f in ${odbcinstPath} ${odbcIniPath}; do`,
 				`  if [ -f "$f${BACKUP_SUFFIX}" ]; then sudo mv "$f${BACKUP_SUFFIX}" "$f"; fi`,
 				`done`,
 				`exit 0`,

--- a/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
+++ b/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
@@ -81,30 +81,64 @@ const ELEMENTS_COLUMNS = ['atomic_number', 'symbol', 'name'];
 const ELEMENTS_FIRST_ROW = ['1', 'H', 'Hydrogen'];
 
 /**
- * The two host families the Workbench lane runs on: Ubuntu 24 by default, Rocky 9 when the
- * `@:workbench-rocky` job selects it (both run the same `@:workbench` test set, so this suite has to
- * work on either).
+ * The three host OSes the Workbench lane runs on: Ubuntu 24 by default, Rocky 9 when the
+ * `@:workbench-rocky` job selects it, and openSUSE Leap 15.6 for `@:workbench-suse`. All three run
+ * the same `@:workbench` test set, so this suite has to work on any of them.
+ *
+ * Keyed by package manager rather than package format, because the two rpm hosts share a format and
+ * a setup script but not a manager: Rocky installs with `dnf`, openSUSE with `zypper`.
  */
-type PackageFormat = 'deb' | 'rpm';
+type PackageManager = 'apt' | 'dnf' | 'zypper';
+
+/**
+ * zypper has to run with the system bin directories ahead of `/opt/conda/bin`, which the openSUSE
+ * image puts first on PATH. zypper shells out to `repo2solv` by name, and conda ships its own
+ * libsolv whose `repo2solv` lacks rpm-md support, so conda's shadows the system one and every
+ * refresh fails with "rpmmd repo type is not supported" -- leaving zypper with no package names and
+ * an install that reports `rstudio-drivers` "not found in package names". Same fix and same reason
+ * as `wb_zypper` in docker/environments/wb-local/install-workbench.sh.
+ */
+const ZYPPER = `sudo env PATH=/usr/sbin:/usr/bin:/sbin:/bin zypper --non-interactive`;
 
 /** The commands that add the Posit Pro repository, install the package, and remove it again. */
-function packageCommands(format: PackageFormat): { addRepo: string; install: string; remove: string; repoFiles: string[] } {
-	return format === 'deb'
-		? {
-			addRepo: `curl -1sLf 'https://dl.posit.co/public/pro/setup.deb.sh' | sudo -E bash`,
-			install: 'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y rstudio-drivers',
-			remove: 'sudo apt-get purge -y rstudio-drivers',
-			// The keyring is removed alongside the source list; leaving it would be harmless but
-			// makes "are the drivers gone?" ambiguous for the next run.
-			repoFiles: ['/etc/apt/sources.list.d/posit-pro.list', '/usr/share/keyrings/posit-pro-archive-keyring.gpg'],
-		}
-		: {
-			addRepo: `curl -1sLf 'https://dl.posit.co/public/pro/setup.rpm.sh' | sudo -E bash`,
-			install: 'sudo dnf install -y rstudio-drivers',
-			remove: 'sudo dnf remove -y rstudio-drivers',
-			repoFiles: ['/etc/yum.repos.d/posit-pro.repo'],
-		};
+function packageCommands(manager: PackageManager): { addRepo: string; install: string; remove: string; repoFiles: string[] } {
+	const rpmSetup = `curl -1sLf 'https://dl.posit.co/public/pro/setup.rpm.sh' | sudo -E bash`;
+	switch (manager) {
+		case 'apt':
+			return {
+				addRepo: `curl -1sLf 'https://dl.posit.co/public/pro/setup.deb.sh' | sudo -E bash`,
+				install: 'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y rstudio-drivers',
+				remove: 'sudo apt-get purge -y rstudio-drivers',
+				// The keyring is removed alongside the source list; leaving it would be harmless but
+				// makes "are the drivers gone?" ambiguous for the next run.
+				repoFiles: ['/etc/apt/sources.list.d/posit-pro.list', '/usr/share/keyrings/posit-pro-archive-keyring.gpg'],
+			};
+		case 'dnf':
+			return {
+				addRepo: rpmSetup,
+				install: 'sudo dnf install -y rstudio-drivers',
+				remove: 'sudo dnf remove -y rstudio-drivers',
+				repoFiles: ['/etc/yum.repos.d/posit-pro.repo'],
+			};
+		case 'zypper':
+			return {
+				addRepo: rpmSetup,
+				// --no-gpg-checks because the Posit repo's key is imported by the setup script into
+				// rpm's keyring, not zypper's, so a fresh repo would otherwise stop for a prompt
+				// that --non-interactive answers with "no".
+				install: `${ZYPPER} --no-gpg-checks install rstudio-drivers`,
+				remove: `${ZYPPER} remove rstudio-drivers`,
+				repoFiles: ['/etc/zypp/repos.d/posit-pro.repo'],
+			};
+	}
 }
+
+/**
+ * Shell snippet that prints the host's package manager. Ordered apt -> dnf -> zypper: openSUSE has
+ * neither of the first two, so it falls through, and checking for `zypper` by name would be the one
+ * probe that conda's PATH could not confuse anyway.
+ */
+const DETECT_MANAGER = `if command -v apt-get > /dev/null; then echo apt; elif command -v dnf > /dev/null; then echo dnf; else echo zypper; fi`;
 
 /**
  * The DSN definitions the pane should discover. Written as a file and copied in rather than
@@ -141,19 +175,21 @@ test.describe('Workbench: Posit Pro Drivers', {
 		test.setTimeout(300_000);
 
 		const probe = await runDockerCommand(
-			`docker exec ${CONTAINER} bash -lc 'if command -v apt-get > /dev/null; then echo deb; else echo rpm; fi; uname -m'`,
-			'Detect the host package format and architecture'
+			`docker exec ${CONTAINER} bash -lc '${DETECT_MANAGER}; uname -m'`,
+			'Detect the host package manager and architecture'
 		);
-		const [format, arch] = probe.stdout.trim().split('\n').map(line => line.trim());
+		const [manager, arch] = probe.stdout.trim().split('\n').map(line => line.trim());
 
 		// Posit publishes `rstudio-drivers` for el9 x86_64 but not el9 aarch64 (the aarch64 repo
 		// carries only posit-chronicle). CI's Rocky lane is x86_64 so it runs there; this only bites
 		// a local `npm run pwb -- --os=rocky9` on Apple Silicon, where it would otherwise fail with a
-		// bare "Unable to find a match" from dnf.
-		test.skip(format === 'rpm' && arch === 'aarch64',
-			'Posit Pro Drivers are not published for el9 aarch64');
+		// bare "Unable to find a match" from dnf. The sles build is x86_64-only too, but the openSUSE
+		// container is always amd64 (Workbench has no arm64 openSUSE package at all), so it cannot
+		// reach this.
+		test.skip(manager !== 'apt' && arch === 'aarch64',
+			'Posit Pro Drivers are not published for this OS on aarch64');
 
-		const pkg = packageCommands(format as PackageFormat);
+		const pkg = packageCommands(manager as PackageManager);
 
 		await test.step('Install the Pro Drivers', async () => {
 			await runDockerCommand(
@@ -231,25 +267,26 @@ test.describe('Workbench: Posit Pro Drivers', {
 		test.setTimeout(120_000);
 
 		const probe = await runDockerCommand(
-			`docker exec ${CONTAINER} bash -lc 'if command -v apt-get > /dev/null; then echo deb; else echo rpm; fi'`,
-			'Detect the host package format'
+			`docker exec ${CONTAINER} bash -lc '${DETECT_MANAGER}'`,
+			'Detect the host package manager'
 		);
-		const pkg = packageCommands(probe.stdout.trim() as PackageFormat);
+		const pkg = packageCommands(probe.stdout.trim() as PackageManager);
 
 		// Tolerant of a partial install: this has to undo whatever beforeAll got through before
 		// failing (or before skipping), so removing an absent package must not abort the rest.
 		//
-		// Only `rstudio-drivers` is removed, not the dependencies it pulled in. On Rocky, unixODBC
-		// ships in the base image and removing it would damage the container for every later suite;
-		// on Ubuntu it arrives as a dependency, and leaving the driver-manager binaries behind is
-		// harmless once the configuration below is restored. `apt-get autoremove` is deliberately
-		// not used -- it would also collect anything else in the image that happens to be orphaned.
+		// Only `rstudio-drivers` is removed, not the dependencies it pulled in. On the rpm hosts
+		// unixODBC ships in the base image and removing it would damage the container for every
+		// later suite; on Ubuntu it arrives as a dependency, and leaving the driver-manager binaries
+		// behind is harmless once the configuration below is restored. `apt-get autoremove` is
+		// deliberately not used -- it would also collect anything else in the image that happens to
+		// be orphaned.
 		await runDockerCommand(
 			`docker exec ${CONTAINER} bash -lc '` + [
 				`${pkg.remove} || true`,
 				`sudo rm -f ${pkg.repoFiles.join(' ')}`,
 				// Restore rather than truncate: the original is empty on Ubuntu but carries the
-				// distro's driver templates on Rocky.
+				// distro's driver templates on the rpm hosts.
 				`for f in ${ODBCINST_PATH} ${ODBCINI_PATH}; do`,
 				`  if [ -f "$f${BACKUP_SUFFIX}" ]; then sudo mv "$f${BACKUP_SUFFIX}" "$f"; fi`,
 				`done`,

--- a/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
+++ b/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
@@ -71,7 +71,7 @@ let odbcIniPath = '/etc/odbc.ini';
  * `odbcinst -j` reports them. Asking the driver manager is the only reliable way: the paths are
  * compile-time, not conventional.
  */
-const RESOLVE_ODBC_PATHS = `odbcinst -j | sed -n 's/^DRIVERS[^:]*: *//p; s/^SYSTEM DATA SOURCES[^:]*: *//p'`;
+const RESOLVE_ODBC_PATHS = `odbcinst -j | sed -n "s/^DRIVERS[^:]*: *//p; s/^SYSTEM DATA SOURCES[^:]*: *//p"`;
 
 // Suffix for the backups of the two config files, restored on teardown. Named for the suite so a
 // stray backup is traceable to what left it behind.
@@ -207,18 +207,6 @@ test.describe('Workbench: Posit Pro Drivers', {
 
 		const pkg = packageCommands(manager as PackageManager);
 
-		// Resolve where this distro's unixODBC actually reads its configuration, before writing any
-		// of it. On openSUSE these come back under /etc/unixODBC, not /etc.
-		const odbcPaths = await runDockerCommand(
-			`docker exec ${CONTAINER} bash -lc '${RESOLVE_ODBC_PATHS}'`,
-			'Resolve the unixODBC configuration paths'
-		);
-		const [resolvedInst, resolvedIni] = odbcPaths.stdout.trim().split('\n').map(line => line.trim());
-		expect(resolvedInst, 'odbcinst -j did not report a system driver file').toBeTruthy();
-		expect(resolvedIni, 'odbcinst -j did not report a system DSN file').toBeTruthy();
-		odbcinstPath = resolvedInst;
-		odbcIniPath = resolvedIni;
-
 		await test.step('Install the Pro Drivers', async () => {
 			await runDockerCommand(
 				`docker exec ${CONTAINER} bash -lc "${pkg.addRepo}"`,
@@ -228,6 +216,27 @@ test.describe('Workbench: Posit Pro Drivers', {
 				`docker exec ${CONTAINER} bash -lc '${pkg.install}'`,
 				'Install the rstudio-drivers package'
 			);
+		});
+
+		// Only now can unixODBC be asked where it reads its configuration -- `odbcinst` ships with
+		// unixODBC, and on Ubuntu and Rocky that arrives as a DEPENDENCY of rstudio-drivers, so
+		// before the install above there is no `odbcinst` to run. (openSUSE has it in the image,
+		// which is why doing this earlier passed there and broke the other two.) Must still come
+		// before anything is written, since it decides where.
+		await test.step('Resolve the unixODBC configuration paths', async () => {
+			const odbcPaths = await runDockerCommand(
+				`docker exec ${CONTAINER} bash -lc '${RESOLVE_ODBC_PATHS}'`,
+				'Ask unixODBC for its system driver and DSN files'
+			);
+			const [resolvedInst, resolvedIni] = odbcPaths.stdout.trim().split('\n').map(line => line.trim());
+			// Assert rather than fall back to /etc: a silent fallback is what makes the openSUSE
+			// failure mode so hard to read -- the config lands somewhere unixODBC ignores, the DSNs
+			// are still listed by the pane, and the only symptom is a connection that expands to
+			// nothing.
+			expect(resolvedInst, 'odbcinst -j did not report a system driver file').toBeTruthy();
+			expect(resolvedIni, 'odbcinst -j did not report a system DSN file').toBeTruthy();
+			odbcinstPath = resolvedInst;
+			odbcIniPath = resolvedIni;
 		});
 
 		await test.step('Register the drivers with unixODBC', async () => {

--- a/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
+++ b/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
@@ -312,8 +312,11 @@ test.describe('Workbench: Posit Pro Drivers', {
 
 		await test.step('Expand the tree down to tables', async () => {
 			await dataConnections.expandConnection(PERIODIC_DSN);
-			await dataConnections.expandNode('Schemas');
-			await dataConnections.expandNode('public');
+			// No 'Schemas' or 'public' row to expand: #15859 made the tree hide a connection's
+			// schema level when there is only one schema, and the `periodic` database has exactly
+			// one once the driver filters out pg_catalog, information_schema and pg_toast. So
+			// Tables sits directly under the connection. Same fix as #15873 made for the Redshift
+			// suite; this spec landed alongside that change and missed it.
 			await dataConnections.expandNode('Tables');
 		});
 

--- a/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
+++ b/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
@@ -67,11 +67,27 @@ let odbcinstPath = '/etc/odbcinst.ini';
 let odbcIniPath = '/etc/odbc.ini';
 
 /**
- * Shell that prints unixODBC's system driver file and system DSN file, one per line, as
- * `odbcinst -j` reports them. Asking the driver manager is the only reliable way: the paths are
- * compile-time, not conventional.
+ * Shell that prints unixODBC's system driver file and system DSN file, one per line.
+ *
+ * Asks `odbcinst -j` when it is there, because that is authoritative -- the paths are unixODBC's
+ * compile-time SYSCONFDIR, not a convention. But it is not always there: on Debian/Ubuntu the
+ * `odbcinst` BINARY is packaged separately from the ODBC libraries, so installing rstudio-drivers
+ * pulls in the libraries and leaves no CLI to ask. Rocky and openSUSE both ship it.
+ *
+ * Hence the fallback, which only ever runs on Debian/Ubuntu: prefer /etc/unixODBC if that directory
+ * exists (the SUSE-family layout) and otherwise /etc. Note a bare pipeline would hide all of this
+ * -- its exit status is sed's, so a missing `odbcinst` exits 0 with empty output, which is exactly
+ * how this failed the first time.
  */
-const RESOLVE_ODBC_PATHS = `odbcinst -j | sed -n "s/^DRIVERS[^:]*: *//p; s/^SYSTEM DATA SOURCES[^:]*: *//p"`;
+const RESOLVE_ODBC_PATHS = [
+	'if command -v odbcinst > /dev/null 2>&1; then',
+	'  odbcinst -j | sed -n "s/^DRIVERS[^:]*: *//p; s/^SYSTEM DATA SOURCES[^:]*: *//p"',
+	'elif [ -d /etc/unixODBC ]; then',
+	'  printf "%s\\n" /etc/unixODBC/odbcinst.ini /etc/unixODBC/odbc.ini',
+	'else',
+	'  printf "%s\\n" /etc/odbcinst.ini /etc/odbc.ini',
+	'fi',
+].join('\n');
 
 // Suffix for the backups of the two config files, restored on teardown. Named for the suite so a
 // stray backup is traceable to what left it behind.


### PR DESCRIPTION
Adds a third Workbench e2e lane, on openSUSE Leap 15.6, and one tag to run all three OS lanes at once.

> Prose below writes lane tags with a space (`@ :workbench`, `@ :workbench-rocky`, ...). Written literally they match the PR-tag parser and trigger those lanes -- which is what happened on the first two pushes of this PR. Only the intentional `@:workbench-all` at the bottom is written for real.

- **New lane:** `@ :workbench-suse` / `run_e2e_workbench_suse` / `npm run pwb -- --os=opensuse15`
- **New tag:** `@:workbench-all` -- Ubuntu + Rocky + openSUSE in one tag
- Reuses `ghcr.io/posit-dev/positron-opensuse156`, the image the electron SUSE lane already runs, so there is no new image to build or publish.

## `@:workbench-all`

Per the QA discussion: `@ :workbench` keeps meaning Ubuntu only, so a routine Workbench PR does not pay for three OS lanes, and `@:workbench-all` is there for a change that warrants full platform coverage.

It sets the three lane flags directly rather than being a fourth flag the workflows have to know about, so every existing `if:` keeps working and there is one less place for the lane list to go stale. (The bare-tag matcher does not fire on `@:workbench-all` -- the boundary class excludes `-` -- hence setting the Ubuntu flag explicitly.)

It also **supersedes** the tags it stands for, so the PR comment stays accurate: `collapse_workbench_all_tags` drops `@ :workbench`, `@ :workbench-rocky` and `@ :workbench-suse` when `@:workbench-all` is present.

| PR body | lanes run | tags in comment |
| --- | --- | --- |
| `@:workbench-all @ :workbench-rocky` | ubuntu, rocky, suse | `@:workbench-all` |
| `@:workbench-all` + `@:console` | ubuntu, rocky, suse | `@:workbench-all,@:console` |
| `@ :workbench-rocky` alone | rocky | `@ :workbench-rocky` |

That runs before the `AUTHOR_TAGS` snapshot, so superseded tags are gone from the comment rather than showing up attributed to the PR description. It is presentation only -- the flags are already set, so nothing it removes can stop a lane running.

It does **not** imply `@ :workbench-stable`: that lane varies the Workbench version and stays on Ubuntu, so it is a different axis from OS coverage. It also leaves the `@ :workbench-snowflake` / `-databricks` / `-azure` credential tags alone -- those are test tags consumed by the Ubuntu lane's shard matrix, not lane selectors.

`WORKBENCH_ALL` goes in `PlatformTags`, not `FeatureTags`: validation would otherwise drop it as a typo, and a lane selector inside `FeatureTags` becomes eligible for auto test-change derivation, which is how an unrelated PR ends up buying three OS lanes. Both properties are asserted against the real enum. Nightly full-suite scheduling is handled separately in positron-builds.

## What the first CI run taught us

The first openSUSE run failed, and the cause was a choice in this PR rather than anything about openSUSE. `start_workbench` routed **both** rpm families through the direct-binary launcher start "for one code path", and on the runner the launcher socket never appeared:

```
rstudio-launcher socket never appeared at /var/run/rstudio-server/rserver-launcher.socket
```

rserver calls `LauncherClient::initialize()` at startup and shuts itself down with ENOENT when that socket is missing, so `:8787` was never coming up; the build-swap timeout two minutes later was the symptom, not the defect.

EL9 is the only family that needs the direct start (its packaged script tests an undefined `$rserver` and passes flags `daemon` does not support). SUSE's script is fine -- `startproc -s -q`, socket up in about a second, verified in the container -- so it now uses the packaged path.

Two things that run exposed, both fixed here:

- **A missing launcher socket was advisory.** It `log_error`'d and continued, so the install "completed with 1 warning" and the real damage surfaced later from a different step. Now it dumps the launcher processes and logs and aborts.
- **The build-swap step reported a verdict with no evidence.** It now dumps the HTTP code, listeners on `:8787`, the rserver process tree, the socket, and the rserver/http/launcher logs. The HTTP code is the discriminator: `502` means an orphaned `rserver-http` still holds the port with no rserver behind it, `000` means nothing is listening -- different bugs.

`wb_ensure_workbench` and `start_workbench` had **diverged** on exactly this choice (the host side already used the init script on SUSE). That divergence is what let it through, so they now make the same family decision.

**Both questions that were open here are now answered by a native run.** All three lanes are green
and openSUSE matches Ubuntu exactly:

| lane | result |
| --- | --- |
| `workbench` (Ubuntu) | 53 passed / 0 failed |
| `workbench-rocky` | 52 passed / 0 failed / 1 flaky (passed on retry) |
| `workbench-suse` | 53 passed / 0 failed / 0 flaky |

- `new/` vs `bundled/`: openSUSE produces identical results to the two established lanes across the
  whole set, so it is not resolving Positron differently from them. (`rstudio-server
  positron-version` turned out to be useless as a check for this -- it reads `bundled/` and caches
  at rserver startup, so it reports "the Positron this Workbench shipped with" regardless.)
- `@ :environment-modules` (R): passes on openSUSE in 9s. The reproducible local failure was a
  Rosetta artifact, which is why it did not get a "fix".

## Five openSUSE defects found by running this

The last one is a product bug, not a lane quirk -- the lane earning its keep on its first run.

- **conda's `repo2solv` shadows the system one.** The image puts `/opt/conda/bin` first on `PATH`, and conda ships its own libsolv whose `repo2solv` lacks rpm-md support. zypper shells out to it *by name*, so every `zypper refresh` died with `rpmmd repo type is not supported` and every install then failed with `not found in package names` -- both of which read like a broken mirror rather than a shadowed binary. All zypper calls go through `wb_zypper`, which puts the system bin directories first.
- **`sysvinit-tools` conflicts with the image's `busybox-sysvinit-tools`.** The real package supplies the `startproc`/`killproc` the SUSE init scripts call; the busybox variant provides a strict subset and nothing on the image requires it.
- **`checkproc` cannot see rserver in the container.** `rstudio-server start` can print `..failed` and exit non-zero while rserver is up and serving. The installer judges the outcome instead of the exit status.
- **The launcher could not create its socket.** It starts as root but drops to the configured
  `server-user` before binding, and on a fresh container `/var/run/rstudio-server` is root-owned, so
  the bind failed with `EACCES` and rserver then shut itself down on `ENOENT`. rserver creates that
  directory itself, but it runs *second* -- it needs the launcher's socket first. Nothing else
  creates it in a container: no `tmpfiles.d` config, and neither the systemd units nor the SysV
  scripts make it.
- **PRODUCT: Positron could not see any system DSN on the SUSE family.** unixODBC bakes its
  `SYSCONFDIR` in at compile time, and openSUSE builds it against `/etc/unixODBC` rather than
  `/etc`. `SYSTEM_CONFIG_DIRS` in `positron-data-driver-odbc` did not include that directory, so a
  DSN defined where the platform actually reads it was invisible to the pane -- while a stray
  `/etc/odbc.ini` was still *offered*, producing a connection that appears and then cannot open.
  Fixed by adding the directory; the e2e suite now also writes wherever `odbcinst -j` reports
  instead of assuming `/etc`.

  Follow-up worth filing separately: Positron *guesses* these directories from a candidate list
  rather than asking unixODBC, so a machine whose `SYSCONFDIR` is none of the four still sees
  nothing, and on SUSE a stale `/etc/odbc.ini` still wins over the real file.

## Per-OS facts, and one refactor

All per-OS knowledge stays in `workbench-local-lib.sh`. Adding a third OS turned two facts into things a *family* branch expresses better than a per-OS one, so `install-workbench.sh` switches on `debian|redhat|suse`. That is also the name of the `extras/init.d/<family>` directory each package ships -- verified, all three exist -- which the SysV install copies from.

## Why the local loop is emulated (and why that is not fixable)

Posit publishes **no arm64 Workbench package for any SUSE version**. The feeds carry exactly one SUSE platform, `opensuse15-x86_64` ("SUSE 15+"), while Ubuntu 22/24/26 and RHEL 9/10 all have arm64. The URL-rewrite trick that finds Rocky's arm64 rpm 404s on every openSUSE path, and openSUSE 15.7 installs the same `opensuse15` rpm.

So URL resolution *refuses* an arm64 openSUSE build rather than silently returning the x86 one, and on an arm64 host `--os=opensuse15` forces an emulated `linux/amd64` container and says so. **CI runners are amd64 and run it natively.**

## Also

- The Pro Drivers suite hardcoded `dnf` for rpm hosts; it now keys off the package manager, since the two rpm OSes share a format and a setup script but not a manager. `rstudio-drivers` *is* published for SLES/openSUSE (`2026.07.0-1.sles`), so the suite runs there rather than needing a skip.
- One prep commit retabs the `<<'JSON'` heredoc fixtures in `pr-tags-lib-test.sh`. They were space-indented, which trips hygiene's tabs-only rule, so *any* commit touching that file was blocked by the pre-commit hook. Node parses those fixtures as JSON and JSON ignores leading whitespace, so it cannot change what a test sees. (Hygiene runs only in the local hook, never in CI -- which is how the file got there.) Reviewable on its own.

## Testing

- `scripts/test/workbench-local-lib-test.sh`: 114 checks. New coverage for the openSUSE feed/image/stem facts, the arm64 refusal on both channels, and the shared-`.rpm`-stem case (openSUSE uses Ubuntu's stem with Rocky's extension, which broke `wb_pkg_version`). The round-trip property is driven off `wb_os_arches` so an amd64-only OS is never asked for a URL that does not exist.
- `scripts/test/pr-tags-lib-test.sh`: new coverage for `collapse_workbench_all_tags`, including what it must *not* absorb, plus the two enum-placement properties.
- Local `--os=opensuse15` install verified end to end: Workbench `2026.09.0+166.pro8` + Positron `2026.09.0-236`, `:8787` serving, sticky-OS resume, PAM `PATH` fix and module setup confirmed in-container.

@:workbench-all