### PR TITLE
ci(memory): notify #positron-test-results when the nightly memory run breaks

### DIFF
--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -300,7 +300,10 @@ jobs:
     needs: memory
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Nearly all of this is one npm install, which has been observed between 5
+    # and 7 minutes; the rendering it guards takes about 6 seconds. A 10-minute
+    # budget killed the job twice on slow-registry nights.
+    timeout-minutes: 20
     permissions:
       contents: read
       # For the AWS OIDC role-assumption in upload-report-to-s3.
@@ -504,3 +507,27 @@ jobs:
             exit 1
           fi
           echo "Posted to ${CHANNEL}."
+
+  # Separate job so it survives the failure it reports: the budget alert is the
+  # last step of `summarize`, so a summarize timeout skips it and the nightly
+  # goes quiet. Posts to #positron-test-results rather than the budget alert's
+  # #positron-dev -- this one says the run broke, not that memory grew.
+  #
+  # `always()` rather than `failure()`, which is false for a cancelled run --
+  # and a job killed by timeout-minutes is reported as cancelled, which is
+  # exactly the case here. The action treats any conclusion outside
+  # success/skipped as a failure, so it decides whether to post.
+  notify:
+    name: notify-test-results
+    needs: [resolve-build, memory, summarize]
+    # Scheduled runs only: a branch dispatch is watched by whoever started it.
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        uses: midleman/slack-workflow-status@v3.1.3
+        with:
+          gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
+          notify_on: "failure"
+          slack_channel: "#positron-test-results"

--- a/.github/workflows/test-memory-metrics.yml
+++ b/.github/workflows/test-memory-metrics.yml
@@ -300,9 +300,8 @@ jobs:
     needs: memory
     if: always()
     runs-on: ubuntu-latest
-    # Nearly all of this is one npm install, which has been observed between 5
-    # and 7 minutes; the rendering it guards takes about 6 seconds. A 10-minute
-    # budget killed the job twice on slow-registry nights.
+    # Nearly all of this is one npm install, seen as slow as 7 minutes; a
+    # 10-minute budget killed the job twice.
     timeout-minutes: 20
     permissions:
       contents: read
@@ -508,15 +507,12 @@ jobs:
           fi
           echo "Posted to ${CHANNEL}."
 
-  # Separate job so it survives the failure it reports: the budget alert is the
-  # last step of `summarize`, so a summarize timeout skips it and the nightly
-  # goes quiet. Posts to #positron-test-results rather than the budget alert's
-  # #positron-dev -- this one says the run broke, not that memory grew.
+  # A separate job so it survives what it reports: the budget alert is
+  # `summarize`'s last step, so a summarize timeout skips it and the nightly
+  # goes quiet.
   #
-  # `always()` rather than `failure()`, which is false for a cancelled run --
-  # and a job killed by timeout-minutes is reported as cancelled, which is
-  # exactly the case here. The action treats any conclusion outside
-  # success/skipped as a failure, so it decides whether to post.
+  # `always()`, not `failure()`: a job killed by timeout-minutes is reported as
+  # cancelled, for which `failure()` is false.
   notify:
     name: notify-test-results
     needs: [resolve-build, memory, summarize]


### PR DESCRIPTION
### Summary

The nightly memory run can break without anyone hearing about it. Its only Slack notification is the memory budget alert, which is the last step of the `summarize` job -- so when that job itself dies, the alert is skipped and the nightly goes quiet. That happened in run 33847261470, where `summarize` hit its 10-minute budget mid-install.

- Adds a separate `notify` job posting to `#positron-test-results`, so it survives the failure it reports
- Distinct from the budget alert's `#positron-dev`: this one says the run broke, not that memory grew
- Gated on `always()`, not `failure()`, which is false for a cancelled run -- and a `timeout-minutes` kill is reported as cancelled
- Scheduled runs only; a branch dispatch is watched by whoever started it
- Raises the `summarize` budget from 10 to 20 minutes

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

