### PR TITLE
e2e: abandon a parked post-reload workbench probe on wall clock

### DIFF
--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -16,6 +16,39 @@ const RELOAD_PROBE_TIMEOUT = 2000;
 const RELOAD_READY_TIMEOUT = 30000;
 
 /**
+ * Wall-clock margin on top of a probe's own timeout, so a probe that is merely
+ * slow still reports its own failure and only a parked one is abandoned.
+ */
+const RELOAD_PROBE_GRACE = 500;
+
+/** Budget for the post-reload load-state hint (best effort, see reloadWindow). */
+const RELOAD_LOADSTATE_TIMEOUT = 5000;
+
+/**
+ * Await `operation`, abandoning it after `timeoutMs` of wall clock.
+ *
+ * A Playwright query can park on a discarded execution-context promise, and no
+ * option on the query bounds that wait: the one-shot probe inside
+ * `expect(...).toBeVisible({ timeout })` never observes its own deadline, and
+ * every retry wrapper (`toPass`, `Code#poll`) awaits the probe, so the retry the
+ * timeout was supposed to trigger never runs. Racing a real timer is what
+ * actually lets go. `Promise.race` leaves a rejection handler attached to
+ * `operation`, so a late settle is handled rather than unhandled.
+ */
+async function withDeadline<T>(operation: Promise<T>, timeoutMs: number, what: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const expired = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(`${what} did not settle within ${timeoutMs}ms`)), timeoutMs);
+	});
+
+	try {
+		return await Promise.race([operation, expired]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
  * Provides hotkey shortcuts for common operations. References the keybindings defined in `test/e2e/fixtures/keybindings.json`.
  */
 export class HotKeys {
@@ -275,6 +308,16 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+B R', 'Reload window');
 		await navigated;
 
+		// `framenavigated` fires at the navigation-commit instant, before the new
+		// document has an execution context bound, so a query issued there aims at a
+		// context that is discarded moments later. DOMContentLoaded is a page-level
+		// lifecycle event rather than a context-bound evaluation, so waiting for it
+		// cannot park the way a locator query can. Best effort: the probe loop below
+		// is the real gate, and a missed load event should not fail the reload on its
+		// own.
+		await page.waitForLoadState('domcontentloaded', { timeout: RELOAD_LOADSTATE_TIMEOUT })
+			.catch(() => { });
+
 		// Bound each probe and retry, rather than spending the whole budget on one
 		// assertion. Playwright parks a query on the execution-context promise that
 		// existed when the query started, and an Electron reload clears the context
@@ -282,11 +325,19 @@ export class HotKeys {
 		// promise and orphans the old one, so a probe that started before the last
 		// clear waits forever on a promise nothing will resolve. That is the Windows
 		// CI failure where the workbench is fully rendered but the assertion reports
-		// "element(s) not found". Abandoning the attempt lets the next one pick up
-		// the current promise. The overall budget is unchanged.
+		// "element(s) not found".
+		//
+		// The probe's own `timeout` does not bound that wait -- a parked probe has
+		// been observed running 17.7s on a 2s budget, starving `toPass` down to three
+		// attempts in 30s -- so the abandonment has to happen on wall clock. Only
+		// then does the next attempt pick up the current promise. The overall budget
+		// is unchanged.
 		await expect(async () => {
-			await expect(page.locator('.monaco-workbench'))
-				.toBeVisible({ timeout: RELOAD_PROBE_TIMEOUT });
+			await withDeadline(
+				expect(page.locator('.monaco-workbench')).toBeVisible({ timeout: RELOAD_PROBE_TIMEOUT }),
+				RELOAD_PROBE_TIMEOUT + RELOAD_PROBE_GRACE,
+				'post-reload workbench probe'
+			);
 		}).toPass({ timeout: RELOAD_READY_TIMEOUT, intervals: [250] });
 
 		// Wait for the workbench lifecycle to reach Restored (the same positive signal


### PR DESCRIPTION
`hotKeys.reloadWindow`'s post-reload workbench gate fails on Windows CI against a workbench that is fully rendered. This is the fourth pass at that failure: #15793 introduced it, #15824 changed only the error string, and #15843's remedy is falsified by its own stated criterion (6 failures across 41 post-fix win/electron runs, against 9 across 95 before it).

### Summary

#15843 bounded each probe with `expect(...).toBeVisible({ timeout: RELOAD_PROBE_TIMEOUT })` so that a probe parked on a discarded execution-context promise would be abandoned and retried. That inner timeout is not enforced against a parked context wait. In the trace for run 33657280051 the 30s gate recorded three probes where its 2000ms/250ms cadence predicts about thirteen: probe 2 ran 17.7s on a 2000ms budget, and probe 3 never returned. `toPass` awaits the probe, so the retry the timeout was meant to trigger never fires.

Two changes, both in `hotKeys.ts`:

- Each probe is now raced against a real timer, so a parked query is genuinely let go and the next attempt can acquire the current context promise. This is what #15843 believed the inner timeout already did.
- After `framenavigated` resolves, wait for `domcontentloaded` before the first probe. `framenavigated` fires at the navigation-commit instant, before the new document has an execution context bound, so #15793's arming aimed the first query at a context that is discarded moments later. A load-state wait is a page-level lifecycle event rather than a context-bound evaluation, so it cannot park; it is best effort, since the probe loop is the real gate.

No timeout was raised. `RELOAD_PROBE_TIMEOUT` (2000ms) and `RELOAD_READY_TIMEOUT` (30000ms) are unchanged. The added 500ms margin exists only so a merely slow probe still reports its own error and only a parked one is abandoned.

### Evidence

From the trace of the failure in run 33657280051 (win/electron):

- `.monaco-workbench` was present in 177 of 839 frame snapshots, including five inside the wait window and the final one. The last screencast frame, four seconds past the deadline, shows a fully rendered workbench with a live Python console.
- 673 screencast frames were served through the deadline and console lines were delivered, so the CDP session was alive. No `Target closed`, `Execution context was destroyed`, `Page closed` or crash entries in either attempt; a single window, no BrowserWindow recreation.
- Three `Frame.expect` probes in the 30s window (t=1784456, 1788575, 1806284) instead of the roughly thirteen the cadence predicts, with a 17.7s gap spanning probe 2.
- The plotly 404 and `ChunkLoadError` lines land at t=1784401-1784413, inside the 892ms teardown window before the gate opens, and appear on passing runs too. They are the webview being disposed, not the failure.

### Blast radius

The gate is shared by 24 `reloadWindow` call sites across 18 specs. The same `.monaco-workbench` signature is currently failing on win/electron in both reload tests in `quarto-inline-output-dataframe.test.ts`, in `quarto-inline-output-persistence.test.ts`, and in `notebooks-positron/notebook-editor.test.ts`.

`Code#poll` and `whenWorkbenchRestored` share the same await-a-parkable-call structure and are deliberately not touched here. They have not been the failing line because the workbench gate trips first; worth a follow-up.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:win @:quarto @:positron-notebooks @:layouts @:sessions @:vscode-settings

Test infrastructure only; no product source changed, so there is nothing here for a unit test to cover. The failure is win/electron only and rate-based (roughly 15% of post-#15843 win/electron runs of the affected tests), so a single green run proves nothing. The signal to read is the win/electron failure rate for reload-based tests across the run as a whole. The tags cover every Windows-tagged spec that calls `reloadWindow` apart from the assistant sign-in test.


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- After an in-place Electron reload on Windows CI, a Playwright locator query issued at the navigation-commit instant parks on an orphaned execution-context promise. PR #15843 tried to bound each probe with an inner {timeout: 2000}, but that inner timeout is NOT enforced against a parked context wait: the trace shows probe 2 running 17.7s on a 2000ms budget and probe 3 never returning, so toPass gets 3 attempts in 30s instead of the ~13 its cadence predicts and never re-acquires a live context. The workbench is fully rendered and the CDP session alive throughout.</summary>

- **Test:** [Quarto - Inline Output: DataFrame and Interactive HTML > Python - Verify interactive HTML widget persists correctly after window reload](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20DataFrame%20and%20Interactive%20HTML%20%3E%20Python%20-%20Verify%20interactive%20HTML%20widget%20persists%20correctly%20after%20window%20reload%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-dataframe.test.ts)
- **Targeted failure:** expect(page.locator('.monaco-workbench')).toBeVisible({timeout:2000}) inside toPass at test/e2e/pages/hotKeys.ts:290, reached from hotKeys.reloadWindow(true) at quarto-inline-output-dataframe.test.ts:206. win/electron only.
- **Signal:** Trace of run 33657280051 attempt 0: monaco-workbench present in 177/839 frame snapshots including 5 inside the wait window and the final snapshot at t=1818479; final screencast frame (t=1818478, 4s past deadline) shows a fully rendered workbench with explorer, editor and a live Python 3.10.10 console banner. Screencast served 673 frames through t=1818478 and console lines were delivered, so CDP was alive. Zero matches for 'Target closed', 'Execution context was destroyed', 'Page closed', 'crash' in either attempt; single window, no BrowserWindow recreation. Only 3 Frame.expect probes recorded in the 30s window (t=1784456, 1788575, 1806284) where 2000ms/250ms predicts ~13; probe 2 spanned 17.7s and probe 3 never returned. plotly 404 / ChunkLoadError land at t=1784401-1784413, inside the 892ms teardown window BEFORE the gate opens, and are present on passing runs too.
- **Frequency:** 3/136 runs (2.2%) on main, win/electron
- **Hypothesis:** The inner expect timeout cannot abort a query parked on a discarded execution-context promise, and toPass/code.poll both await their inner call, so no retry wrapper's deadline can fire. Abandoning each probe on wall clock (Promise.race against a real timer) lets the next iteration acquire the current context promise; the win/electron reloadWindow failure rate should fall toward 0. Falsified if failures continue with a rendered workbench and fewer probes than the cadence predicts.
- **Supersedes:** PR #15843 (e64be3c713, Sep 1) bounded each probe with an inner timeout on the premise that the bound would be honoured; the trace shows it is not (17.7s probe on a 2000ms budget), so it changed nothing: 6 failures / 41 post-fix win/electron runs (14.6%) vs 9/95 (9.5%) before. PR #15824 (8c269d5d45, Aug 31) changed the error string only (locator.waitFor -> expect toBeVisible), which is why this test shows three pattern IDs for one defect. PR #15793 (07918e5e58, Aug 28) is the trigger: arming at framenavigated moved the first query to the nav-commit instant, before the context is bound.

</details>
