### PR TITLE
Speed up rebuild.sh by staging node_modules aside and deleting them in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,4 +97,8 @@ dist
 # ci-arm dev container local secrets
 .devcontainer/ci-arm/.env
 .devcontainer/ci-arm/license.txt
+# Staging folders rebuild.sh moves the old node_modules trees into before
+# deleting them in the background. Present while rebuild.sh runs, and left
+# behind if a run is interrupted before the deletion finishes.
+.rebuild-trash.*
 # --- End Positron ---

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -31,11 +31,95 @@ case "${proceed}" in
 ;;
 esac
 
+# Staging folders for the old 'node_modules' folders are named with this prefix
+# plus a random suffix, so concurrent or successive runs never collide. 'trash'
+# is this run's folder; 'trash_pid' is the background job deleting them.
+trash_prefix=".rebuild-trash."
+trash=""
+trash_pid=""
+
+# Is there anything staged for deletion, from this run or an earlier one?
+trash_exists() {
+	for dir in "${trash_prefix}"*; do
+		[ -d "${dir}" ] && return 0
+	done
+	return 1
+}
+
+# Delete the contents of every staging folder in parallel, then the folders.
+#
+# This deliberately sweeps *all* staging folders, not just this run's, so a
+# rebuild that was interrupted hard enough to strand one gets cleaned up by the
+# next rebuild. 'rmdir' rather than 'rm -rf' for the folder itself: if anything
+# inside it survived, the folder stays behind and the next run retries it.
+#
+# The subshell ignores the interrupts sent to the rest of the script, so an
+# aborted run still finishes cleaning up instead of stranding ~700,000 files.
+# The folders disappearing doubles as the "still working" indicator.
+start_trash_removal() {
+	trash_exists || return 0
+	(
+		trap '' HUP INT TERM
+		for dir in "${trash_prefix}"*; do
+			[ -d "${dir}" ] || continue
+			find "${dir}" -mindepth 1 -maxdepth 1 -print0 \
+				| xargs -0 -n 1 -P 8 rm -rf
+			rmdir "${dir}" 2>/dev/null
+		done
+	) &
+	trash_pid=$!
+}
+
+# Leave the tree in a known state if the user gives up part way through.
+on_interrupt() {
+	echo
+	if [ -n "${trash_pid}" ] || trash_exists; then
+		# Interrupted before the deletion started? Start it now, so the folders
+		# already moved aside do not linger.
+		[ -n "${trash_pid}" ] || start_trash_removal
+		echo "Aborted. The old node_modules folders are still being deleted in the"
+		echo "background; the '${trash_prefix}*' folders disappear once that finishes."
+	else
+		echo "Aborted."
+	fi
+	exit 130
+}
+trap on_interrupt HUP INT TERM
+
 # Kill any running deemons.
 npm run build-stop
 
 # Remove any existing node_modules folders.
-git ls-files --directory -i -o -x node_modules | xargs rm -rf
+#
+# There are dozens of these, holding many hundreds of thousands of small files
+# between them, and both figures only grow. Deletion costs per directory entry
+# rather than per byte, so a straight 'rm -rf' works through all of them one
+# serial unlink() at a time, making it far and away the slowest step here.
+# Renaming a directory within the same volume is O(1) no matter how much is
+# inside it, though, so move every tree into one staging directory (instant),
+# then delete that directory in parallel in the background while 'npm install'
+# runs. The deletion is metadata-bound rather than bandwidth-bound, so it
+# parallelizes well and overlaps happily with the install.
+#
+# The 'grep' matters: with '--directory', 'git ls-files' also reports the
+# *ancestors* of an ignored folder (a 'pkg/' entry alongside 'pkg/node_modules/')
+# whenever that ancestor holds no tracked files. Feeding those straight to 'rm'
+# would delete the parent folder too, so keep only the 'node_modules' entries.
+# Nothing is lost by filtering, because every folder is also listed in full.
+trash=$(mktemp -d "${trash_prefix}XXXXXXXXXX") || exit 1
+git ls-files --directory -i -o -x node_modules \
+	| sed 's|/$||' \
+	| grep -E '(^|/)node_modules$' > "${trash}/folders"
+
+n=0
+while read -r folder; do
+	n=$((n + 1))
+	mv "${folder}" "${trash}/${n}"
+done < "${trash}/folders"
+rm -f "${trash}/folders"
+echo "Moved ${n} node_modules folder(s) aside; deleting them in the background."
+
+start_trash_removal
 
 # Remove the build directory.
 rm -rf .build
@@ -57,5 +141,15 @@ npm install
 # Run 'npm install' for e2e tests.
 echo "Installing e2e test dependencies..."
 npm --prefix test/e2e install
+
+# Wait for the background deletion of the old 'node_modules' folders. By now it
+# has almost certainly finished during the installs above. It removes the
+# staging folders itself, so there is nothing left to clean up here.
+if [ -n "${trash_pid}" ]; then
+	echo "Waiting for the old node_modules folders to finish deleting..."
+	wait "${trash_pid}"
+fi
+
+trap - HUP INT TERM
 
 echo "Done"

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -142,6 +142,11 @@ npm install
 echo "Installing e2e test dependencies..."
 npm --prefix test/e2e install
 
+# Everything that had to happen has happened, so stop treating an interrupt as
+# an abort. Only the background deletion is still outstanding, and it cleans up
+# after itself whether or not we stick around to watch.
+trap - HUP INT TERM
+
 # Wait for the background deletion of the old 'node_modules' folders. By now it
 # has almost certainly finished during the installs above. It removes the
 # staging folders itself, so there is nothing left to clean up here.
