### PR TITLE
ci(memory): break down kernel memory by language in the memory reports

### DIFF
--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -331,8 +331,7 @@ jobs:
           rm package.json
           echo '{}' > package.json
 
-          # --no-audit --no-fund: two extra registry round-trips this job has no
-          # use for, and round-trips are what makes this install slow.
+          # Two more registry round-trips whose output this job never reads.
           npm install --no-audit --no-fund $SPECS
           npm --prefix test/e2e run compile -- -p tsconfig.summarize.json
 

--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -296,23 +296,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Deliberately NOT ./.github/actions/setup-e2e-test-dependencies, which the
-      # memory matrix job uses: that installs the whole Playwright toolchain and
-      # downloads the browser binaries, and this job renders one HTML file from
-      # JSON on disk. It never launches a browser. Seven npm installs inside a
-      # 10-minute budget is also how this job died twice in run 33813858347, on a
-      # night the registry was slow: one install took 7 minutes on its own.
-      #
-      # summarize-cli's import closure is Node builtins, so TypeScript and
-      # @types/node compile it. tsconfig.summarize.json compiles that closure and
-      # nothing else, and fails loudly if an import ever reaches past it.
+      # Not ./.github/actions/setup-e2e-test-dependencies: this job renders one
+      # HTML file from JSON on disk, so it needs tsc, not the Playwright toolchain.
       - name: Compile the summarizer
         run: |
