### PR TITLE
Bump @softwarenerd/deemon-ng from 1.1.0 to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "@openai/codex": "0.142.0",
         "@playwright/cli": "^0.1.9",
         "@playwright/test": "^1.62.1",
-        "@softwarenerd/deemon-ng": "^1.1.0",
+        "@softwarenerd/deemon-ng": "^1.2.0",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
         "@swc/core": "1.3.62",
         "@testing-library/dom": "^10.4.1",
@@ -7690,9 +7690,9 @@
       }
     },
     "node_modules/@softwarenerd/deemon-ng": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@softwarenerd/deemon-ng/-/deemon-ng-1.1.0.tgz",
-      "integrity": "sha512-Lvrvrg5U4yh9mOR070LWgCrxPEN5dL3AwpnsdXAvy4uRx8SO0Qw1lLaH9Y/R2kEFoA1ezYHbrGWN9Ar1SK8VAw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@softwarenerd/deemon-ng/-/deemon-ng-1.2.0.tgz",
+      "integrity": "sha512-4y6ZFNIHlRiQk5ZXfOnaQekYY9wAXEHAdMeGfDiNdcXDXdZG6hmJ6u9LuxYBs5v+WP/6tE4U+wBpPtxj9JdFUA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "@midleman/playwright-reporter": "^0.55.1",
     "@playwright/cli": "^0.1.9",
     "@playwright/test": "^1.62.1",
-    "@softwarenerd/deemon-ng": "^1.1.0",
+    "@softwarenerd/deemon-ng": "^1.2.0",
     "@stylistic/eslint-plugin-ts": "^2.8.0",
     "@types/chrome-remote-interface": "^0.33.0",
     "@swc/core": "1.3.62",


### PR DESCRIPTION
## Summary

Bumps the `@softwarenerd/deemon-ng` dev dependency from `1.1.0` to `1.2.0`. This is the package behind all of the `deemon`-wrapped `watch*d` scripts in `package.json` (`watchd`, `watch-clientd`, `watch-extensionsd`, `watch-e2ed`, and their `kill-*`/`restart-*` counterparts).

The notable change in 1.2.0 is a new `DEEMON_AUTO_KILL` environment variable, which tells a daemon to stop when the terminal session that started it exits. That gives us the option, later, of having the build daemons clean themselves up with the terminal instead of lingering until an explicit `kill-watch*d`. 1.2.0 also fixes the test sandbox leaking the developer's environment. Nothing in this PR changes how Positron invokes `deemon`, so behavior is unchanged unless `DEEMON_AUTO_KILL` is set.

To enable this, add:

```
export DEEMON_AUTO_KILL=true
```

To your `.zshenv` file.

## Release Notes

### New Features

- N/A

### Bug Fixes

- N/A

## QA Notes

Verify the daemon-based watch scripts still start, attach, restart, and kill correctly after `npm install`:

- `npm run watchd` then `npm run kill-watchd`
- `npm run watch-clientd` / `npm run kill-watch-clientd`
- `npm run watch-extensionsd` / `npm run kill-watch-extensionsd`
- `npm run restart-watchd` against a running daemon

Also confirm the `npm run build-*` helpers (`build-ps`, `build-start`, `build-check`, `build-stop`) behave as before.
