### PR TITLE
Windows: Normalize line endings when splitting code by input boundary

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2050,6 +2050,11 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 		errorBehavior?: RuntimeErrorBehavior,
 		executionId?: string,
 		executionMetadata?: Record<string, unknown>) {
+		// Normalize line endings so the boundary provider's line-by-line parse
+		// (and the local split) see clean LF input, not a CRLF editor's carriage
+		// returns. The runtime's parser normalizes source the same way.
+		code = code.replace(/\r\n?/g, '\n');
+
 		// If a manually assigned execution ID is provided, add it to the set of
 		// external execution IDs.
 		if (executionId) {
@@ -2433,6 +2438,11 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 	 */
 	async submitCode(code: string, attribution: IConsoleCodeAttribution): Promise<CodeSubmissionResult> {
 		const t0 = Date.now();
+
+		// Normalize line endings so the boundary provider's line-by-line parse
+		// (and the local split) see clean LF input, not a CRLF editor's carriage
+		// returns. The runtime's parser normalizes source the same way.
+		code = code.replace(/\r\n?/g, '\n');
 
 		// Flow 3 short-circuit: completeness checking is disabled, so run the
 		// code as-is with no checks, no roundtrips, and no submission visuals.

--- a/src/vs/workbench/services/positronConsole/test/browser/submitCode.vitest.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/submitCode.vitest.ts
@@ -180,6 +180,42 @@ describe('PositronConsoleInstance.submitCode', () => {
 		expect(executedCode).toEqual(['2 +\n3']);
 	});
 
+	it('normalizes CRLF line endings before the boundary provider and split', async () => {
+		const { instance, languageFeaturesService } = createInstance(disposables);
+
+		// The boundary provider parses the code line-by-line; a stray carriage
+		// return outside a string is a syntax error, so CRLF input must be
+		// normalized to LF before it reaches the provider (and before the local
+		// split), matching how R normalizes source. Record what the provider is
+		// handed so we can assert it never sees a carriage return.
+		let providerText: string | undefined;
+		disposables.add(languageFeaturesService.inputBoundaryProvider.register(
+			{ language: 'r', scheme: 'inmemory' },
+			{
+				provideInputBoundaries: model => {
+					providerText = model.getValue();
+					return [
+						{ range: { start: 0, end: 2 }, kind: 'complete' },
+						{ range: { start: 2, end: 3 }, kind: 'complete' },
+					];
+				}
+			}
+		));
+
+		const executedCode: string[] = [];
+		disposables.add(instance.onDidExecuteCode(e => executedCode.push(e.code)));
+
+		// A multi-line quoted statement followed by another line, with Windows
+		// CRLF line endings (as an editor selection from a CRLF file produces).
+		await instance.submitCode(
+			`text1 <- 'First line \r\n second line'\r\ntext2 <- ''`,
+			{ source: CodeAttributionSource.Interactive }
+		);
+
+		expect(providerText).not.toContain('\r');
+		expect(executedCode).toEqual([`text1 <- 'First line \n second line'`]);
+	});
+
 	it('shows the continuation prompt when the session reports incomplete code (no provider)', async () => {
 		const { instance, session } = createInstance(disposables);
 


### PR DESCRIPTION
Fixes #15734 (regression from https://github.com/posit-dev/positron/pull/15078)

On Windows (or in CRLF files in general), Running R code with Ctrl+Enter did nothing when the selection held a multi-line quoted string followed by another line: the code was pasted into the Console but never executed.

The cause is line endings. Positron recently started splitting submitted code into complete statements locally, using a provider that parses the code one line at a time. On a CRLF file the editor selection carries carriage returns, and a stray carriage return after a string's closing quote is a syntax error to R's parser. That made the whole statement look incomplete, so the Console left it in the input line instead of running it. 

The fix normalizes line endings to LF before the code is parsed and split. This is how R itself treats source, so the code that actually runs is unchanged.

(There is a related carriage-return bug in Ark's line splitter that deserves its own issue, but normalizing here is needed regardless, because the split happens on the Positron side.)

### Validation Steps

@:console

1. In a file with CRLF line endings (the status bar reads "CRLF"), paste:

```r
text1 <- 'First line
 second line'
text2 <- ''
```

2. Select all and press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>Enter</kbd>. Both statements run in the Console.
3. Confirm the same code with LF endings still runs, and that a genuinely incomplete statement such as `f <- function(` still shows a continuation prompt.