-          # From the root package.json rather than restated, for the same reason
-          # the setup action reads it there: a hardcoded range drifts. The name
-          # matters as well as the version -- `typescript` is aliased to
-          # @typescript/typescript6, whose bin is `tsc6` rather than `tsc`, which
-          # is what test/e2e's compile script invokes by path.
+          # Ranges from the root package.json so a hardcoded one can't drift; the
+          # name matters too, since `typescript` is aliased and its bin is `tsc6`.
           SPECS=$(node -e '
             const pkg = require("./package.json");
             const ranges = { ...pkg.dependencies, ...pkg.devDependencies };
@@ -325,9 +314,7 @@ jobs:
             console.log(names.map((n) => n + "@" + ranges[n]).join(" "));
           ')
 
-          # Same stub swap the setup action does: `npm install <pkg>` in the repo
-          # root would otherwise install the product's entire dependency tree
-          # before getting to the two packages this job asked for.
+          # Otherwise npm install here builds the product's whole dependency tree.
           rm package.json
           echo '{}' > package.json
 

--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -296,11 +296,43 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Compiles test/e2e, which is where summarize-cli.ts lives. Same action
-      # the memory job uses, so the compiled output this job runs is built the
-      # same way.
-      - name: Setup test dependencies and compile tests
-        uses: ./.github/actions/setup-e2e-test-dependencies
+      # Deliberately NOT ./.github/actions/setup-e2e-test-dependencies, which the
+      # memory matrix job uses: that installs the whole Playwright toolchain and
+      # downloads the browser binaries, and this job renders one HTML file from
+      # JSON on disk. It never launches a browser. Seven npm installs inside a
+      # 10-minute budget is also how this job died twice in run 33813858347, on a
+      # night the registry was slow: one install took 7 minutes on its own.
+      #
+      # summarize-cli's import closure is Node builtins, so TypeScript and
+      # @types/node compile it. tsconfig.summarize.json compiles that closure and
+      # nothing else, and fails loudly if an import ever reaches past it.
+      - name: Compile the summarizer
+        run: |
+          # From the root package.json rather than restated, for the same reason
+          # the setup action reads it there: a hardcoded range drifts. The name
+          # matters as well as the version -- `typescript` is aliased to
+          # @typescript/typescript6, whose bin is `tsc6` rather than `tsc`, which
+          # is what test/e2e's compile script invokes by path.
+          SPECS=$(node -e '
+            const pkg = require("./package.json");
+            const ranges = { ...pkg.dependencies, ...pkg.devDependencies };
+            const names = ["typescript", "@types/node"];
+            const missing = names.filter((n) => !ranges[n]);
+            if (missing.length) {
+              console.error("not declared in the root package.json: " + missing.join(", "));
+              process.exit(1);
+            }
+            console.log(names.map((n) => n + "@" + ranges[n]).join(" "));
+          ')
+
+          # Same stub swap the setup action does: `npm install <pkg>` in the repo
+          # root would otherwise install the product's entire dependency tree
+          # before getting to the two packages this job asked for.
+          rm package.json
+          echo '{}' > package.json
+
+          npm install $SPECS
+          npm --prefix test/e2e run compile -- -p tsconfig.summarize.json
 
       # Downloads every memory-report-<lane>-<scenario> artifact that was
       # uploaded, each into its own subdirectory named after the artifact --

--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -331,7 +331,9 @@ jobs:
           rm package.json
           echo '{}' > package.json
 
-          npm install $SPECS
+          # --no-audit --no-fund: two extra registry round-trips this job has no
+          # use for, and round-trips are what makes this install slow.
+          npm install --no-audit --no-fund $SPECS
           npm --prefix test/e2e run compile -- -p tsconfig.summarize.json
 
       # Downloads every memory-report-<lane>-<scenario> artifact that was

--- a/test/e2e/tsconfig.summarize.json
+++ b/test/e2e/tsconfig.summarize.json
@@ -1,0 +1,24 @@
+{
+	// Compiles only summarize-cli.ts and whatever it imports, for the nightly
+	// Memory Metrics summarize job.
+	//
+	// That job used to run the full e2e setup action -- seven npm installs plus
+	// the Playwright browser binaries -- to render one HTML file from JSON on
+	// disk, and twice hit its 10-minute budget mid-install (run 33813858347).
+	// summarize-cli's import closure is Node builtins only, so TypeScript and
+	// @types/node are the whole toolchain it needs.
+	//
+	// `files` rather than `include`: tsc pulls the closure in through the
+	// imports, so this stays correct as the closure changes, and an import that
+	// reaches a package the job does not install fails the compile loudly rather
+	// than at render time.
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"types": [
+			"node"
+		]
+	},
+	"files": [
+		"utils/memory/summarize-cli.ts"
+	]
+}

--- a/test/e2e/utils/memory/kernel.ts
+++ b/test/e2e/utils/memory/kernel.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Per-language decomposition of the `kernel` role.
+ *
+ * A lot of a session scenario's memory is the kernel itself, and the role table
+ * reports it as one flat figure while the process tree reports it as unaggregated
+ * pids. This is the middle view the extension host already has: the role's total,
+ * split by which language runtime holds it.
+ *
+ * Pure functions only, like the rest of the report modules: no I/O, so both the
+ * per-scenario report and the scenario summary can build their own tables from
+ * these without either owning the mapping.
+ */
+
+import { LabeledProcess, MemorySnapshot, ProcessRole } from './types.js';
+
+/**
+ * The only role in scope.
+ *
+ * `kernel_supervisor` (kcserver, the supervisor wrapper script) and
+ * `language_server` (ruff, tsserver, Quarto's LSP) are adjacent roles and
+ * deliberately excluded: restricting to `kernel` is what keeps these figures
+ * summing to a row the role table already shows, rather than double-counting
+ * against two of them.
+ */
+const KERNEL_ROLE: ProcessRole = 'kernel';
+
+export const KERNEL_LABEL_ARK = 'R (ark)';
+export const KERNEL_LABEL_PYTHON = 'Python';
+export const KERNEL_LABEL_UNKNOWN = 'unknown';
+
+/**
+ * Maps a kernel process's command basename to a stable series label.
+ *
+ * The twin of `kernel_label_for()` in the dashboard's
+ * `src/helpers/kernel_trend_helpers.R`, which derives the same labels from the
+ * same `cmd_basename` field of the published payload. The two must agree: the
+ * dashboard stores the label rather than deriving it at read time, so a
+ * disagreement is repaired by a re-backfill, not a redeploy. The sum-invariant
+ * test in `render.vitest.ts` is the alarm for our half drifting.
+ *
+ * Only the basename is available, so the Python kernel arrives as `python3`, or
+ * `python3.11` depending on the runner image. Matching any `^python` under this
+ * role means an image bump cannot silently fork one series into two.
+ *
+ * An unmapped basename appears as itself rather than being swallowed into an
+ * "other" bucket, so a kernel we have never measured shows up the first night it
+ * runs -- unnamed, but visible.
+ */
+export function kernelLabelFor(cmdBasename: string): string {
+	if (cmdBasename === '') {
+		return KERNEL_LABEL_UNKNOWN;
+	}
+	if (cmdBasename === 'ark') {
+		return KERNEL_LABEL_ARK;
+	}
+	if (cmdBasename.startsWith('python')) {
+		return KERNEL_LABEL_PYTHON;
+	}
+	return cmdBasename;
+}
+
+function kernelProcesses(snapshot: MemorySnapshot): LabeledProcess[] {
+	return snapshot.processes.filter(proc => proc.processRole === KERNEL_ROLE);
+}
+
+/**
+ * One launch's kernel PSS per label, in first-seen order. Empty for a scenario
+ * that starts no session, which is what lets the callers omit the whole section
+ * rather than render an empty table.
+ */
+export function kernelTotals(snapshot: MemorySnapshot): Map<string, number> {
+	const totals = new Map<string, number>();
+	for (const proc of kernelProcesses(snapshot)) {
+		const label = kernelLabelFor(proc.cmdBasename);
+		totals.set(label, (totals.get(label) ?? 0) + proc.pssBytes);
+	}
+	return totals;
+}
+
+/**
+ * How many processes each label's figure adds up, at its highest across
+ * launches.
+ *
+ * The max rather than a median: the count is shown to warn that a figure is a
+ * sum, and a launch that spawned a second kernel is exactly what the reader
+ * needs told, not a value it can be averaged out of.
+ */
+export function kernelProcessCounts(snapshots: MemorySnapshot[]): Map<string, number> {
+	const counts = new Map<string, number>();
+	for (const snapshot of snapshots) {
+		const perLaunch = new Map<string, number>();
+		for (const proc of kernelProcesses(snapshot)) {
+			const label = kernelLabelFor(proc.cmdBasename);
+			perLaunch.set(label, (perLaunch.get(label) ?? 0) + 1);
+		}
+		for (const [label, count] of perLaunch) {
+			counts.set(label, Math.max(counts.get(label) ?? 0, count));
+		}
+	}
+	return counts;
+}

--- a/test/e2e/utils/memory/kernel.vitest.ts
+++ b/test/e2e/utils/memory/kernel.vitest.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, test } from 'vitest';
+import { KERNEL_LABEL_ARK, KERNEL_LABEL_PYTHON, KERNEL_LABEL_UNKNOWN, kernelLabelFor, kernelProcessCounts, kernelTotals } from './kernel.js';
+import { LabeledProcess, MemorySnapshot } from './types.js';
+
+const MB = 1024 * 1024;
+
+const proc = (overrides: Partial<LabeledProcess> = {}): LabeledProcess => ({
+	pid: 100, ppid: 1, depth: 0, processName: 'positron', processRole: 'main',
+	labeled: true, cmdBasename: 'positron', pssBytes: 100 * MB, rssBytes: 200 * MB,
+	pssMin: 100 * MB, pssMax: 100 * MB,
+	pssSamples: [100 * MB], rssSamples: [200 * MB],
+	forcedGc: false,
+	...overrides
+});
+
+const snapshot = (procs: LabeledProcess[], launchIndex = 0): MemorySnapshot => ({
+	scenario: 'session-r', lane: 'desktop', capturedAt: '2026-08-11T00:00:00.000Z',
+	positronVersion: '2026.09.0-35', launchIndex, settleMs: 12_000,
+	treeTotalPssBytes: procs.reduce((sum, p) => sum + p.pssBytes, 0),
+	processes: procs, extensions: []
+});
+
+describe('kernelLabelFor', () => {
+	// These four expectations are the wire contract with the dashboard's
+	// kernel_label_for(): it stores the label it derives, so a disagreement here
+	// costs a re-backfill to repair rather than a redeploy.
+	test('maps ark to the R kernel label', () => {
+		expect(kernelLabelFor('ark')).toBe(KERNEL_LABEL_ARK);
+	});
+
+	// The whole point of the prefix match: the runner image's python3.11 becoming
+	// python3.12 must not fork one series into two.
+	test('maps every python basename to one label', () => {
+		expect(kernelLabelFor('python')).toBe(KERNEL_LABEL_PYTHON);
+		expect(kernelLabelFor('python3')).toBe(KERNEL_LABEL_PYTHON);
+		expect(kernelLabelFor('python3.11')).toBe(KERNEL_LABEL_PYTHON);
+		expect(kernelLabelFor('python3.13')).toBe(KERNEL_LABEL_PYTHON);
+	});
+
+	// Deliberately not an "other" bucket: a kernel we have never seen shows up
+	// the first night it runs, unnamed but visible.
+	test('leaves an unmapped basename as itself', () => {
+		expect(kernelLabelFor('julia')).toBe('julia');
+	});
+
+	test('calls an empty basename unknown, so no row is keyed on a blank', () => {
+		expect(kernelLabelFor('')).toBe(KERNEL_LABEL_UNKNOWN);
+	});
+});
+
+describe('kernelTotals', () => {
+	test('sums kernel-role PSS by label', () => {
+		const totals = kernelTotals(snapshot([
+			proc(),
+			proc({ pid: 200, processRole: 'kernel', cmdBasename: 'ark', pssBytes: 180 * MB }),
+			proc({ pid: 201, processRole: 'kernel', cmdBasename: 'python3', pssBytes: 90 * MB })
+		]));
+		expect([...totals]).toEqual([[KERNEL_LABEL_ARK, 180 * MB], [KERNEL_LABEL_PYTHON, 90 * MB]]);
+	});
+
+	test('folds two processes sharing a label into one figure', () => {
+		const totals = kernelTotals(snapshot([
+			proc({ pid: 200, processRole: 'kernel', cmdBasename: 'python3', pssBytes: 90 * MB }),
+			proc({ pid: 201, processRole: 'kernel', cmdBasename: 'python3.11', pssBytes: 60 * MB })
+		]));
+		expect(totals.get(KERNEL_LABEL_PYTHON)).toBe(150 * MB);
+	});
+
+	// Restricting to `kernel` is what keeps these figures summing to a band the
+	// dashboard already shows. kcserver and the language servers are adjacent
+	// roles with their own rows in the role table.
+	test('excludes the supervisor and language-server roles', () => {
+		const totals = kernelTotals(snapshot([
+			proc({ pid: 200, processRole: 'kernel_supervisor', cmdBasename: 'kcserver', pssBytes: 30 * MB }),
+			proc({ pid: 201, processRole: 'language_server', cmdBasename: 'ruff', pssBytes: 20 * MB })
+		]));
+		expect(totals.size).toBe(0);
+	});
+
+	test('is empty for a scenario that starts no kernel', () => {
+		expect(kernelTotals(snapshot([proc()])).size).toBe(0);
+	});
+});
+
+describe('kernelProcessCounts', () => {
+	test('counts the processes one label covers', () => {
+		const counts = kernelProcessCounts([snapshot([
+			proc({ pid: 200, processRole: 'kernel', cmdBasename: 'python3' }),
+			proc({ pid: 201, processRole: 'kernel', cmdBasename: 'python3.11' }),
+			proc({ pid: 202, processRole: 'kernel', cmdBasename: 'ark' })
+		])]);
+		expect(counts.get(KERNEL_LABEL_PYTHON)).toBe(2);
+		expect(counts.get(KERNEL_LABEL_ARK)).toBe(1);
+	});
+
+	// The max rather than the median or the first launch: the column exists to
+	// warn that a figure is a sum, and a launch that spawned a second kernel is
+	// exactly what a reader needs told.
+	test('takes the highest count across launches', () => {
+		const counts = kernelProcessCounts([
+			snapshot([proc({ pid: 200, processRole: 'kernel', cmdBasename: 'ark' })], 0),
+			snapshot([
+				proc({ pid: 200, processRole: 'kernel', cmdBasename: 'ark' }),
+				proc({ pid: 201, processRole: 'kernel', cmdBasename: 'ark' })
+			], 1)
+		]);
+		expect(counts.get(KERNEL_LABEL_ARK)).toBe(2);
+	});
+});

--- a/test/e2e/utils/memory/publish.ts
+++ b/test/e2e/utils/memory/publish.ts
@@ -335,7 +335,13 @@ export type BaselineResponse =
 		snapshot: {
 			tree_total_pss_bytes: number;
 			settle_ms: number;
-			processes: { process_name: string; process_role: string; pss_bytes: number }[];
+			/**
+			 * `cmd_basename` is optional because the API gained it after this client
+			 * shipped (posit-dev/e2e-test-insights#241): a baseline stored by the
+			 * older route carries no such field, and treating its absence as an error
+			 * would throw away an otherwise usable baseline.
+			 */
+			processes: { process_name: string; process_role: string; cmd_basename?: string; pss_bytes: number }[];
 			extensions: { extension_id: string; activation_event: string | null }[];
 		};
 	};
