### PR TITLE
e2e: remove all three zypper repo files on pro-drivers teardown

### DIFF
--- a/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
+++ b/test/e2e/tests/workbench/pro-drivers/pro-drivers-odbc-discovery.test.ts
@@ -160,7 +160,14 @@ function packageCommands(manager: PackageManager): { addRepo: string; install: s
 				// that --non-interactive answers with "no".
 				install: `${ZYPPER} --no-gpg-checks install rstudio-drivers`,
 				remove: `${ZYPPER} remove rstudio-drivers`,
-				repoFiles: ['/etc/zypp/repos.d/posit-pro.repo'],
+				// Globbed because `zypper ar` writes one file per alias, and the setup script adds
+				// three (posit-pro, posit-pro-noarch, posit-pro-source). Removing only the first
+				// leaves the other two, and the next `addRepo` in that container then dies with
+				// "Repository named posit-pro-noarch already exists" -- surfaced by the setup
+				// script's catch-all as "Could not install the repository, do you have
+				// permissions?", which masks the real failure on a retry. Rocky needs no glob: dnf
+				// writes all three sections into a single posit-pro.repo.
+				repoFiles: ['/etc/zypp/repos.d/posit-pro*.repo'],
 			};
 	}
 }


### PR DESCRIPTION
Teardown in the Pro Drivers suite removed one zypper repo file when the Posit setup script writes three, so the repo was never actually cleaned on the SUSE family.

### Summary

`zypper ar` writes one file per alias, and `setup.rpm.sh` adds three aliases:

```
/etc/zypp/repos.d/posit-pro.repo
/etc/zypp/repos.d/posit-pro-noarch.repo
/etc/zypp/repos.d/posit-pro-source.repo
```

`packageCommands('zypper')` listed only the first. The other two survived teardown, and since zypper refuses to add a repo whose name is already registered, the next `addRepo` in that container failed. The setup script reports any failure at that step through a catch-all `die`, so what surfaced was:

```
Could not install the repository, do you have permissions?
```

That is not a permissions problem, and it is actively misleading: on a Playwright retry, `beforeAll` re-runs, hits the leftover repos, and this message overwrites the honest failure in the summary output. It is why the openSUSE lane in positron-builds read as a repo/setup problem when the real failure was a discovery timeout (`expectConnectionDetected`) against a Positron daily that predated the `/etc/unixODBC` addition to `SYSTEM_CONFIG_DIRS` in #15895.

Verified in `ghcr.io/posit-dev/positron-opensuse156:24.18.0`, adding the repo then simulating each cleanup:

| cleanup | left behind | re-add exit |
| --- | --- | --- |
| `posit-pro.repo` (before) | `posit-pro-noarch.repo`, `posit-pro-source.repo` | 1 |
| `posit-pro*.repo` (after) | nothing | 0 |

Rocky needs no equivalent change, and I confirmed that rather than assuming it: `dnf config-manager` writes all three sections into a single `posit-pro.repo`, so deleting that one file is already complete there.

**This does not make the positron-builds openSUSE lane pass.** That failure is version skew and self-heals once a daily ships containing #15895 -- positron's own lanes build Positron from the branch, so they already have the fix, while positron-builds installs the latest published daily. This change only stops the real error from being masked next time.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:workbench-suse

Note that a green lane here does not by itself exercise the fix: in a clean container the first `addRepo` succeeds either way, and the bug only appears on a second run in the same container. The evidence for the fix is the before/after table above, reproduced directly in the openSUSE image. The lane is here to confirm no regression on the SUSE path.
