### PR TITLE
Skip non executable cells when executing Quarto documents

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -41,7 +41,7 @@ import {
 	WillExecuteEvent,
 } from '../common/quartoExecutionTypes.js';
 import { usingQuartoInlineOutputStatementSplitting } from '../common/positronQuartoConfig.js';
-import { RuntimeOnlineState, RuntimeState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { RuntimeOnlineState, RuntimeState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, ILanguageRuntimeMessageWebOutput, ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { getWebviewMessageType } from '../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 import { DeferredPromise, raceCancellationError, RunOnceScheduler, timeout } from '../../../../base/common/async.js';
 import { CodeAttributionSource, IConsoleCodeAttribution, ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
@@ -227,6 +227,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 		@IMissingPackagesPreflightService private readonly _missingPackagesPreflightService: IMissingPackagesPreflightService,
+		@ILanguageRuntimeService private readonly _languageRuntimeService: ILanguageRuntimeService,
 	) {
 		super();
 
@@ -274,7 +275,16 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		if (isMultiCellExecution) {
 			const textModel = await this._getTextModel(documentUri);
 			if (textModel) {
+				const primaryLanguage = this._documentModelService.getModel(textModel).primaryLanguage;
 				filteredCells = cells.filter(cell => {
+					// Skip diagram/markup cells (mermaid, dot, ...) that have no
+					// way to execute, so one of them can't abort the run.
+					if (!this._isExecutableLanguage(cell.language, primaryLanguage)) {
+						this._logService.debug(
+							`[QuartoExecutionManager] Skipping cell ${cell.id} with non-executable language '${cell.language}'`
+						);
+						return false;
+					}
 					const codeRange = new Range(
 						cell.codeStartLine,
 						1,
@@ -661,6 +671,21 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 
 		this._executionQueue.set(documentUri, executionPromise);
 		return executionPromise;
+	}
+
+	/**
+	 * Whether a cell's language can be executed: the document's primary
+	 * language (kernel), a shell language (terminal), or any language with a
+	 * registered runtime (console). Diagram/markup languages such as mermaid,
+	 * dot, or plantuml match none of these and are treated as non-executable.
+	 */
+	private _isExecutableLanguage(language: string, primaryLanguage: string | undefined): boolean {
+		const lang = language.toLowerCase();
+		if (isShellLanguage(lang) || lang === primaryLanguage?.toLowerCase()) {
+			return true;
+		}
+		return this._languageRuntimeService.registeredRuntimes.some(
+			runtime => runtime.languageId.toLowerCase() === lang);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -18,7 +18,7 @@ import { ILanguageService } from '../../../../../editor/common/languages/languag
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
 import { createModelServices } from '../../../../../editor/test/common/testTextModel.js';
-import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeService } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { QuartoExecutionManager, shouldSkipFirstCommandFinished } from '../../browser/quartoExecutionManager.js';
 import { PromptInputState, IPromptInputModel } from '../../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
@@ -138,6 +138,7 @@ describe('QuartoExecutionManager', () => {
 			stubInterface<IMissingPackagesPreflightService>({
 				confirmBeforeRun: () => Promise.resolve(true),
 			}),
+			asLanguageRuntimeService(['python', 'r']),
 		);
 		ctx.disposables.add(executionManager);
 	});
@@ -257,6 +258,66 @@ describe('QuartoExecutionManager', () => {
 			await executionPromise;
 			expect(executionManager.getExecutionState(first.id)).toBe(CellExecutionState.Error);
 			expect(executionManager.getExecutionState(second.id)).toBe(CellExecutionState.Idle);
+		});
+	});
+
+	describe('Non-executable languages', () => {
+		it('skips diagram cells with no runtime during a multi-cell run (#15819)', async () => {
+			const documentUri = URI.file('/test-mermaid-run-above.qmd');
+			const mermaidCell: QuartoCodeCell = {
+				id: 'mermaid-cell',
+				index: 0,
+				language: 'mermaid',
+				startLine: 1,
+				endLine: 3,
+				codeStartLine: 2,
+				codeEndLine: 2,
+				label: undefined,
+				options: '',
+				contentHash: 'mermaid',
+			};
+			const pythonCell: QuartoCodeCell = {
+				id: 'python-cell',
+				index: 1,
+				language: 'python',
+				startLine: 4,
+				endLine: 6,
+				codeStartLine: 5,
+				codeEndLine: 5,
+				label: undefined,
+				options: '',
+				contentHash: 'python',
+			};
+			const documentLines = [
+				'```{mermaid}',
+				'graph TD; A-->B;',
+				'```',
+				'```{python}',
+				'x = 1',
+				'```',
+			];
+			const mockModel = new MockQuartoDocumentModel([mermaidCell, pythonCell], documentLines);
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			const consoleSpy = vi.spyOn(mockConsoleService, 'executeCode');
+
+			// A "Run Cells Above" gesture including the mermaid cell must run the
+			// python cell rather than aborting on the mermaid cell.
+			const executionPromise = executionManager.executeCells(documentUri, [mermaidCell, pythonCell]);
+			const executionId = await mockKernelManager.waitForExecution();
+			mockSession.receiveStateMessage({
+				parent_id: executionId,
+				state: RuntimeOnlineState.Idle,
+			});
+			await executionPromise;
+
+			expect(consoleSpy).not.toHaveBeenCalled();
+			expect(executionManager.getExecutionState(mermaidCell.id)).toBe(CellExecutionState.Idle);
+			expect(executionManager.getExecutionState(pythonCell.id)).toBe(CellExecutionState.Completed);
 		});
 	});
 
@@ -1305,6 +1366,7 @@ describe('QuartoExecutionManager', () => {
 				stubInterface<IMissingPackagesPreflightService>({
 					confirmBeforeRun: () => Promise.resolve(true),
 				}),
+				asLanguageRuntimeService(['python', 'r']),
 			);
 			ctx.disposables.add(executionManagerWithMock);
 
@@ -1408,6 +1470,7 @@ describe('QuartoExecutionManager', () => {
 				stubInterface<IMissingPackagesPreflightService>({
 					confirmBeforeRun: () => Promise.resolve(true),
 				}),
+				asLanguageRuntimeService(['python', 'r']),
 			);
 			ctx.disposables.add(localExecutionManager);
 
@@ -1945,6 +2008,20 @@ function asTerminalService(mock: MockTerminalService): ITerminalService {
 		// languages, so this branch is never exercised in this file.
 		getActiveOrCreateInstance: mock.getActiveOrCreateInstance.bind(mock) as unknown as ITerminalService['getActiveOrCreateInstance'],
 	});
+}
+
+/**
+ * Build an ILanguageRuntimeService whose registeredRuntimes advertise a runtime
+ * for each of the given language IDs. Used to decide which non-primary cell
+ * languages are executable via the console.
+ */
+function asLanguageRuntimeService(languageIds: string[]): ILanguageRuntimeService {
+	const registeredRuntimes = languageIds.map(languageId => ({
+		...TestLanguageRuntimeMetadata,
+		languageId,
+		runtimeId: `test.runtime.${languageId}`,
+	}));
+	return stubInterface<ILanguageRuntimeService>({ registeredRuntimes });
 }
 
 function asConsoleService(mock: RecordingConsoleService): IPositronConsoleService {


### PR DESCRIPTION
Fixes #15819

With `quarto.inlineOutput.enabled`, the native "Run Cells Above" and "Run Cell and Below" toolbar gestures aborted when one of the cells above was a Mermaid diagram. Positron treated the ```{mermaid}``` block as an ordinary executable cell, tried to run it in a console, and failed with "no registered runtime for the 'mermaid' language". Because cells stop the run on error by default, every cell after the Mermaid cell was left un-run.

The multi-cell run now skips cells whose language cannot be executed. A cell is executable if it is the document's primary language, a shell language, or has a registered runtime. Diagram and markup languages such as mermaid, dot, and plantuml match none of these and are passed over, matching what the Quarto extension's "Run All" already does. Single-cell runs are unchanged, since running one cell is an explicit action.

### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Fixed "Run Cells Above" and "Run Cell and Below" aborting on a Mermaid cell when inline output is enabled (#15819)

### Validation Steps

@:quarto

1. Set `quarto.inlineOutput.enabled: true`.
2. Open a `.qmd` with several Python cells and a ```{mermaid}``` cell in the middle.
3. Put the cursor in a cell below the Mermaid cell and run "Run Cells Above".
4. Verify all Python cells above run in order and the Mermaid cell is skipped rather than stopping the run.