@@ -389,7 +395,11 @@ export function baselineToSnapshot(body: BaselineResponse, scenario: MemoryScena
 			// knows it would otherwise become an invalid ProcessRole at runtime and
 			// fall through every switch downstream.
 			processRole: isProcessRole(p.process_role) ? p.process_role : 'unlabeled',
-			labeled: true, cmdBasename: '',
+			labeled: true,
+			// Empty when the response predates the field. `kernelLabelFor` reads that
+			// as `unknown`, and the kernel card leaves its per-label changes blank
+			// rather than reporting every language as new.
+			cmdBasename: typeof p.cmd_basename === 'string' ? p.cmd_basename : '',
 			// The response carries no such field and the report reads it for neither
 			// side of the delta, so this is neutral rather than a claim -- the same
 			// reasoning as `labeled: true` above.

--- a/test/e2e/utils/memory/publish.vitest.ts
+++ b/test/e2e/utils/memory/publish.vitest.ts
@@ -307,6 +307,35 @@ describe('baselineToSnapshot', () => {
 		expect(mapped?.processes[0].processRole).toBe('kernel');
 	});
 
+	test('carries cmd_basename through, so a kernel can be diffed per language', () => {
+		const mapped = baselineToSnapshot({
+			found: true,
+			...baselineProvenance,
+			snapshot: {
+				tree_total_pss_bytes: 1000, settle_ms: 5000,
+				processes: [{ process_name: 'positron-r (ark)', process_role: 'kernel', cmd_basename: 'ark', pss_bytes: 40 }],
+				extensions: []
+			}
+		}, 'idle');
+		expect(mapped?.processes[0].cmdBasename).toBe('ark');
+	});
+
+	// The API gained the field after this client shipped, so a baseline stored by
+	// the older route has none. Blank keeps that baseline usable: the kernel card
+	// leaves its per-label changes blank rather than reporting every kernel new.
+	test('reads a missing cmd_basename as blank rather than rejecting the baseline', () => {
+		const mapped = baselineToSnapshot({
+			found: true,
+			...baselineProvenance,
+			snapshot: {
+				tree_total_pss_bytes: 1000, settle_ms: 5000,
+				processes: [{ process_name: 'positron-r (ark)', process_role: 'kernel', pss_bytes: 40 }],
+				extensions: []
+			}
+		}, 'idle');
+		expect(mapped?.processes[0].cmdBasename).toBe('');
+	});
+
 	test('fills unmapped numbers with zero rather than plausible values', () => {
 		const mapped = baselineToSnapshot({
 			found: true,

--- a/test/e2e/utils/memory/render.ts
+++ b/test/e2e/utils/memory/render.ts
@@ -3,7 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { deltaHtml, escapeHtml, formatBytes, GC_NOTE, KB, notSteadyStateCardHtml, REPORT_CSS, signed } from './report-shell.js';
+import { kernelProcessCounts, kernelTotals } from './kernel.js';
+import { deltaHtml, deltaHtmlFromDiff, escapeHtml, formatBytes, GC_NOTE, KB, notSteadyStateCardHtml, REPORT_CSS, signed } from './report-shell.js';
 import { unstableProcesses } from './snapshot.js';
 import { ActivatedExtension, ExtensionHeapBreakdown, ExtensionHeapStatus, LabeledProcess, MemorySnapshot, ProcessRole } from './types.js';
 
@@ -356,6 +357,93 @@ export function extensionHeapRows(
 	return rows;
 }
 
+/**
+ * One kernel language's share of the `kernel` role, or the summed TOTAL.
+ *
+ * Shaped like {@link ExtensionHeapRow} rather than reusing it: the two tables
+ * render the same way, but a kernel row carries a process count and an
+ * extension row carries an id, and one type holding both would let either
+ * table render a field the other filled in.
+ */
+export type KernelRow = {
+	/** A label from `kernelLabelFor`, or `TOTAL` on the summed row. */
+	label: string;
+	bytes: number;
+	/** How many processes this figure adds up, at its highest across launches. */
+	processCount: number;
+	/** The rendered change for the markdown table: blank, "new", or a signed figure. */
+	change: string;
+	/** The same change unrendered, for the HTML card's glyph and class. Undefined when there is nothing to compare against. */
+	changeBytes?: number;
+	isTotal?: boolean;
+};
+
+const KERNEL_TOTAL_ROW = 'TOTAL';
+
+/**
+ * Median PSS per kernel label across launches, largest first, with a summed
+ * TOTAL when there is more than one label.
+ *
+ * Empty for a scenario that starts no session, which is what makes the whole
+ * card omissible rather than an empty table a reader has to read as "no
+ * kernel" instead of "the measurement failed".
+ *
+ * A label absent from a launch counts as zero for that launch, the same
+ * zero-filling `byRole` does and for the same reason.
+ */
+export function kernelRows(snapshots: MemorySnapshot[], baseline?: MemorySnapshot): KernelRow[] {
+	const perLaunch = snapshots.map(kernelTotals);
+	const labels = new Set(perLaunch.flatMap(totals => [...totals.keys()]));
+	if (labels.size === 0) {
+		return [];
+	}
+	const counts = kernelProcessCounts(snapshots);
+	const baselineTotals = baseline ? kernelTotals(baseline) : undefined;
+
+	// Blank rather than "new" everywhere when the baseline had no kernel at all:
+	// that is the first night, or a baseline captured from a scenario that starts
+	// no session, not a night the kernels appeared.
+	const changeFor = (label: string, bytes: number): Pick<KernelRow, 'change' | 'changeBytes'> => {
+		if (baselineTotals === undefined || baselineTotals.size === 0) {
+			return { change: '' };
+		}
+		const before = baselineTotals.get(label);
+		if (before === undefined) {
+			return { change: 'new' };
+		}
+		return { change: signed(bytes - before), changeBytes: bytes - before };
+	};
+
+	const rows: KernelRow[] = [...labels]
+		.map(label => ({ label, bytes: median(perLaunch.map(totals => totals.get(label) ?? 0)) }))
+		.sort((a, b) => b.bytes - a.bytes)
+		.map(({ label, bytes }) => ({ label, bytes, processCount: counts.get(label) ?? 0, ...changeFor(label, bytes) }));
+
+	// One label makes the TOTAL that label's figure printed twice, which says
+	// nothing and invites the reader to hunt for the difference.
+	if (rows.length < 2) {
+		return rows;
+	}
+
+	// Summed from the rows rather than re-derived, for the same reason the
+	// extension table does it: the column a reader adds up is the column that is
+	// printed. Per-label medians across launches need not sum to any one
+	// launch's kernel total.
+	const total = rows.reduce((sum, row) => sum + row.bytes, 0);
+	const baselineTotal = baselineTotals === undefined || baselineTotals.size === 0
+		? undefined
+		: [...baselineTotals.values()].reduce((sum, bytes) => sum + bytes, 0);
+	rows.push({
+		label: KERNEL_TOTAL_ROW,
+		bytes: total,
+		processCount: [...counts.values()].reduce((sum, count) => sum + count, 0),
+		change: baselineTotal === undefined ? '' : signed(total - baselineTotal),
+		changeBytes: baselineTotal === undefined ? undefined : total - baselineTotal,
+		isTotal: true
+	});
+	return rows;
+}
+
 export function renderMarkdown(snapshots: MemorySnapshot[], baseline?: MemorySnapshot): string {
 	const total = totalAcrossLaunches(snapshots);
 	const lines: string[] = [`## Memory: ${snapshots[0]?.scenario}`, ''];
@@ -406,6 +494,20 @@ export function renderMarkdown(snapshots: MemorySnapshot[], baseline?: MemorySna
 			const label = row.extensionId === UNATTRIBUTED_ROW
 				? `_${UNATTRIBUTED_ROW}_`
 				: row.extensionId === EXTENSION_TOTAL_ROW ? `**${EXTENSION_TOTAL_ROW}**` : `\`${row.extensionId}\``;
+			lines.push(`| ${label} | ${formatBytes(row.bytes)} | ${row.change} |`);
+		}
+		lines.push('');
+	}
+
+	// Below the extension table for the same reason the card is: both decompose a
+	// row of the role table above, and neither means anything without it.
+	const kernels = kernelRows(snapshots, baseline);
+	if (kernels.length > 0) {
+		lines.push(`### Kernel memory: ${snapshots[0]?.scenario}`, '');
+		lines.push('| Kernel | PSS | Change |', '| --- | --- | --- |');
+		for (const row of kernels) {
+			const count = row.processCount > 1 ? ` (${row.processCount} processes)` : '';
+			const label = row.isTotal ? `**${row.label}**` : `${row.label}${count}`;
 			lines.push(`| ${label} | ${formatBytes(row.bytes)} | ${row.change} |`);
 		}
 		lines.push('');
@@ -733,6 +835,58 @@ function unlabeledNoteHtml(snapshots: MemorySnapshot[], roleTotals: Map<ProcessR
 	return `<p class="muted">${unlabeled.length} unlabeled process name(s) across ${snapshots.length} launch(es), ${formatBytes(bytes)} in the median launch: ${names}. Add them to the role map in <code>test/e2e/utils/memory/label.ts</code>.</p>`;
 }
 
+/**
+ * One kernel row's label: the language, plus a process count when the figure is
+ * a sum. Not code-formatted -- these are display names, not process names, and
+ * setting them in the same face as a `cmdBasename` implies they are one.
+ */
+function kernelRowLabelHtml(row: KernelRow): string {
+	if (row.isTotal) {
+		// No count here: the column warns that a label's figure is a sum, and a
+		// row named TOTAL has already said that about itself.
+		return `<strong>${escapeHtml(row.label)}</strong>`;
+	}
+	const count = row.processCount > 1 ? ` <span class="muted">(${row.processCount} processes)</span>` : '';
+	return `${escapeHtml(row.label)}${count}`;
+}
+
+/** The change cell for one kernel row, at the role table's scale rather than the extension table's. */
+function kernelChangeHtml(row: KernelRow): string {
+	if (row.changeBytes !== undefined) {
+		return deltaHtmlFromDiff(row.changeBytes);
+	}
+	return row.change === '' ? '' : `<span class="delta-flat">${escapeHtml(row.change)}</span>`;
+}
+
+/**
+ * Decomposes the role table's `kernel` row by language runtime.
+ *
+ * Empty string for a scenario that starts no session, so the card is absent
+ * rather than an empty table -- idle, editors and data-explorer run no kernel,
+ * and an empty table there reads as a failed measurement.
+ */
+function kernelCardHtml(rows: KernelRow[]): string {
+	if (rows.length === 0) {
+		return '';
+	}
+	// TOTAL is every other row added up, so including it would make it the longest
+	// bar by construction and squash the kernels it is meant to compare.
+	const maxBytes = Math.max(0, ...rows.filter(row => !row.isTotal).map(row => row.bytes));
+	return `<div class="card">
+		<h2>Kernel memory</h2>
+		<table>
+			<tr><th>Kernel</th><th align="right">PSS</th><th></th><th align="right">Change</th></tr>
+			${rows.map(row => `<tr${row.isTotal ? ' class="total-row"' : ''}>
+				<td>${kernelRowLabelHtml(row)}</td>
+				<td align="right">${formatBytes(row.bytes)}</td>
+				<td>${row.isTotal ? '' : magnitudeBar(row.bytes, maxBytes)}</td>
+				<td align="right">${kernelChangeHtml(row)}</td>
+			</tr>`).join('\n')}
+		</table>
+		<p class="muted">Rows decompose the <code>kernel</code> role by language runtime; <code>kernel_supervisor</code> and <code>language_server</code> are separate roles and are not counted here.</p>
+	</div>`;
+}
+
 export function renderHtml(snapshots: MemorySnapshot[], baseline?: MemorySnapshot): string {
 	const first = snapshots[0];
 	const total = totalAcrossLaunches(snapshots);
@@ -757,6 +911,8 @@ export function renderHtml(snapshots: MemorySnapshot[], baseline?: MemorySnapsho
 	const newProcessesCard = newProcessesHtml(snapshots, baseline);
 	const unlabeledNote = unlabeledNoteHtml(snapshots, roleTotals);
 	const instabilityCard = instabilityHtml(snapshots);
+
+	const kernelCard = kernelCardHtml(kernelRows(snapshots, baseline));
 
 	const heapRows = extensionHeapRows(snapshots, baseline);
 	// TOTAL is every other row added up, so including it would make it the longest
@@ -812,6 +968,8 @@ export function renderHtml(snapshots: MemorySnapshot[], baseline?: MemorySnapsho
 	</div>
 
 	${extensionHeapCard}
+
+	${kernelCard}
 
 	<div class="card">
 		<h2>Process tree</h2>

--- a/test/e2e/utils/memory/render.ts
+++ b/test/e2e/utils/memory/render.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { kernelProcessCounts, kernelTotals } from './kernel.js';
+import { KERNEL_LABEL_UNKNOWN, kernelProcessCounts, kernelTotals } from './kernel.js';
 import { deltaHtml, deltaHtmlFromDiff, escapeHtml, formatBytes, GC_NOTE, KB, notSteadyStateCardHtml, REPORT_CSS, signed } from './report-shell.js';
 import { unstableProcesses } from './snapshot.js';
 import { ActivatedExtension, ExtensionHeapBreakdown, ExtensionHeapStatus, LabeledProcess, MemorySnapshot, ProcessRole } from './types.js';
@@ -400,11 +400,20 @@ export function kernelRows(snapshots: MemorySnapshot[], baseline?: MemorySnapsho
 	const counts = kernelProcessCounts(snapshots);
 	const baselineTotals = baseline ? kernelTotals(baseline) : undefined;
 
+	// The baseline arrives from the dashboard API, which returns a role and a
+	// figure per process but no command name, so `baselineToSnapshot` leaves
+	// cmdBasename empty and every baseline kernel lands under `unknown`. That
+	// total is still the right thing to diff the TOTAL row against, but it can
+	// say nothing about any individual language, so per-label changes stay blank
+	// rather than reporting every kernel as "new" every night.
+	const baselineLabeled = baselineTotals !== undefined
+		&& [...baselineTotals.keys()].some(label => label !== KERNEL_LABEL_UNKNOWN);
+
 	// Blank rather than "new" everywhere when the baseline had no kernel at all:
 	// that is the first night, or a baseline captured from a scenario that starts
 	// no session, not a night the kernels appeared.
 	const changeFor = (label: string, bytes: number): Pick<KernelRow, 'change' | 'changeBytes'> => {
-		if (baselineTotals === undefined || baselineTotals.size === 0) {
+		if (baselineTotals === undefined || !baselineLabeled) {
 			return { change: '' };
 		}
 		const before = baselineTotals.get(label);

--- a/test/e2e/utils/memory/render.vitest.ts
+++ b/test/e2e/utils/memory/render.vitest.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect, test } from 'vitest';
-import { extensionHeapRows, formatBytes, renderHtml, renderMarkdown } from './render.js';
+import { byRole, extensionHeapRows, formatBytes, kernelRows, renderHtml, renderMarkdown } from './render.js';
 import { REPORT_CSS } from './report-shell.js';
 import { ActivatedExtension, ExtensionHeapBreakdown, ExtensionHeapStatus, LabeledProcess, MemorySnapshot } from './types.js';
 
@@ -754,5 +754,150 @@ describe('extension host heap breakdown', () => {
 
 		expect(html).toContain('Extension host heap');
 		expect(html).toContain('GitHub.copilot-chat');
+	});
+});
+
+describe('kernelRows', () => {
+	const kernelProc = (cmdBasename: string, pssBytes: number, pid: number): LabeledProcess =>
+		proc({ pid, processRole: 'kernel', processName: cmdBasename, cmdBasename, pssBytes });
+
+	test('ranks the labels largest first', () => {
+		const rows = kernelRows([snapshot([
+			proc(),
+			kernelProc('python3', 90 * MB, 200),
+			kernelProc('ark', 180 * MB, 201)
+		])]);
+
+		expect(rows.map(row => row.label)).toEqual(['R (ark)', 'Python', 'TOTAL']);
+		expect(rows[0].bytes).toBe(180 * MB);
+	});
+
+	// The same zero-filling byRole does, and for the same reason: a kernel that
+	// appeared in one launch of three must not read as heavy as one that ran in
+	// all three.
+	test('counts a label absent from a launch as zero in the median', () => {
+		const rows = kernelRows([
+			snapshot([kernelProc('ark', 90 * MB, 200)], 0),
+			snapshot([], 1),
+			snapshot([], 2)
+		]);
+
+		expect(rows.find(row => row.label === 'R (ark)')!.bytes).toBe(0);
+	});
+
+	test('says how many processes a label folds together', () => {
+		const rows = kernelRows([snapshot([
+			kernelProc('python3', 90 * MB, 200),
+			kernelProc('python3.11', 60 * MB, 201)
+		])]);
+
+		expect(rows[0]).toMatchObject({ label: 'Python', bytes: 150 * MB, processCount: 2 });
+	});
+
+	// With one label the TOTAL is that label's figure printed twice, which says
+	// nothing and invites the reader to look for the difference.
+	test('omits the TOTAL row for a single label', () => {
+		const rows = kernelRows([snapshot([kernelProc('ark', 90 * MB, 200)])]);
+
+		expect(rows.map(row => row.label)).toEqual(['R (ark)']);
+	});
+
+	test('sums the TOTAL from the printed rows', () => {
+		const rows = kernelRows([snapshot([
+			kernelProc('ark', 180 * MB, 200),
+			kernelProc('python3', 90 * MB, 201)
+		])]);
+
+		expect(rows.at(-1)).toMatchObject({ label: 'TOTAL', bytes: 270 * MB, isTotal: true });
+	});
+
+	test('is empty for a scenario that starts no kernel', () => {
+		expect(kernelRows([snapshot([proc()])])).toEqual([]);
+	});
+
+	test('reports a change against the previous nightly', () => {
+		const rows = kernelRows(
+			[snapshot([kernelProc('ark', 180 * MB, 200)])],
+			snapshot([kernelProc('ark', 160 * MB, 200)]));
+
+		expect(rows[0]).toMatchObject({ change: '+20.0 MB', changeBytes: 20 * MB });
+	});
+
+	// A kernel the previous nightly did not run is a different fact from one that
+	// held flat, so it says so rather than reporting its whole figure as growth.
+	test('calls a label the baseline never had new', () => {
+		const rows = kernelRows(
+			[snapshot([kernelProc('ark', 180 * MB, 200)])],
+			snapshot([kernelProc('python3', 90 * MB, 200)]));
+
+		const row = rows.find(entry => entry.label === 'R (ark)')!;
+		expect(row.change).toBe('new');
+		expect(row.changeBytes).toBeUndefined();
+	});
+
+	// Blank rather than "new" on every row: a baseline with no kernel at all is
+	// the first night, or an idle baseline, not a night the kernels appeared.
+	test('leaves the change blank when the baseline had no kernel', () => {
+		const rows = kernelRows([snapshot([kernelProc('ark', 180 * MB, 200)])], snapshot([proc()]));
+
+		expect(rows[0].change).toBe('');
+	});
+
+	// The alarm for our label mapping drifting from the dashboard's: it sums the
+	// kernel band the same way, so if a basename stops being counted here it has
+	// stopped being counted there too. Single launch, where a median is exact --
+	// across launches the per-label medians need not sum to the role's own median.
+	test('sums to the kernel row in the role table', () => {
+		const snapshots = [snapshot([
+			proc(),
+			kernelProc('ark', 180 * MB, 200),
+			kernelProc('python3.11', 90 * MB, 201),
+			kernelProc('julia', 40 * MB, 202)
+		])];
+
+		const total = kernelRows(snapshots).find(row => row.isTotal)!.bytes;
+		expect(total).toBe(byRole(snapshots).get('kernel'));
+	});
+});
+
+describe('kernel card', () => {
+	const sessionSnapshot = snapshot([
+		proc(),
+		proc({ pid: 200, processRole: 'kernel', processName: 'ark', cmdBasename: 'ark', pssBytes: 180 * MB })
+	]);
+
+	test('renders the labels in html', () => {
+		const html = renderHtml([sessionSnapshot]);
+
+		expect(html).toContain('Kernel memory');
+		expect(html).toContain('R (ark)');
+	});
+
+	// The count column warns that a label's figure is a sum; TOTAL says that
+	// about itself, and the suffix there only reads as a second figure.
+	test('leaves the process count off the TOTAL row', () => {
+		const html = renderHtml([snapshot([
+			proc({ pid: 200, processRole: 'kernel', processName: 'ark', cmdBasename: 'ark', pssBytes: 180 * MB }),
+			proc({ pid: 201, processRole: 'kernel', processName: 'python3', cmdBasename: 'python3', pssBytes: 90 * MB })
+		])]);
+
+		expect(html).not.toContain('<strong>TOTAL</strong> <span class="muted">(2 processes)');
+	});
+
+	// idle, editors and data-explorer start no session, and an empty table there
+	// reads as a failed measurement rather than as a scenario without a kernel.
+	test('omits the card entirely when no kernel ran', () => {
+		expect(renderHtml([snapshot([proc()])])).not.toContain('Kernel memory');
+	});
+
+	test('renders the labels in markdown', () => {
+		const markdown = renderMarkdown([sessionSnapshot]);
+
+		expect(markdown).toContain('### Kernel memory');
+		expect(markdown).toContain('R (ark)');
+	});
+
+	test('omits the markdown section when no kernel ran', () => {
+		expect(renderMarkdown([snapshot([proc()])])).not.toContain('### Kernel memory');
 	});
 });

--- a/test/e2e/utils/memory/render.vitest.ts
+++ b/test/e2e/utils/memory/render.vitest.ts
@@ -843,6 +843,22 @@ describe('kernelRows', () => {
 		expect(rows[0].change).toBe('');
 	});
 
+	// The real shape of a fetched baseline: the dashboard API returns a role and a
+	// figure per process but no command name, so every baseline kernel reads as
+	// `unknown`. Reporting "new" against that would call every kernel new every
+	// night, so per-label changes stay blank while the TOTAL still diffs.
+	test('leaves per-label changes blank when the baseline carries no command names', () => {
+		const rows = kernelRows(
+			[snapshot([kernelProc('ark', 180 * MB, 200), kernelProc('python3', 90 * MB, 201)])],
+			snapshot([
+				proc({ pid: 200, processRole: 'kernel', processName: 'ark', cmdBasename: '', pssBytes: 160 * MB }),
+				proc({ pid: 201, processRole: 'kernel', processName: 'python3', cmdBasename: '', pssBytes: 90 * MB })
+			]));
+
+		expect(rows.filter(row => !row.isTotal).map(row => row.change)).toEqual(['', '']);
+		expect(rows.at(-1)).toMatchObject({ change: '+20.0 MB', changeBytes: 20 * MB });
+	});
+
 	// The alarm for our label mapping drifting from the dashboard's: it sums the
 	// kernel band the same way, so if a basename stops being counted here it has
 	// stopped being counted there too. Single launch, where a median is exact --

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -89,11 +89,12 @@ export type KernelSummaryRow = {
 	label: string;
 	values: Partial<Record<MemoryScenario, number>>;
 	/**
-	 * The most processes this label covered in any scenario's any launch, for the
-	 * label suffix. Row-level rather than per cell: a suffix that changed down a
-	 * row would have to sit in the cells, competing with the figures.
+	 * How many processes each scenario's figure sums, at its highest across that
+	 * scenario's launches. Per cell rather than per row: one scenario running a
+	 * second kernel was previously reported as a suffix on the label, which read
+	 * as a claim about every cell in the row.
 	 */
-	processCount: number;
+	processCounts: Partial<Record<MemoryScenario, number>>;
 };
 
 export type KernelMatrix = {
@@ -101,6 +102,8 @@ export type KernelMatrix = {
 	rows: KernelSummaryRow[];
 	/** The whole `kernel` role per scenario: the sum of every row above. Absent for a scenario that ran none. */
 	totals: Partial<Record<MemoryScenario, number>>;
+	/** Kernel processes per scenario across every label, for the TOTAL row's marker. */
+	totalProcessCounts: Partial<Record<MemoryScenario, number>>;
 };
 
 /** One process that was still moving when it was sampled, named for the warning banner. */
@@ -427,11 +430,12 @@ function buildKernelMatrix(entries: ScenarioSnapshots[], scenarios: MemoryScenar
 		return undefined;
 	}
 
-	const counts = new Map<string, number>();
-	for (const { snapshots } of entries) {
-		for (const [label, count] of kernelProcessCounts(snapshots)) {
-			counts.set(label, Math.max(counts.get(label) ?? 0, count));
-		}
+	// Kept per scenario rather than maxed into one number per label: the count is
+	// a property of the scenario that ran the kernel, and only one scenario has
+	// ever run two.
+	const countsByScenario = new Map<MemoryScenario, Map<string, number>>();
+	for (const { scenario, snapshots } of entries) {
+		countsByScenario.set(scenario, kernelProcessCounts(snapshots));
 	}
 
 	const peak = (label: string) => Math.max(0, ...[...mediansByScenario.values()].map(m => m.get(label) ?? 0));
@@ -445,21 +449,32 @@ function buildKernelMatrix(entries: ScenarioSnapshots[], scenarios: MemoryScenar
 					values[scenario] = value;
 				}
 			}
-			return { label, values, processCount: counts.get(label) ?? 0 };
+			const processCounts: Partial<Record<MemoryScenario, number>> = {};
+			for (const scenario of scenarios) {
+				const count = countsByScenario.get(scenario)?.get(label);
+				if (count !== undefined) {
+					processCounts[scenario] = count;
+				}
+			}
+			return { label, values, processCounts };
 		});
 
 	// Summed from the rendered rows, so the column a reader adds up is the column
 	// that is printed. A scenario that ran no kernel is left absent rather than
 	// totalled to zero.
 	const totals: Partial<Record<MemoryScenario, number>> = {};
+	const totalProcessCounts: Partial<Record<MemoryScenario, number>> = {};
 	for (const scenario of scenarios) {
 		if ((mediansByScenario.get(scenario)?.size ?? 0) === 0) {
 			continue;
 		}
 		totals[scenario] = rows.reduce((sum, row) => sum + (row.values[scenario] ?? 0), 0);
+		// Summed, not maxed: TOTAL spans the labels, so two kernels of one language
+		// and one of another is three processes in that column.
+		totalProcessCounts[scenario] = rows.reduce((sum, row) => sum + (row.processCounts[scenario] ?? 0), 0);
 	}
 
-	return { rows, totals };
+	return { rows, totals, totalProcessCounts };
 }
 
 /**
@@ -619,11 +634,18 @@ type CellOptions = {
 	 * activated an extension idle does not -- which is what the scenario is for.
 	 */
 	newInScenario?: boolean;
+	/**
+	 * How many processes this one figure sums, superscripted when above one.
+	 *
+	 * Per cell because the fact is per cell: only `quarto-inline` runs a second
+	 * ark, and stating it once on the row label claimed it of `session-r` too.
+	 */
+	processCount?: number;
 };
 
 /** One scenario's cell: the value, plus (for a non-idle scenario) its delta against idle underneath. */
 function cellHtml(scenario: MemoryScenario, value: number | undefined, options: CellOptions = {}): string {
-	const { delta, threshold, flagNoBaseline, newInScenario } = options;
+	const { delta, threshold, flagNoBaseline, newInScenario, processCount } = options;
 	if (value === undefined) {
 		return `<td align="right"${baselineClass(scenario)}>${ABSENT_MARKER}</td>`;
 	}
@@ -645,7 +667,14 @@ function cellHtml(scenario: MemoryScenario, value: number | undefined, options: 
 	// Positioned absolutely off `.value-wrap` rather than appended inline: an inline
 	// dagger widens this cell's content, which widens the whole column and shifts
 	// every other row's value left to share it, breaking the alignment down the column.
-	const marker = flagNoBaseline ? '<span class="baseline-marker">&dagger;</span>' : '';
+	// Same absolute-positioning trick for the same reason. Only one of the two can
+	// ever apply to a cell: the dagger is a delta marker, and the kernel table
+	// that carries counts has no deltas at all.
+	const marker = flagNoBaseline
+		? '<span class="baseline-marker">&dagger;</span>'
+		: processCount !== undefined && processCount > 1
+			? `<span class="count-marker">${processCount}</span>`
+			: '';
 	return `<td align="right"${baselineClass(scenario)}><span class="value-wrap"><span class="value">${formatBytes(value)}</span>${marker}</span>${deltaLine}</td>`;
 }
 
@@ -775,14 +804,17 @@ function kernelCardHtml(matrix: SummaryMatrix): string {
 		return '';
 	}
 	const rows = kernels.rows.map(row => {
-		const count = row.processCount > 1 ? ` <span class="muted">(${row.processCount} processes)</span>` : '';
-		const cells = matrix.scenarios.map(scenario => cellHtml(scenario, row.values[scenario])).join('');
+		const cells = matrix.scenarios.map(scenario => cellHtml(scenario, row.values[scenario], {
+			processCount: row.processCounts[scenario]
+		})).join('');
 		return `<tr>
-		<td>${escapeHtml(row.label)}${count}</td>
+		<td>${escapeHtml(row.label)}</td>
 		${cells}
 	</tr>`;
 	}).join('\n');
-	const totalCells = matrix.scenarios.map(scenario => cellHtml(scenario, kernels.totals[scenario])).join('');
+	const totalCells = matrix.scenarios.map(scenario => cellHtml(scenario, kernels.totals[scenario], {
+		processCount: kernels.totalProcessCounts[scenario]
+	})).join('');
 
 	return `<div class="card">
 		<h2>Kernel memory by language</h2>
@@ -795,8 +827,17 @@ function kernelCardHtml(matrix: SummaryMatrix): string {
 				${totalCells}
 			</tr>
 		</table>
+		${hasMultiProcessKernel(kernels) ? `<div class="footnote">${KERNEL_COUNT_FOOTNOTE}</div>` : ''}
 	</div>`;
 }
+
+/** Whether any cell will carry a count marker, which gates the footnote explaining it. */
+function hasMultiProcessKernel(kernels: KernelMatrix): boolean {
+	return kernels.rows.some(row => Object.values(row.processCounts).some(count => count > 1));
+}
+
+const KERNEL_COUNT_FOOTNOTE = `A superscript is how many kernel processes that figure sums;
+	an unmarked figure is a single process.`;
 
 /**
  * Says what the rows are and, as importantly, why there are no deltas: idle
@@ -884,7 +925,7 @@ export const SUMMARY_CSS = `
 		absolutely positioned dagger inside it cannot widen this cell and shift every
 		other row's value in the column to share the extra space. */
 		.value-wrap { position: relative; }
-		.baseline-marker { position: absolute; left: 100%; top: 0; margin-left: 1px; font-size: 0.7em; line-height: 1; color: #9ca3af; }
+		.baseline-marker, .count-marker { position: absolute; left: 100%; top: 0; margin-left: 1px; font-size: 0.7em; line-height: 1; color: #9ca3af; }
 		/* Only some cells carry a delta on a second line. Centering would then drop a bare
 		value half a line below its emphasized neighbour, so the row no longer reads
 		across. Top-aligned, every PSS figure shares a baseline and the deltas hang below. */

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -737,7 +737,6 @@ function extensionCardHtml(matrix: SummaryMatrix): string {
 	const rows = matrix.extensions.rows.map(row => extensionRowHtml(row, matrix.scenarios)).join('\n');
 	return `<div class="card">
 		<h2>Extension host heap by extension</h2>
-		<div class="meta">${EXTENSION_DELTA_LEGEND}</div>
 		<div class="meta">${EXTENSION_COVERAGE_NOTE}</div>
 		<table class="matrix">
 			<tr><th>Extension</th>${scenarioHeaderHtml(matrix.scenarios)}</tr>
@@ -749,23 +748,19 @@ function extensionCardHtml(matrix: SummaryMatrix): string {
 }
 
 /**
- * The extension table's own legend. Separate from {@link DELTA_LEGEND} because
- * its floor is a different number, and one legend quoting the role floor over an
- * extension table would misstate the bar by a factor of five.
- */
-const EXTENSION_DELTA_LEGEND = `Deltas mark changes that exceed normal launch-to-launch variation
-	and are at least ${formatBytes(MIN_EXTENSION_EMPHASIS_BYTES)}.`;
-
-/**
- * Says what the figures are and what `unattributed` holds, in one line.
+ * What the figures are, the delta bar, and what `unattributed` holds.
  *
- * Deliberately short: this is the dashboard surface, and the row order already
- * shows that the extensions and `unattributed` make up TOTAL. How the partition
- * is built, and why it sits under the `extension_host` PSS row, belong in the
- * module docs rather than above the table.
+ * Deliberately terse: the table already carries most of this, so the note only
+ * has to make it readable. How the partition is built, and why it sits under the
+ * `extension_host` PSS row, belong in the module docs rather than above a table.
+ *
+ * Interpolates its own floor rather than spelling it out. {@link DELTA_LEGEND}
+ * quotes the role floor, which is five times larger, so a hardcoded number here
+ * would misstate the bar the moment either constant moved.
  */
-const EXTENSION_COVERAGE_NOTE = `Rows show each extension's reachable V8 heap;
-	<em>unattributed</em> includes host runtime and extension code not owned by an extension object.`;
+const EXTENSION_COVERAGE_NOTE = `Reachable V8 heap by extension. Deltas flag changes beyond
+	normal launch variation and &ge;${formatBytes(MIN_EXTENSION_EMPHASIS_BYTES)};
+	<em>unattributed</em> includes host runtime and unowned extension code.`;
 
 /**
  * The kernel section, or nothing at all.
@@ -807,9 +802,9 @@ function kernelCardHtml(matrix: SummaryMatrix): string {
  * Says what the rows are and, as importantly, why there are no deltas: idle
  * runs no kernel, so there is no baseline column to measure one from.
  */
-const KERNEL_COVERAGE_NOTE = `Rows decompose the <code>kernel</code> role by language runtime;
-	<code>kernel_supervisor</code> and <code>language_server</code> are separate roles and are not counted here.
-	No deltas: idle starts no session, so there is no baseline kernel to compare against.`;
+const KERNEL_COVERAGE_NOTE = `Kernel memory by language runtime. Excludes
+	<code>kernel_supervisor</code> and <code>language_server</code>;
+	no deltas because idle has no kernel baseline.`;
 
 /** True when at least one row will render the dagger marker, which gates the footnote explaining it. */
 function hasNoBaselineRows(matrix: SummaryMatrix): boolean {

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -831,9 +831,16 @@ function kernelCardHtml(matrix: SummaryMatrix): string {
 	</div>`;
 }
 
-/** Whether any cell will carry a count marker, which gates the footnote explaining it. */
+/**
+ * Whether any cell will carry a count marker, which gates the footnote explaining it.
+ *
+ * TOTAL as well as the rows: a scenario running one kernel of each of two
+ * languages leaves every row at one process and still totals two, so gating on
+ * the rows alone printed a superscript with nothing to explain it.
+ */
 function hasMultiProcessKernel(kernels: KernelMatrix): boolean {
-	return kernels.rows.some(row => Object.values(row.processCounts).some(count => count > 1));
+	const counts = [...kernels.rows.map(row => row.processCounts), kernels.totalProcessCounts];
+	return counts.some(byScenario => Object.values(byScenario).some(count => count > 1));
 }
 
 const KERNEL_COUNT_FOOTNOTE = `A superscript is how many kernel processes that figure sums;

--- a/test/e2e/utils/memory/summary.ts
+++ b/test/e2e/utils/memory/summary.ts
@@ -16,6 +16,7 @@
  */
 
 import { deltaHtmlFromDiff, escapeHtml, formatBytes, GC_FOOTNOTE, notSteadyStateCardHtml, REPORT_CSS } from './report-shell.js';
+import { kernelProcessCounts, kernelTotals } from './kernel.js';
 import { byRole, EXTENSION_HEAP_FLOOR_BYTES, extensionHeapUnavailableText, UNATTRIBUTED_ROW } from './render.js';
 import { unstableProcesses } from './snapshot.js';
 import { MemoryLane } from './lanes.js';
@@ -73,6 +74,33 @@ export type ExtensionMatrix = {
 	totals: Partial<Record<MemoryScenario, number>>;
 	totalDeltaVsIdle: Partial<Record<MemoryScenario, number>>;
 	totalEmphasisThreshold: Partial<Record<MemoryScenario, number>>;
+};
+
+/**
+ * One kernel language's median PSS across every scenario that ran it.
+ *
+ * No `deltaVsIdle`, unlike {@link SummaryRow} and {@link ExtensionSummaryRow}:
+ * idle starts no session, so every kernel row's baseline cell is absent and a
+ * delta column would be empty down its whole length. The comparison a reader
+ * wants here is across the scenario columns, not against idle.
+ */
+export type KernelSummaryRow = {
+	/** A label from `kernelLabelFor`: `R (ark)`, `Python`, or an unmapped basename. */
+	label: string;
+	values: Partial<Record<MemoryScenario, number>>;
+	/**
+	 * The most processes this label covered in any scenario's any launch, for the
+	 * label suffix. Row-level rather than per cell: a suffix that changed down a
+	 * row would have to sit in the cells, competing with the figures.
+	 */
+	processCount: number;
+};
+
+export type KernelMatrix = {
+	/** Largest first, by the biggest cell in the row. No floor: there are only ever a handful of labels. */
+	rows: KernelSummaryRow[];
+	/** The whole `kernel` role per scenario: the sum of every row above. Absent for a scenario that ran none. */
+	totals: Partial<Record<MemoryScenario, number>>;
 };
 
 /** One process that was still moving when it was sampled, named for the warning banner. */
@@ -134,6 +162,13 @@ export type SummaryMatrix = {
 	extensions?: ExtensionMatrix;
 	/** Why there is no `extensions` table, when there is none. */
 	extensionsUnavailable?: string;
+	/**
+	 * Decomposition of the `kernel` row, one language per row and the same
+	 * scenario columns. Undefined when no scenario ran a kernel, which the
+	 * report omits rather than reporting as unavailable: unlike a failed heap
+	 * attribution, a run with no kernel is a legitimate result.
+	 */
+	kernels?: KernelMatrix;
 	/** What run this matrix describes, for the header. */
 	meta: SummaryMeta;
 };
@@ -370,6 +405,64 @@ function buildExtensionMatrix(entries: ScenarioSnapshots[], scenarios: MemorySce
 }
 
 /**
+ * Builds the per-kernel matrix, mirroring the role matrix column for column.
+ *
+ * No floor and no collapsed tail, unlike the extension matrix: a scenario runs
+ * one or two kernels, so every row is worth a line. A label absent from a
+ * launch counts as zero in that scenario's median, the same zero-filling
+ * `byRole` does; a label absent from the scenario entirely stays absent, so the
+ * cell renders an em-dash rather than a 0 MB kernel that never ran.
+ */
+function buildKernelMatrix(entries: ScenarioSnapshots[], scenarios: MemoryScenario[]): KernelMatrix | undefined {
+	const mediansByScenario = new Map<MemoryScenario, Map<string, number>>();
+	for (const { scenario, snapshots } of entries) {
+		const perLaunch = snapshots.map(kernelTotals);
+		const labels = new Set(perLaunch.flatMap(totals => [...totals.keys()]));
+		mediansByScenario.set(scenario, new Map([...labels].map(label => [
+			label, median(perLaunch.map(totals => totals.get(label) ?? 0))
+		])));
+	}
+	const labels = new Set([...mediansByScenario.values()].flatMap(medians => [...medians.keys()]));
+	if (labels.size === 0) {
+		return undefined;
+	}
+
+	const counts = new Map<string, number>();
+	for (const { snapshots } of entries) {
+		for (const [label, count] of kernelProcessCounts(snapshots)) {
+			counts.set(label, Math.max(counts.get(label) ?? 0, count));
+		}
+	}
+
+	const peak = (label: string) => Math.max(0, ...[...mediansByScenario.values()].map(m => m.get(label) ?? 0));
+	const rows: KernelSummaryRow[] = [...labels]
+		.sort((a, b) => peak(b) - peak(a))
+		.map(label => {
+			const values: Partial<Record<MemoryScenario, number>> = {};
+			for (const scenario of scenarios) {
+				const value = mediansByScenario.get(scenario)?.get(label);
+				if (value !== undefined) {
+					values[scenario] = value;
+				}
+			}
+			return { label, values, processCount: counts.get(label) ?? 0 };
+		});
+
+	// Summed from the rendered rows, so the column a reader adds up is the column
+	// that is printed. A scenario that ran no kernel is left absent rather than
+	// totalled to zero.
+	const totals: Partial<Record<MemoryScenario, number>> = {};
+	for (const scenario of scenarios) {
+		if ((mediansByScenario.get(scenario)?.size ?? 0) === 0) {
+			continue;
+		}
+		totals[scenario] = rows.reduce((sum, row) => sum + (row.values[scenario] ?? 0), 0);
+	}
+
+	return { rows, totals };
+}
+
+/**
  * Builds the per-role x per-scenario matrix.
  *
  * Columns are `idle` first (the baseline), then the rest ascending by TOTAL
@@ -466,7 +559,9 @@ export function buildSummaryMatrix(entries: ScenarioSnapshots[]): SummaryMatrix 
 	// snapshots, which the matrix does not carry.
 	const extensionsUnavailable = extensions ? undefined : extensionHeapUnavailableText(entries.flatMap(e => e.snapshots));
 
-	return { scenarios: sortedScenarios, rows, totals, totalEmphasisThreshold, unstable, forcedGcRoles, extensions, extensionsUnavailable, meta: buildSummaryMeta(entries) };
+	const kernels = buildKernelMatrix(entries, sortedScenarios);
+
+	return { scenarios: sortedScenarios, rows, totals, totalEmphasisThreshold, unstable, forcedGcRoles, extensions, extensionsUnavailable, kernels, meta: buildSummaryMeta(entries) };
 }
 
 /** Muted em-dash: a role that did not exist in this scenario, never a fabricated zero. */
@@ -671,6 +766,50 @@ const EXTENSION_DELTA_LEGEND = `Deltas mark changes that exceed normal launch-to
  */
 const EXTENSION_COVERAGE_NOTE = `Rows show each extension's reachable V8 heap;
 	<em>unattributed</em> includes host runtime and extension code not owned by an extension object.`;
+
+/**
+ * The kernel section, or nothing at all.
+ *
+ * Below the role table because it decomposes one of its rows, and below the
+ * extension table so the two breakdowns sit together. Cells carry no delta: see
+ * {@link KernelSummaryRow}.
+ */
+function kernelCardHtml(matrix: SummaryMatrix): string {
+	const kernels = matrix.kernels;
+	if (kernels === undefined) {
+		return '';
+	}
+	const rows = kernels.rows.map(row => {
+		const count = row.processCount > 1 ? ` <span class="muted">(${row.processCount} processes)</span>` : '';
+		const cells = matrix.scenarios.map(scenario => cellHtml(scenario, row.values[scenario])).join('');
+		return `<tr>
+		<td>${escapeHtml(row.label)}${count}</td>
+		${cells}
+	</tr>`;
+	}).join('\n');
+	const totalCells = matrix.scenarios.map(scenario => cellHtml(scenario, kernels.totals[scenario])).join('');
+
+	return `<div class="card">
+		<h2>Kernel memory by language</h2>
+		<div class="meta">${KERNEL_COVERAGE_NOTE}</div>
+		<table class="matrix">
+			<tr><th>Kernel</th>${scenarioHeaderHtml(matrix.scenarios)}</tr>
+			${rows}
+			<tr class="total-row">
+				<td><strong>TOTAL</strong></td>
+				${totalCells}
+			</tr>
+		</table>
+	</div>`;
+}
+
+/**
+ * Says what the rows are and, as importantly, why there are no deltas: idle
+ * runs no kernel, so there is no baseline column to measure one from.
+ */
+const KERNEL_COVERAGE_NOTE = `Rows decompose the <code>kernel</code> role by language runtime;
+	<code>kernel_supervisor</code> and <code>language_server</code> are separate roles and are not counted here.
+	No deltas: idle starts no session, so there is no baseline kernel to compare against.`;
 
 /** True when at least one row will render the dagger marker, which gates the footnote explaining it. */
 function hasNoBaselineRows(matrix: SummaryMatrix): boolean {
@@ -882,6 +1021,8 @@ export function renderSummaryHtml(matrix: SummaryMatrix): string {
 	</div>
 
 	${extensionCardHtml(matrix)}
+
+	${kernelCardHtml(matrix)}
 </div>
 </body>
 </html>`;

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -782,6 +782,42 @@ describe('kernel matrix', () => {
 		expect(matrix.kernels).toBeUndefined();
 	});
 
+	// The regression a row-level count caused: quarto-inline runs two arks and
+	// session-r one, and a single number per row reported both as two.
+	test('counts kernel processes per scenario, not per row', () => {
+		const twoArks = scenarioEntry('quarto-inline', [
+			proc(), kernelProc('ark', 100, 200), kernelProc('ark', 100, 201)
+		]);
+		const kernels = buildSummaryMatrix([...entries, twoArks]).kernels!;
+		const ark = kernels.rows.find(row => row.label === 'R (ark)')!;
+
+		expect(ark.processCounts['quarto-inline']).toBe(2);
+		expect(ark.processCounts['session-r']).toBe(1);
+		// Summed across labels, so a column's marker counts every kernel in it.
+		expect(kernels.totalProcessCounts['quarto-inline']).toBe(2);
+	});
+
+	// Only the cell it is true of is marked, and the label carries no suffix.
+	test('superscripts only the multi-process cell', () => {
+		const twoArks = scenarioEntry('quarto-inline', [
+			proc(), kernelProc('ark', 100, 200), kernelProc('ark', 100, 201)
+		]);
+		const html = renderSummaryHtml(buildSummaryMatrix([...entries, twoArks]));
+		const arkRow = html.split('R (ark)')[1].split('</tr>')[0];
+
+		expect(html).not.toContain('processes)');
+		expect(arkRow.match(/<span class="count-marker">/g)).toHaveLength(1);
+		expect(arkRow).toContain('<span class="count-marker">2</span>');
+	});
+
+	test('omits the count footnote when every kernel is one process', () => {
+		const html = renderSummaryHtml(buildSummaryMatrix(entries));
+
+		// The class name itself is in the stylesheet either way; the span is not.
+		expect(html).not.toContain('<span class="count-marker">');
+		expect(html).not.toContain('A superscript is how many');
+	});
+
 	test('renders the card in html', () => {
 		const html = renderSummaryHtml(buildSummaryMatrix(entries));
 

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -728,3 +728,72 @@ describe('containerHtmlFrom', () => {
 		expect(() => containerHtmlFrom(doc, 'server')).toThrow(/server/);
 	});
 });
+
+describe('kernel matrix', () => {
+	const kernelProc = (cmdBasename: string, mb: number, pid: number): LabeledProcess =>
+		proc({ pid, processRole: 'kernel', processName: cmdBasename, cmdBasename, pssBytes: mb * MB });
+
+	const entries: ScenarioSnapshots[] = [
+		scenarioEntry('idle', [proc()]),
+		scenarioEntry('session-r', [proc(), kernelProc('ark', 180, 200)]),
+		scenarioEntry('session-python', [proc(), kernelProc('python3', 90, 200)]),
+		scenarioEntry('notebook', [proc(), kernelProc('python3.11', 120, 200)])
+	];
+
+	test('decomposes the kernel role by language across scenarios', () => {
+		const kernels = buildSummaryMatrix(entries).kernels!;
+
+		expect(kernels.rows.map(row => row.label)).toEqual(['R (ark)', 'Python']);
+		expect(kernels.rows[0].values['session-r']).toBe(180 * MB);
+		expect(kernels.rows[1].values['session-python']).toBe(90 * MB);
+		expect(kernels.rows[1].values['notebook']).toBe(120 * MB);
+	});
+
+	// The em-dash the cell renderer prints for an absent value, not a fabricated
+	// zero: idle starts no session, so it has no R kernel rather than a 0 MB one.
+	test('leaves a scenario without that kernel absent', () => {
+		const kernels = buildSummaryMatrix(entries).kernels!;
+
+		expect(kernels.rows[0].values['idle']).toBeUndefined();
+		expect(kernels.rows[0].values['session-python']).toBeUndefined();
+	});
+
+	test('totals the kernels a scenario did run', () => {
+		const kernels = buildSummaryMatrix(entries).kernels!;
+
+		expect(kernels.totals['session-r']).toBe(180 * MB);
+		expect(kernels.totals['idle']).toBeUndefined();
+	});
+
+	// The invariant the dashboard's chart depends on, checked on our side of the
+	// same mapping: the labels have to add up to the band they decompose.
+	test('sums to the kernel row in the role matrix, per scenario', () => {
+		const matrix = buildSummaryMatrix(entries);
+		const kernelRole = matrix.rows.find(row => row.role === 'kernel')!;
+
+		for (const scenario of ['session-r', 'session-python', 'notebook'] as MemoryScenario[]) {
+			expect(matrix.kernels!.totals[scenario]).toBe(kernelRole.values[scenario]);
+		}
+	});
+
+	test('is undefined when no scenario ran a kernel', () => {
+		const matrix = buildSummaryMatrix([scenarioEntry('idle', [proc()])]);
+
+		expect(matrix.kernels).toBeUndefined();
+	});
+
+	test('renders the card in html', () => {
+		const html = renderSummaryHtml(buildSummaryMatrix(entries));
+
+		expect(html).toContain('Kernel memory by language');
+		expect(html).toContain('R (ark)');
+	});
+
+	// Absent rather than an "unavailable" sentence: unlike a failed heap
+	// attribution, a run with no kernel is a legitimate result.
+	test('omits the card when no scenario ran a kernel', () => {
+		const html = renderSummaryHtml(buildSummaryMatrix([scenarioEntry('idle', [proc()])]));
+
+		expect(html).not.toContain('Kernel memory by language');
+	});
+});

--- a/test/e2e/utils/memory/summary.vitest.ts
+++ b/test/e2e/utils/memory/summary.vitest.ts
@@ -818,6 +818,23 @@ describe('kernel matrix', () => {
 		expect(html).not.toContain('A superscript is how many');
 	});
 
+	// TOTAL sums across labels, so it can be marked while every row it sums is a
+	// single process. The footnote has to follow the marker, not the rows.
+	test('footnotes a TOTAL marker that no single row earns', () => {
+		const twoLanguages = scenarioEntry('quarto-inline', [
+			proc(), kernelProc('ark', 100, 200), kernelProc('python3', 100, 201)
+		]);
+		const matrix = buildSummaryMatrix([...entries, twoLanguages]);
+		const html = renderSummaryHtml(matrix);
+		// Scoped to the kernel card: the extension table has a TOTAL row of its own, earlier.
+		const totalRow = html.split('<h2>Kernel memory by language</h2>')[1].split('TOTAL')[1].split('</tr>')[0];
+
+		expect(matrix.kernels!.rows.every(row => (row.processCounts['quarto-inline'] ?? 0) <= 1)).toBe(true);
+		expect(matrix.kernels!.totalProcessCounts['quarto-inline']).toBe(2);
+		expect(totalRow).toContain('<span class="count-marker">2</span>');
+		expect(html).toContain('A superscript is how many');
+	});
+
 	test('renders the card in html', () => {
 		const html = renderSummaryHtml(buildSummaryMatrix(entries));
 


### PR DESCRIPTION
### Summary

The memory reports showed `kernel` as one flat number, so an R-side and a Python-side change looked identical; this splits that row by language runtime.

<img width="1125" height="237" alt="Screenshot 2026-09-04 at 8 57 23 AM" src="https://github.com/user-attachments/assets/0669cf0c-eea4-4f79-994f-9dbb0d99ca71" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

