### PR TITLE
e2e: pin the smoke-driver console echo at Debug to stop the CDP flood

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -183,6 +183,7 @@
   "src/vs/workbench/services/actions/": ["@:assistant"],
   "src/vs/workbench/services/encryption/": [],
   "src/vs/workbench/services/encryption/browser/browserEncryptionService.ts": ["@:web"],
+  "src/vs/workbench/services/log/": [],
   "src/vs/workbench/services/notification/": [],
   "src/vs/workbench/services/themes/": [],
   "src/vs/workbench/services/themes/browser/positronColorThemeFilter.ts": []

--- a/src/vs/workbench/services/log/common/fixedLevelConsoleLogger.ts
+++ b/src/vs/workbench/services/log/common/fixedLevelConsoleLogger.ts
@@ -36,3 +36,23 @@ export class FixedLevelConsoleLogger extends ConsoleLogger {
 		super.setLevel(level);
 	}
 }
+
+/**
+ * The subset of the environment service this decision reads. Declared structurally so the rule
+ * can be exercised on its own; callers pass the real `INativeWorkbenchEnvironmentService`.
+ */
+export interface IConsoleEchoEnvironment {
+	readonly enableSmokeTestDriver?: boolean;
+	readonly verbose: boolean;
+}
+
+/**
+ * Whether the console echo should be pinned instead of following the file-log level.
+ *
+ * Only under the e2e smoke driver, and only when the run has not asked for verbose output --
+ * `--verbose` is the way back to the full echo when someone is debugging a smoke-driver window
+ * by hand.
+ */
+export function shouldPinConsoleEcho(environmentService: IConsoleEchoEnvironment): boolean {
+	return environmentService.enableSmokeTestDriver === true && !environmentService.verbose;
+}

--- a/src/vs/workbench/services/log/common/fixedLevelConsoleLogger.ts
+++ b/src/vs/workbench/services/log/common/fixedLevelConsoleLogger.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ConsoleLogger, LogLevel } from '../../../../platform/log/common/log.js';
+
+/**
+ * A {@link ConsoleLogger} whose level is pinned at construction and cannot be changed
+ * afterwards.
+ *
+ * `LogService` wires `primaryLogger.onDidChangeLogLevel` to its own `setLevel`, which a
+ * `MultiplexLogger` then fans out to every logger it holds. That couples the console echo to
+ * the file-log level, so `--log=trace` puts trace-level output on the console as well as on
+ * disk. Under the e2e smoke driver that echo is pushed over the Playwright CDP session, and
+ * the volume starves the request/response direction of the same session: `expect` evaluations
+ * and screencast frames queue up for tens of seconds and then drain in one batch, while the
+ * renderer itself is running normally. Pinning the console echo keeps the CDP channel quiet
+ * without touching what is written to disk.
+ */
+export class FixedLevelConsoleLogger extends ConsoleLogger {
+
+	private levelPinned = false;
+
+	constructor(logLevel: LogLevel) {
+		super(logLevel);
+		// Field initializers run after `super()`, so `levelPinned` is still undefined during the
+		// base constructor's own `setLevel` call and the requested level is applied normally.
+		this.levelPinned = true;
+	}
+
+	override setLevel(level: LogLevel): void {
+		if (this.levelPinned) {
+			return;
+		}
+		super.setLevel(level);
+	}
+}

