### PR TITLE
Accept an optional document in the run app API

### DIFF
--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -111,6 +111,11 @@ interface RunAppOptionsBase {
     name: string;
 
     /**
+     * The document to run. When omitted, the active editor's document is used.
+     */
+    document?: vscode.TextDocument;
+
+    /**
      * How to preview the application once the URL is detected.
      *
      * Defaults to `'default'`, which resolves to the user's
@@ -194,6 +199,11 @@ export interface DebugAppOptions {
      * The human-readable label for the application e.g. `'Streamlit'`.
      */
     name: string;
+
+    /**
+     * The document to debug. When omitted, the active editor's document is used.
+     */
+    document?: vscode.TextDocument;
 
     /**
      * A function that will be called to get the ${@link vscode.DebugConfiguration, debug configuration} for debugging the application.

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -76,9 +76,16 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 	public async runApplication(options: RunAppOptions): Promise<vscode.Uri | undefined> {
 		try {
-			const document = this.getDocumentForRun(options.name);
+			const document = this.getDocumentForRun(options);
 			if (!document) {
 				return;
+			}
+
+			// Keep this check adjacent to the queue call below: an await in
+			// between would let a concurrent invocation slip past it.
+			if (this._runApplicationSequencerByName.has(options.name)) {
+				this.showAppAlreadyStartingError(options.name);
+				return undefined;
 			}
 			return await this.queueRunApplication(options.name, (progress) => this.doRunApplication(document, options, progress));
 		} catch (error) {
@@ -89,9 +96,16 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 	public async runApplicationInConsole(options: RunConsoleAppOptions): Promise<vscode.Uri | undefined> {
 		try {
-			const document = this.getDocumentForRun(options.name);
+			const document = this.getDocumentForRun(options);
 			if (!document) {
 				return;
+			}
+
+			// Keep this check adjacent to the queue call below: an await in
+			// between would let a concurrent invocation slip past it.
+			if (this._runApplicationSequencerByName.has(options.name)) {
+				this.showAppAlreadyStartingError(options.name);
+				return undefined;
 			}
 			return await this.queueRunApplication(options.name, (progress) => this.doRunApplicationInConsole(document, options, progress));
 		} catch (error) {
@@ -100,18 +114,9 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		}
 	}
 
-	private getDocumentForRun(appName: string): vscode.TextDocument | undefined {
-		const document = vscode.window.activeTextEditor?.document;
-		if (!document) {
-			return undefined;
-		}
-
-		if (this._runApplicationSequencerByName.has(appName)) {
-			vscode.window.showErrorMessage(vscode.l10n.t('{0} application is already starting.', appName));
-			return undefined;
-		}
-
-		return document;
+	/** The document to run or debug: the caller's, else the active editor's. */
+	private getDocumentForRun(options: { document?: vscode.TextDocument }): vscode.TextDocument | undefined {
+		return options.document ?? vscode.window.activeTextEditor?.document;
 	}
 
 	public getProxyServerUri(appUrl: string): vscode.Uri | undefined {
@@ -457,7 +462,8 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 						// Keep watching for the URL. The observer has no cancellation
 						// token, so `detector.found` still resolves if the app prints
 						// its URL later. Don't await: holding the run task open would
-						// block a re-run (see `getDocumentForRun`) and would pin the
+						// block a re-run (see the sequencer guard in
+						// `runApplicationInConsole`) and would pin the
 						// progress notification.
 						this.watchForLateAppUrl(detector.found, executionFinished, {
 							appName: options.name,
@@ -502,14 +508,15 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 	public async debugApplication(options: DebugAppOptions): Promise<void> {
 		try {
-			// If there's no active text editor, do nothing.
-			const document = vscode.window.activeTextEditor?.document;
+			const document = this.getDocumentForRun(options);
 			if (!document) {
 				return;
 			}
 
+			// Keep this check adjacent to the queue call below: an await in
+			// between would let a concurrent invocation slip past it.
 			if (this._debugApplicationSequencerByName.has(options.name)) {
-				vscode.window.showErrorMessage(vscode.l10n.t('{0} application is already starting.', options.name));
+				this.showAppAlreadyStartingError(options.name);
 				return;
 			}
 
@@ -704,6 +711,11 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		}
 
 		return persisted[name];
+	}
+
+	/** Notify the user that the named application is already starting. */
+	private showAppAlreadyStartingError(appName: string): void {
+		vscode.window.showErrorMessage(vscode.l10n.t('{0} application is already starting.', appName));
 	}
 
 	private showRunError(appName: string, error: unknown): void {

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -113,6 +113,11 @@ interface RunAppOptionsBase {
 	name: string;
 
 	/**
+	 * The document to run. When omitted, the active editor's document is used.
+	 */
+	document?: vscode.TextDocument;
+
+	/**
 	 * How to preview the application once the URL is detected.
 	 *
 	 * Defaults to `'default'`, which resolves to the user's
@@ -196,6 +201,11 @@ export interface DebugAppOptions {
 	 * The human-readable label for the application e.g. `'Streamlit'`.
 	 */
 	name: string;
+
+	/**
+	 * The document to debug. When omitted, the active editor's document is used.
+	 */
+	document?: vscode.TextDocument;
 
 	/**
 	 * A function that will be called to get the ${@link vscode.DebugConfiguration, debug configuration} for debugging the application.

--- a/extensions/positron-run-app/src/test/api.test.ts
+++ b/extensions/positron-run-app/src/test/api.test.ts
@@ -72,7 +72,12 @@ suite('PositronRunApp', () => {
 		sinon.stub(positron.runtime, 'getPreferredRuntime').callsFake(async (_languageId) => runtime);
 
 		// Stub the positron proxy API.
-		sinon.stub(vscode.commands, 'executeCommand')
+		// Call through for every other command: tests rely on real commands
+		// (e.g. workbench.action.closeAllEditors), which a bare stub would
+		// silently turn into no-ops.
+		const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
+		executeCommandStub.callThrough();
+		executeCommandStub
 			.withArgs('positronProxy.startPendingProxyServer')
 			.resolves({
 				proxyPath: '/proxy/path',
@@ -124,6 +129,33 @@ suite('PositronRunApp', () => {
 		const terminal = vscode.window.terminals.find((t) => t.name === runAppOptions.name);
 		assert.ok(terminal, 'Terminal not found');
 	}
+
+	test('appLauncher: document option runs the given document without relying on the active editor', async () => {
+		// Close all editors so the active-editor fallback can't be what runs.
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+		await waitFor(() => vscode.window.activeTextEditor === undefined, 'Editors did not close');
+		const document = await vscode.workspace.openTextDocument(uri);
+
+		await runAppApi.runApplication({ ...runAppOptions, document });
+
+		const terminal = vscode.window.terminals.find((t) => t.name === runAppOptions.name);
+		assert.ok(terminal, 'Terminal not found');
+		sinon.assert.calledOnceWithMatch(previewUrlStub, localhostUriMatch);
+	});
+
+	test('appLauncher: no document and no active editor runs nothing', async () => {
+		// With nothing to fall back to there is no app to run, so the run is a
+		// no-op rather than an error: only a programmatic caller can reach this.
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+		await waitFor(() => vscode.window.activeTextEditor === undefined, 'Editors did not close');
+		// Earlier tests leave their terminals open, so count rather than look one up by name.
+		const terminalCount = vscode.window.terminals.length;
+
+		await runAppApi.runApplication(runAppOptions);
+
+		assert.strictEqual(vscode.window.terminals.length, terminalCount, 'No terminal should have been created');
+		sinon.assert.notCalled(previewUrlStub);
+	});
 
 	test('appLauncher: shell integration supported', async () => {
 		// Run the application.


### PR DESCRIPTION
Part of #15897. No outward changes yet, still works as expected:

https://github.com/user-attachments/assets/b1e9c862-5628-465c-b738-98f43c1e1a8e

### Summary

Adds an optional `document` to `RunAppOptionsBase` and `DebugAppOptions`. When provided, `runApplication`, `runApplicationInConsole`, and `debugApplication` run that document. Otherwise, they continue to use the active editor. Existing behavior is unchanged because no current caller passes `document`.

This enables callers such as editor title actions and agents to run a specific file without first making it active.

This PR does not close #15897. A follow-up will update the Python web app commands to pass their URI through this API.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:apps

Run the extension host tests:

```bash
npm run test-extension -- -l positron-run-app
```

The new tests verify that:

- A supplied `document` runs even when no editor is active.
- Nothing runs when neither `document` nor an active editor is available.

Manual regression check:

1. Open a Streamlit or Dash app.
2. Click Run in the editor title bar and confirm the app starts and appears in the Viewer.
3. Click Run again while the app is starting and confirm the “application is already starting” error appears.
4. Repeat with the Debug button.