### PR TITLE
e2e: wait for the session working directory before running an unsaved script

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -18,6 +18,7 @@ const EMPTY_CONSOLE = '.positron-console .empty-console';
 const INTERRUPT_RUNTIME = 'div.action-bar-button-face .codicon-positron-interrupt-runtime';
 const SUGGESTION_LIST = '.suggest-widget .monaco-list-row';
 const CONSOLE_LINES = `${ACTIVE_CONSOLE_INSTANCE} div span`;
+const WORKING_DIRECTORY_LABEL = '.current-working-directory-label .label';
 const ERROR = '.activity-error-message';
 
 /*
@@ -207,6 +208,22 @@ export class Console {
 			}
 			await this.waitForReady(prompt, timeout);
 			await this.waitForConsoleContents('started', { timeout, expectedCount });
+		});
+	}
+
+	/**
+	 * Wait until the console action bar reports a working directory for the
+	 * active session.
+	 *
+	 * A session's working directory arrives asynchronously, over the UI comm,
+	 * after the "started" banner. Until it lands, anything deriving a
+	 * session-relative path gets an absolute one instead.
+	 */
+	async waitForWorkingDirectory(timeout = 30000): Promise<void> {
+		await test.step('Wait for console working directory to be reported', async () => {
+			await expect(
+				this.code.driver.currentPage.locator(WORKING_DIRECTORY_LABEL)
+			).not.toBeEmpty({ timeout });
 		});
 	}
 

--- a/test/e2e/tests/editor/unsaved-script-execution.test.ts
+++ b/test/e2e/tests/editor/unsaved-script-execution.test.ts
@@ -57,6 +57,11 @@ for (const config of languageConfigs) {
 		test(`${config.session === 'r' ? 'R' : 'Python'} - runs an untitled script without a save prompt`, async ({ app, runCommand }) => {
 			const { editor, editors, console: consolePane } = app.workbench;
 
+			// The scratch path below is formatted relative to the session's
+			// working directory, which the session reports asynchronously after
+			// it starts. Running before it lands yields an absolute path.
+			await consolePane.waitForWorkingDirectory();
+
 			await test.step('Create a new untitled script with code', async () => {
 				await runCommand(config.newFileCommand);
 				await editor.type(config.code);


### PR DESCRIPTION
### Summary
Resolving a frequent flake in the Python [unsaved-script](https://connect.posit.it/e2e-test-insights/?branch=main&tab=test_health&sort=pain&date=2&search=test/e2e/tests/editor/unsaved-script-execution.test.ts) test. The test clicks Run before the session has reported its working directory. Until that lands over the UI comm, `formatPathForCode` has no session base to relativize against and falls back to an absolute path, so the session-relative assertion missed.
- Adds a `waitForWorkingDirectory()` helper to the Console page object
- Awaits it before creating the untitled script
- Keeps the strict relative-path assertion rather than loosening it

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:editor @:console @:ark @:web @:win @:rocky-web @:suse-web

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- The test asserts a session-cwd-relative scratch path but does not wait for the session to have reported its working directory. Clicking Run ~400ms after the interpreter's 'started' line composes the %run command while dynState.currentWorkingDirectory is still '', so formatPathForCode skips the 'session' base, fails the 'home' base (the workspace root is not under $HOME), and echoes an absolute path that the strict regex rejects.</summary>

- **Test:** [Run Unsaved Script > Python - runs an untitled script without a save prompt](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Run%20Unsaved%20Script%20%3E%20Python%20-%20runs%20an%20untitled%20script%20without%20a%20save%20prompt%7C%7C%7Ctest%2Fe2e%2Ftests%2Feditor%2Funsaved-script-execution.test.ts)
- **Targeted failure:** expect(locator).toHaveCount(expected) failed -- locator('.console-instance[style*="z-index: auto"] div span').getByText(/"\.positron-untitled-\d+\.py"/) Expected: 1 Received: 0
- **Signal:** Console at failure showed `%run -- "/tmp/vscsmoke/test-files/.positron-untitled-1.py"` (absolute) plus SCRATCH_PY_RAN, while the R sibling in the same run showed `source(".positron-untitled-1.R", echo = TRUE)` (relative) through the identical API call. The Python action bar's Current Working Directory label (actionBar.tsx:211, same dynState source) read /tmp/vscsmoke/test-files in the failure snapshot -- i.e. the value was populated by the end of the 15s wait but not at click time. Ruled out: save prompt (marker printed; DialogService warning is post-deadline teardown), wrong scratch directory (the absolute path IS the workspace root), locator drift (console-instance present throughout; R sibling used the same locator shape and passed).
- **Frequency:** 27/35 runs (77.1%) on main, ubuntu/chromium
- **Hypothesis:** Gating the Run click on the console action bar's working-directory label being non-empty removes the race, because that label renders from the same dynState.currentWorkingDirectory the path formatter reads. The absolute path is functionally harmless (%run and source() both accept absolute paths), so the cold-start window is cosmetic and not filed as a product bug.

</details>