--- a/src/vs/workbench/services/log/common/fixedLevelConsoleLogger.ts
+++ b/src/vs/workbench/services/log/common/fixedLevelConsoleLogger.ts
@@ -56,3 +56,13 @@ export interface IConsoleEchoEnvironment {
 export function shouldPinConsoleEcho(environmentService: IConsoleEchoEnvironment): boolean {
 	return environmentService.enableSmokeTestDriver === true && !environmentService.verbose;
 }
+
+/**
+ * The level the console echo is pinned to under the smoke driver.
+ *
+ * Debug rather than Info: in one measured failure window, trace records were 614 of the 791
+ * console messages, so stopping at Debug removes 78% of the volume while keeping debug output
+ * in the Playwright trace, where it sits on the same timeline as the test's own actions. Info
+ * would cut 90% and give that up.
+ */
+export const PINNED_CONSOLE_LEVEL = LogLevel.Debug;

--- a/src/vs/workbench/services/log/electron-browser/logService.ts
+++ b/src/vs/workbench/services/log/electron-browser/logService.ts
@@ -32,11 +32,13 @@ export class NativeLogService extends LogService {
 			// so every trace record is also pushed over the Playwright CDP session. That flood
 			// starves the session's request/response direction: `expect` evaluations park for tens
 			// of seconds against a workbench that is already rendered, then drain in one batch.
-			// Pin the echo at Info under the smoke driver; on-disk logs stay at trace, and
-			// `--verbose` opts back out.
+			// Pin the echo at Debug under the smoke driver, which drops 78% of the volume (trace
+			// records were 614 of the 791 messages in one measured failure window) while keeping
+			// debug output in the trace, where it sits on the same timeline as the test's actions.
+			// On-disk logs stay at trace, and `--verbose` opts back out.
 			// consoleLogger = new ConsoleLogger(fileLogger.getLevel());
 			consoleLogger = environmentService.enableSmokeTestDriver && !environmentService.verbose
-				? new FixedLevelConsoleLogger(LogLevel.Info)
+				? new FixedLevelConsoleLogger(LogLevel.Debug)
 				: new ConsoleLogger(fileLogger.getLevel());
 			// --- End Positron ---
 		}

--- a/src/vs/workbench/services/log/electron-browser/logService.ts
+++ b/src/vs/workbench/services/log/electron-browser/logService.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ConsoleLogger, ILogger, isDevConsoleLogForwardingEnabled, LogLevel, registerDevConsoleLogForwarder } from '../../../../platform/log/common/log.js';
+import { ConsoleLogger, ILogger, isDevConsoleLogForwardingEnabled, registerDevConsoleLogForwarder } from '../../../../platform/log/common/log.js';
 import { INativeWorkbenchEnvironmentService } from '../../environment/electron-browser/environmentService.js';
 import { LoggerChannelClient } from '../../../../platform/log/common/logIpc.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { windowLogGroup, windowLogId } from '../common/logConstants.js';
 import { LogService } from '../../../../platform/log/common/logService.js';
 // --- Start Positron ---