@@ -149,7 +154,5 @@ if [ -n "${trash_pid}" ]; then
 	echo "Waiting for the old node_modules folders to finish deleting..."
 	wait "${trash_pid}"
 fi
-
-trap - HUP INT TERM
 
 echo "Done"


### PR DESCRIPTION
Running `rebuild.sh` on my machine took **5 minutes 49 seconds**, and **28% of that time** (~1 minute 38 seconds) was spent recursively removing `node_modules` folders so `npm install` could rebuild them. This PR cuts the total to **4 minutes 29 seconds**, roughly **23% faster**.

## Why it was slow

Not `git ls-files` — that enumerates the folders in about 0.6 seconds. All of the time was in `rm -rf`. There are dozens of `node_modules` folders holding many hundreds of thousands of generally small files between them, and deletion costs per directory entry rather than per byte, so the old one-liner worked through every one of those entries with a serial `unlink()`. Piping to a bare `xargs` made it worse by handing all the paths to a single `rm` process.

## The approach

Instead of deleting the folders in place, the script now renames each one into a randomly-named staging folder at the repo root (`.rebuild-trash.XXXXXXXXXX`, created with `mktemp -d`). A rename within the same volume is O(1) no matter how much is inside the folder, so this part is instant. The actual deletion then happens in a background job that works through the staged folders in parallel (`xargs -P 8`), overlapping the removal work with `npm install` instead of blocking it. The script `wait`s for it at the very end, by which point it has almost always already finished.

The deletion no longer sits on the critical path: what used to be a ~1 minute 38 second serial step is now a set of near-instant renames plus a background job that runs while npm install does. End to end that is worth 1 minute 20 seconds.

## It also fixes a latent bug

Worth calling out separately, because it is a correctness fix rather than a performance one. With `--directory`, `git ls-files` also reports the *ancestor* of an ignored folder whenever that ancestor holds no tracked files — a `pkg/` entry alongside `pkg/node_modules/`. Piped straight into `rm -rf`, that deletes the parent folder too, not just the `node_modules` inside it. The repo escapes this today only because every parent of a `node_modules` happens to contain at least one tracked file. The new code filters the listing down to entries that actually end in `node_modules`, and nothing is lost by filtering, because git lists every folder in full alongside the ancestor entry.

I also tried enumerating with `find` instead of git and rejected it: `find` picks up `extensions/css-language-features/server/test/linksTestFixtures/node_modules`, which is tracked test data. Staying with git's ignored-only listing keeps that safe, and I verified the new pipeline selects exactly the same set of folders as the old command did.

## Interrupt handling

Ctrl-C during a rebuild previously left whatever `rm -rf` was mid-way through in a half-deleted state, with nothing to clean it up. Now:

- A `trap` covers `HUP`, `INT` and `TERM`, and the background deleter ignores those signals itself, so Ctrl-C returns immediately while cleanup still runs to completion rather than stranding a partially-deleted tree.
- The sweep covers *all* `.rebuild-trash.*` folders, not just the current run's, so anything stranded by a hard kill or a reboot gets collected by the next rebuild.
- The staging folder is removed with `rmdir` rather than `rm -rf`, so if anything inside it somehow survives, the folder deliberately stays behind for the next run to retry instead of vanishing over orphaned files.
- The window where a run is interrupted after folders have been moved aside but before the deleter launched is covered too: the trap starts the deleter in that case.

One deliberate design choice: on abort the deletion **continues in the background** rather than being killed. Killing it would strand perhaps hundreds of thousands of files, and deleting synchronously in the trap would reintroduce exactly the multi-minute wait this change exists to remove.

## Deliberately unchanged

The other `rm -rf` calls (`.build`, the Ark target directories, and the prebuilt Ark and Kallichore binaries) are left as they are. They come to roughly 5,450 directory entries between them against hundreds of thousands for `node_modules`, which is well under a second of work, and `ark/target/release` being much the largest by size is irrelevant given that cost tracks entries rather than bytes. Folding them into the staging machinery would mean hoisting them above the staging call and adding existence guards for each, for no measurable gain.

The `node_modules` folders inside the `ai-lib` submodule are still skipped, exactly as before, since the outer `git ls-files` cannot see into a submodule. That is pre-existing behaviour rather than something this PR changes, but it may be worth a separate look if the root `npm install` is meant to manage them.

## Testing

The timings above are from real runs on macOS. The interrupt and sweep behaviour was verified against throwaway git fixtures rather than a real tree, since several of the cases are destructive:

| Scenario | Result |
| --- | --- |
| Normal run | Staged folders deleted, staging folder removed, exit 0 |
| Ctrl-C during `npm install` | Exits 130 immediately; deleter survives and self-cleans |
| Ctrl-C after moves, before the deleter starts | Trap starts the deleter; nothing left behind |
| Ctrl-C before the staging folder exists | Plain `Aborted.`, no staging folder created |
| Stranded staging folders from an earlier run | Swept by the next run, alongside its own |
| Ancestor-deletion case | Parent folders preserved, and a tracked `node_modules` fixture preserved |

Only exercised on macOS. The constructs used (`mktemp -d` with a relative template, `find -mindepth`/`-maxdepth`, `xargs -0 -P`) are available in both BSD and GNU userlands, and the script already required bash for `read -p`.