-import { FixedLevelConsoleLogger, shouldPinConsoleEcho } from '../common/fixedLevelConsoleLogger.js';
+import { FixedLevelConsoleLogger, PINNED_CONSOLE_LEVEL, shouldPinConsoleEcho } from '../common/fixedLevelConsoleLogger.js';
 // --- End Positron ---
 
 export class NativeLogService extends LogService {
@@ -28,17 +28,12 @@ export class NativeLogService extends LogService {
 		} else {
 			// Normal mode: Log to console
 			// --- Start Positron ---
-			// The console echo below follows the file-log level, and e2e runs pass `--log=trace`,
-			// so every trace record is also pushed over the Playwright CDP session. That flood
-			// starves the session's request/response direction: `expect` evaluations park for tens
-			// of seconds against a workbench that is already rendered, then drain in one batch.
-			// Pin the echo at Debug under the smoke driver, which drops 78% of the volume (trace
-			// records were 614 of the 791 messages in one measured failure window) while keeping
-			// debug output in the trace, where it sits on the same timeline as the test's actions.
-			// On-disk logs stay at trace, and `--verbose` opts back out.
+			// Under the e2e smoke driver the console echo is pinned instead of following the
+			// file-log level, which `--log=trace` would otherwise push over the Playwright CDP
+			// session in volumes that starve it. See PINNED_CONSOLE_LEVEL for why Debug.
 			// consoleLogger = new ConsoleLogger(fileLogger.getLevel());
 			consoleLogger = shouldPinConsoleEcho(environmentService)
-				? new FixedLevelConsoleLogger(LogLevel.Debug)
+				? new FixedLevelConsoleLogger(PINNED_CONSOLE_LEVEL)
 				: new ConsoleLogger(fileLogger.getLevel());
 			// --- End Positron ---
 		}

--- a/src/vs/workbench/services/log/electron-browser/logService.ts
+++ b/src/vs/workbench/services/log/electron-browser/logService.ts
@@ -10,7 +10,7 @@ import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { windowLogGroup, windowLogId } from '../common/logConstants.js';
 import { LogService } from '../../../../platform/log/common/logService.js';
 // --- Start Positron ---
-import { FixedLevelConsoleLogger } from '../common/fixedLevelConsoleLogger.js';
+import { FixedLevelConsoleLogger, shouldPinConsoleEcho } from '../common/fixedLevelConsoleLogger.js';
 // --- End Positron ---
 
 export class NativeLogService extends LogService {
@@ -37,7 +37,7 @@ export class NativeLogService extends LogService {
 			// debug output in the trace, where it sits on the same timeline as the test's actions.
 			// On-disk logs stay at trace, and `--verbose` opts back out.
 			// consoleLogger = new ConsoleLogger(fileLogger.getLevel());
-			consoleLogger = environmentService.enableSmokeTestDriver && !environmentService.verbose
+			consoleLogger = shouldPinConsoleEcho(environmentService)
 				? new FixedLevelConsoleLogger(LogLevel.Debug)
 				: new ConsoleLogger(fileLogger.getLevel());
 			// --- End Positron ---

--- a/src/vs/workbench/services/log/electron-browser/logService.ts
+++ b/src/vs/workbench/services/log/electron-browser/logService.ts
@@ -3,12 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ConsoleLogger, ILogger, isDevConsoleLogForwardingEnabled, registerDevConsoleLogForwarder } from '../../../../platform/log/common/log.js';
+import { ConsoleLogger, ILogger, isDevConsoleLogForwardingEnabled, LogLevel, registerDevConsoleLogForwarder } from '../../../../platform/log/common/log.js';
 import { INativeWorkbenchEnvironmentService } from '../../environment/electron-browser/environmentService.js';
 import { LoggerChannelClient } from '../../../../platform/log/common/logIpc.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { windowLogGroup, windowLogId } from '../common/logConstants.js';
 import { LogService } from '../../../../platform/log/common/logService.js';
+// --- Start Positron ---
+import { FixedLevelConsoleLogger } from '../common/fixedLevelConsoleLogger.js';
+// --- End Positron ---
 
 export class NativeLogService extends LogService {
 
@@ -24,7 +27,18 @@ export class NativeLogService extends LogService {
 			consoleLogger = loggerService.createConsoleMainLogger();
 		} else {
 			// Normal mode: Log to console
-			consoleLogger = new ConsoleLogger(fileLogger.getLevel());
+			// --- Start Positron ---
+			// The console echo below follows the file-log level, and e2e runs pass `--log=trace`,
+			// so every trace record is also pushed over the Playwright CDP session. That flood
+			// starves the session's request/response direction: `expect` evaluations park for tens
+			// of seconds against a workbench that is already rendered, then drain in one batch.
+			// Pin the echo at Info under the smoke driver; on-disk logs stay at trace, and
+			// `--verbose` opts back out.
+			// consoleLogger = new ConsoleLogger(fileLogger.getLevel());
+			consoleLogger = environmentService.enableSmokeTestDriver && !environmentService.verbose
+				? new FixedLevelConsoleLogger(LogLevel.Info)
+				: new ConsoleLogger(fileLogger.getLevel());
+			// --- End Positron ---
 		}
 
 		super(fileLogger, [consoleLogger]);

--- a/src/vs/workbench/services/log/test/common/fixedLevelConsoleLogger.vitest.ts
+++ b/src/vs/workbench/services/log/test/common/fixedLevelConsoleLogger.vitest.ts
@@ -6,7 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import { ConsoleLogger, LogLevel, MultiplexLogger } from '../../../../../platform/log/common/log.js';
-import { FixedLevelConsoleLogger } from '../../common/fixedLevelConsoleLogger.js';
+import { FixedLevelConsoleLogger, shouldPinConsoleEcho } from '../../common/fixedLevelConsoleLogger.js';
 
 describe('FixedLevelConsoleLogger', () => {
 
@@ -30,5 +30,27 @@ describe('FixedLevelConsoleLogger', () => {
 
 		expect({ pinned: pinned.getLevel(), upstream: upstream.getLevel() })
 			.toEqual({ pinned: LogLevel.Info, upstream: LogLevel.Trace });
+	});
+});
+
+describe('shouldPinConsoleEcho', () => {
+
+	test('pins only under the smoke driver, and never when verbose is asked for', () => {
+		const decide = (enableSmokeTestDriver: boolean | undefined, verbose: boolean) =>
+			shouldPinConsoleEcho({ enableSmokeTestDriver, verbose });
+
+		expect({
+			smoke: decide(true, false),
+			smokeVerbose: decide(true, true),
+			normal: decide(false, false),
+			normalVerbose: decide(false, true),
+			flagAbsent: decide(undefined, false),
+		}).toEqual({
+			smoke: true,
+			smokeVerbose: false,
+			normal: false,
+			normalVerbose: false,
+			flagAbsent: false,
+		});
 	});
 });

--- a/src/vs/workbench/services/log/test/common/fixedLevelConsoleLogger.vitest.ts
+++ b/src/vs/workbench/services/log/test/common/fixedLevelConsoleLogger.vitest.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ConsoleLogger, LogLevel, MultiplexLogger } from '../../../../../platform/log/common/log.js';
+import { FixedLevelConsoleLogger } from '../../common/fixedLevelConsoleLogger.js';
+
+describe('FixedLevelConsoleLogger', () => {
+
+	test('keeps the level it was constructed with when setLevel is called', () => {
+		const logger = new FixedLevelConsoleLogger(LogLevel.Info);
+
+		logger.setLevel(LogLevel.Trace);
+
+		expect(logger.getLevel()).toBe(LogLevel.Info);
+	});
+
+	test('ignores the level a MultiplexLogger fans out, unlike ConsoleLogger', () => {
+		// This is the coupling the class exists to break: LogService wires the file logger's
+		// onDidChangeLogLevel to its own setLevel, which a MultiplexLogger forwards to every
+		// logger it holds. Under `--log=trace` that puts trace records on the console, and the
+		// e2e smoke driver pushes them over the Playwright CDP session.
+		const pinned = new FixedLevelConsoleLogger(LogLevel.Info);
+		const upstream = new ConsoleLogger(LogLevel.Info);
+
+		new MultiplexLogger([pinned, upstream]).setLevel(LogLevel.Trace);
+
+		expect({ pinned: pinned.getLevel(), upstream: upstream.getLevel() })
+			.toEqual({ pinned: LogLevel.Info, upstream: LogLevel.Trace });
+	});
+});


### PR DESCRIPTION
Stops the e2e console flood that has been failing the post-reload workbench check on Windows.

### What was happening

The test harness and the app share one connection. The app was narrating everything it did down that line -- with `--log=trace`, thousands of low-level status messages -- and that narration is one-way, so it flowed freely. The harness's questions ("is the workbench visible yet?") need an answer coming back, and those got stuck behind it.

In [run 33866584127](https://github.com/posit-dev/positron/actions/runs/33866584127), the harness asked 11 times over 30 seconds and got no reply, so the test failed. The workbench had been rendered the whole time. We know because when the chatter died down, the last five probes all came back `error: null` -- they passed, just far too late.

| From the trace | |
|---|---|
| Probe durations | 2.0s - 18.3s, against a 2000ms timeout |
| How they resolved | all flushed together at one instant |
| Last 5 probes | passed, after the drain |
| Console messages during the wait | 791, largest gap 2.19s |
| Screencast frames during the wait | 5, largest gap 20.3s |
| `.monaco-workbench` in the DOM | 18/18 snapshots |

Console messages are pushed one-way; evaluations, screencasts and screenshots need a round trip. Push kept flowing, round trips starved.

### The fix

`FixedLevelConsoleLogger` is a `ConsoleLogger` whose level is pinned at construction, selected under `enableSmokeTestDriver && !verbose`. Pinning is necessary rather than just constructing one at Debug: `LogService` wires the file logger's `onDidChangeLogLevel` to its own `setLevel`, and the `MultiplexLogger` fans that out to every logger it holds.

No timeouts changed.

### Do we lose the trace logs we debug from? No.

This was the main worry, so to be explicit about where each copy lives:

- **The app's own log files** -- `renderer.log`, `main.log`, the exthost logs -- are written by the **file** logger, which this does not touch. They stay at full trace. Every test zips them and attaches them to its Playwright report, so they survive in the published report. This is the copy we actually debug from.
- **The console echo** is a *duplicate* of those same records, shouted down the connection as well as written to disk. That is the only thing being reduced.

The file logger and the console logger are siblings on the same multiplexer, so anything dropped from the console is still in the file by construction. There is no record that existed only on the console side. And anything that never went through the logger -- direct `console.log` calls, extension-host passthrough -- is unaffected either way.

**What we do lose:** the console echo put app messages on the same timeline as the harness's actions, in the trace and in `e2e-test-runner.log`. That combined view gets thinner, and you correlate two files by timestamp instead of reading one. That is the entire cost.

### How many tests this affects

Not just the one that surfaced it. Querying 14 days of `main` history for every spec that calls `hotKeys.reloadWindow`: **10 tests match this fingerprint, across 93 fail/flaky events.** All Windows-only, all carrying the same three `.monaco-workbench` error strings (the three eras of this one defect).

| Test | Spec | Events | Rate |
|---|---|---|---|
| Py - HTML widget persists after reload | quarto-inline-output-dataframe | 22 | 4.6% |
| R - DataFrame persists after reload | quarto-inline-output-dataframe | 20 | 4.2% |
| Rename sessions, name persists | session-rename | 14 | 4.4% |
| Ghost editor: no dup notebook on reload | notebook-editor | 9 | 3.0% |
| Copilot "Learn How to Hide AI Features" | copilot-signin-suppressed | 7 | 2.4% |
| Untitled names increment after reload | notebook-untitled-naming | 7 | 1.5% |
| Import prompt on "Don't Show Again" | import-vscode-settings | 6 | 2.0% |
| Import prompt on "Later" | import-vscode-settings | 5 | 1.7% |
| Copilot AI sign-in entry in Accounts | copilot-signin-suppressed | 2 | 0.7% |
| Hidden panel stays hidden | panel-visibility | 1 | 0.2% |

`session-rename` is the one caveat: 12 of its 14 are Windows but 2 are ubuntu, so part of that count is probably something else.

**It has also cost us coverage outright.** Five reload tests are currently `test.skip` -- two in `lsp-outline`, plus `session-mgmt`, `r-session-hooks`, and `notebook-scroll-position`. That last one says why:

```ts
// skipping because reloadWindow is unreliable
test.skip('Scroll position is restored after window reload', ...)
```

Nobody ever diagnosed *why* it was unreliable. If this fix holds, those five are re-enable candidates.

Worth noting it is not universal: `externally-managed-python-prompt`, `quarto-inline-output-rawhtml-persistence`, and `default-python-interpreter` all reload without ever tripping it, so it needs a heavy enough console burst at the wrong moment.

**Unrelated, flagged in passing:** an "Unknown error" cluster in `import-vscode-settings` (8 events across three tests, Windows-only, first seen Aug 28) has no captured message, so it cannot be attributed to this from history alone. Possibly a second defect worth its own look.

### Why Debug and not Info

Measured from the failure window: of 791 messages, 78% were trace and 12% debug.

| | Messages left | Cut |
|---|---|---|
| Pin at Debug (this PR) | 177 | 78% |
| Pin at Info | 78 | 90% |

Info gives ~2.3x more headroom but throws away the debug records, which are the readable ones. 78% is a large enough cut to keep them. Worth noting the flood is concentrated and mundane: extension-location lookups and command dispatch tracing alone are over a quarter of it, both trace-level.

### Why the four previous attempts did not work

#15793, #15824, #15843 and #15902 all changed *how the harness asks*. The asking was never broken -- #15902 provably fixed the retry loop (11 probes at a textbook 2751-2786ms cadence, versus 3-in-30s before), and the failure rate still went from 7/112 (6.3%) to 6/32 (18.8%).

It is also the same stall confirmed in May 2026, which #13900 papered over at startup with a 60s budget. `reloadWindow` has 30s and this drain landed at ~33.3s, which is why startup survived it and reload did not. 18 specs call `hotKeys.reloadWindow`; the quarto test is just the one that surfaced it.

### Scope

This affects **all Electron lanes** -- Windows, Ubuntu, macOS, Rocky/SUSE/SLES/Debian. Not web/chromium, which uses a different log service, so those runs still flood.

The flag itself is internal: registered in `argv.ts` with no `cat` or `description`, so it never appears in `--help`, and everything passing it is a test or automation harness. A shipped build still honours it, so anyone launching manually with it gets the capped console; `--verbose` opts out. There is precedent for gating this way in `localProcessExtensionHost.ts`.

### Considered and rejected

Stopping the harness from *listening* instead of the app from *talking*. It does not work: trace recording subscribes independently, and the browser ships console events as a side effect of the same channel Playwright needs to evaluate anything at all. The messages cross the wire either way.

### Test coverage

`fixedLevelConsoleLogger.vitest.ts` covers two things:

- **The pin**, including a case asserting the level after a real `MultiplexLogger` fan-out, so it documents the coupling and not just the behaviour.
- **The gate.** `shouldPinConsoleEcho` is a separate function precisely so the condition is reachable without casting a `LoggerChannelClient` into place, and the test covers all four smoke/verbose combinations plus the flag-absent case. Without it, inverting the condition would silently restore the flood -- or suppress trace during a verbose run -- with every other test still green.

All three were verified to fail when the behaviour they cover is removed.

There is no automated assertion that console volume actually drops -- that is what this cannot prove locally, and why it is a draft. The falsifiable prediction: post-reload gate failures stop **with no timeout changed**. If they do not, the flood was not the starving traffic.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test infrastructure)

### Validation Steps

@:critical @:quarto @:sessions @:positron-notebooks @:interpreter @:win

This touches logging for every Electron e2e run, so the value is a broad green run rather than one scenario.

1. Watch the win/electron lane -- the only environment this defect appears in.
2. Watch anything calling `hotKeys.reloadWindow`, especially `tests/quarto/quarto-inline-output-persistence.test.ts` ("Python - Verify kernel status persists after window reload").
3. Confirm the per-test `logs-*.zip` attachment on a report still contains trace-level records. The console echo is capped; the log files must not be. (Note: the `test-logs` artifact is not the place to check -- both electron lanes set `upload_logs: false`.)


### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- Post-reload .monaco-workbench gate fails because trace-level renderer console output floods the Playwright CDP session during extension-host reactivation, starving the request/response direction; every Frame.expect evaluation queues and the batch drains ~33.3s in, past the 30s RELOAD_READY_TIMEOUT. The workbench is rendered and visible throughout.</summary>

- **Test:** [Quarto - Inline Output: Persistence > Python - Verify kernel status persists after window reload](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=Quarto%20-%20Inline%20Output%3A%20Persistence%20%3E%20Python%20-%20Verify%20kernel%20status%20persists%20after%20window%20reload%7C%7C%7Ctest%2Fe2e%2Ftests%2Fquarto%2Fquarto-inline-output-persistence.test.ts)
- **Targeted failure:** Error: post-reload workbench probe did not settle within 2500ms (pattern B), win/electron only
- **Signal:** 11 probes at exact 2750ms cadence (loop healthy, #15902 works); probe server-side durations 2.0-18.3s on a 2000ms timeout, all flushing together t=2213105-2214540; last 5 probes error:null (passed) at the drain; 791 console events max gap 2.19s vs 5 screencast frames max gap 20.3s; .monaco-workbench present in 18/18 DOM snapshots during the wait
- **Frequency:** 4/144 runs (2.8%) on main, win/electron
- **Hypothesis:** electron.ts:37 passes --log=trace unconditionally and logService.ts:27 couples the ConsoleLogger level to the file log level, so every trace-level renderer log is echoed to console and pushed over CDP. Smoke-gating the console echo at Info (on-disk logs unchanged) removes the flood and the reload gate should stop failing with no timeout change. Same confirmed root cause as the May 2026 Windows CDP stall (PR #13900 stopgap); the echo cap was implemented then reverted 2026-05-29 and never landed. Startup survives it only because application.ts:245 uses LOAD_TIMEOUT=60s.
- **Supersedes:** PRs #15793, #15824, #15843, #15902 all treated this as a client-side probe-loop defect; #15902 measurably fixed the loop (11 clean 2750ms cycles vs 3-in-30s) but the rate went 6.3% -> 18.8% because the starved channel was never the loop

</details>

