### PR TITLE
Let agents run and debug web apps through Positron's app commands

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -471,42 +471,120 @@
                 "command": "python.execDashInTerminal",
                 "icon": "$(play)",
                 "title": "%python.command.python.execDashInTerminal.title%",
-                "enablement": "pythonAppFramework == dash"
+                "agent": {
+                    "description": "Run and preview a Dash app.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.execFastAPIInTerminal",
                 "icon": "$(play)",
                 "title": "%python.command.python.execFastAPIInTerminal.title%",
-                "enablement": "pythonAppFramework == fastapi"
+                "agent": {
+                    "description": "Run a FastAPI app and preview its interactive API docs.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.execFlaskInTerminal",
                 "icon": "$(play)",
                 "title": "%python.command.python.execFlaskInTerminal.title%",
-                "enablement": "pythonAppFramework == flask"
+                "agent": {
+                    "description": "Run and preview a Flask app.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.execGradioInTerminal",
                 "icon": "$(play)",
                 "title": "%python.command.python.execGradioInTerminal.title%",
-                "enablement": "pythonAppFramework == gradio"
+                "agent": {
+                    "description": "Run and preview a Gradio app.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.execMarimoInTerminal",
                 "icon": "$(play)",
                 "title": "%python.command.python.execMarimoInTerminal.title%",
-                "enablement": "pythonAppFramework == marimo"
+                "agent": {
+                    "description": "Run and preview a marimo notebook as an app.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.execStreamlitInTerminal",
                 "icon": "$(play)",
                 "title": "%python.command.python.execStreamlitInTerminal.title%",
-                "enablement": "pythonAppFramework == streamlit"
+                "agent": {
+                    "description": "Run and preview a Streamlit app.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
@@ -519,42 +597,120 @@
                 "command": "python.debugDashInTerminal",
                 "icon": "$(debug-alt)",
                 "title": "%python.command.python.debugDashInTerminal.title%",
-                "enablement": "pythonAppFramework == dash"
+                "agent": {
+                    "description": "Run and preview a Dash app under the Python debugger.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.debugFastAPIInTerminal",
                 "icon": "$(debug-alt)",
                 "title": "%python.command.python.debugFastAPIInTerminal.title%",
-                "enablement": "pythonAppFramework == fastapi"
+                "agent": {
+                    "description": "Run a FastAPI app under the Python debugger and preview its interactive API docs.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.debugFlaskInTerminal",
                 "icon": "$(debug-alt)",
                 "title": "%python.command.python.debugFlaskInTerminal.title%",
-                "enablement": "pythonAppFramework == flask"
+                "agent": {
+                    "description": "Run and preview a Flask app under the Python debugger.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.debugGradioInTerminal",
                 "icon": "$(debug-alt)",
                 "title": "%python.command.python.debugGradioInTerminal.title%",
-                "enablement": "pythonAppFramework == gradio"
+                "agent": {
+                    "description": "Run and preview a Gradio app under the Python debugger.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.debugMarimoInTerminal",
                 "icon": "$(debug-alt)",
                 "title": "%python.command.python.debugMarimoInTerminal.title%",
-                "enablement": "pythonAppFramework == marimo"
+                "agent": {
+                    "description": "Run and preview a marimo notebook as an app under the Python debugger.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
                 "command": "python.debugStreamlitInTerminal",
                 "icon": "$(debug-alt)",
                 "title": "%python.command.python.debugStreamlitInTerminal.title%",
-                "enablement": "pythonAppFramework == streamlit"
+                "agent": {
+                    "description": "Run and preview a Streamlit app under the Python debugger.",
+                    "args": [
+                        {
+                            "name": "uri",
+                            "required": false,
+                            "description": "URI of the app file to run. Omit to run the active editor's file.",
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": "Nothing. Returns when Positron has previewed the app, or when an error occurred."
+                }
             },
             {
                 "category": "Python",
@@ -1653,6 +1809,78 @@
                 }
             ],
             "commandPalette": [
+                {
+                    "category": "Python",
+                    "command": "python.execDashInTerminal",
+                    "title": "%python.command.python.execDashInTerminal.title%",
+                    "when": "pythonAppFramework == dash"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.debugDashInTerminal",
+                    "title": "%python.command.python.debugDashInTerminal.title%",
+                    "when": "pythonAppFramework == dash"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.execFastAPIInTerminal",
+                    "title": "%python.command.python.execFastAPIInTerminal.title%",
+                    "when": "pythonAppFramework == fastapi"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.debugFastAPIInTerminal",
+                    "title": "%python.command.python.debugFastAPIInTerminal.title%",
+                    "when": "pythonAppFramework == fastapi"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.execFlaskInTerminal",
+                    "title": "%python.command.python.execFlaskInTerminal.title%",
+                    "when": "pythonAppFramework == flask"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.debugFlaskInTerminal",
+                    "title": "%python.command.python.debugFlaskInTerminal.title%",
+                    "when": "pythonAppFramework == flask"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.execGradioInTerminal",
+                    "title": "%python.command.python.execGradioInTerminal.title%",
+                    "when": "pythonAppFramework == gradio"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.debugGradioInTerminal",
+                    "title": "%python.command.python.debugGradioInTerminal.title%",
+                    "when": "pythonAppFramework == gradio"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.execMarimoInTerminal",
+                    "title": "%python.command.python.execMarimoInTerminal.title%",
+                    "when": "pythonAppFramework == marimo"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.debugMarimoInTerminal",
+                    "title": "%python.command.python.debugMarimoInTerminal.title%",
+                    "when": "pythonAppFramework == marimo"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.execStreamlitInTerminal",
+                    "title": "%python.command.python.execStreamlitInTerminal.title%",
+                    "when": "pythonAppFramework == streamlit"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.debugStreamlitInTerminal",
+                    "title": "%python.command.python.debugStreamlitInTerminal.title%",
+                    "when": "pythonAppFramework == streamlit"
+                },
                 {
                     "category": "Python",
                     "command": "python.analysis.restartLanguageServer",

--- a/extensions/positron-skills/templates/positron-commands/SKILL.md
+++ b/extensions/positron-skills/templates/positron-commands/SKILL.md
@@ -3,18 +3,17 @@ name: positron-commands
 description: >
   Running Positron IDE commands: changing the window layout, focusing panes
   (Console, Variables, Plots, Help, Packages), clearing the console, opening a
-  file or data file in the right editor, listing or discovering interpreters,
-  listing running sessions, switching or starting a session, restarting or
-  interrupting a stuck one, setting up Python, and reading, installing or
-  updating the packages in a session. Use when the user wants Positron itself
-  to act, or to know what is installed, rather than to run R or Python code.
+  file or data file in the right editor, discovering interpreters, listing,
+  switching, starting, restarting or interrupting sessions, setting up Python,
+  reading, installing or updating the packages in a session, and running or
+  debugging a web app (Shiny, Flask, Dash, Streamlit, FastAPI, Gradio,
+  marimo). Use when the user wants Positron itself to act, or to know what is
+  installed, rather than to run R or Python code.
   Triggers: "switch to the data science layout", "show the variables pane",
   "clear the console", "open data.csv", "what interpreters are available",
-  "switch to my R session", "start a new Python session", "my R interpreter
-  isn't showing up", "my session is stuck", "is pandas installed?", "install
-  dplyr", "update all my packages", "do I have any vulnerable packages?", "I
-  don't have Python installed", "set up a Python environment", "which Python am
-  I using".
+  "switch to my R session", "start a new Python session", "my session is
+  stuck", "is pandas installed?", "install dplyr", "update all my packages",
+  "set up a Python environment", "run my shiny app", "my app URL doesn't load".
 ---
 
 # Positron IDE commands
@@ -106,3 +105,13 @@ rather than running code to check.
 Read when the user is getting Python set up: installing a Python interpreter when
 they have none, creating a project environment (venv, Conda, or uv), or finding
 out which interpreter is currently active.
+
+**Interactive web apps** -- [references/interactive-apps.md]({{skill_dir}}/references/interactive-apps.md)
+Read when the user wants a web app running or debugged: "run my app", "start
+the shiny/flask/dash/streamlit/marimo app", "preview my dashboard". Read it
+**before** starting any app server yourself -- app servers must not be started via
+`executeCode` or a raw terminal command for supported app frameworks. The
+commands it documents manage the terminal, detect the app URL, set up any
+proxying the environment requires (on Posit Workbench, raw `localhost`
+URLs are not reachable from the user's browser), and preview the app -- in the
+Viewer by default, or wherever the user's preview mode setting points.

--- a/extensions/positron-skills/templates/positron-commands/references/interactive-apps.md
+++ b/extensions/positron-skills/templates/positron-commands/references/interactive-apps.md
@@ -1,0 +1,287 @@
+# Positron interactive web app commands
+
+Running an interactive web app -- Dash, FastAPI, Flask, Gradio, marimo,
+Streamlit, or Shiny -- through Positron's Develop Data Apps feature. See
+[SKILL.md]({{skill_dir}}/SKILL.md) for how to call these commands and how to
+handle failures.
+
+The **Arguments** and **Returns** entries below are generated from the command
+metadata this build and its installed extensions publish, so they always match
+this Positron. The surrounding guidance is hand-written.
+
+## Prefer these commands over running a server yourself
+
+The commands below run an app the way Positron's play button does: a managed
+terminal or console, automatic URL detection, any proxying the environment
+requires, and a preview once the URL is found. Starting the same app with
+`executeCode` or a raw terminal command (`python app.py`, `flask run`,
+`shiny run`, and so on) blocks a console or leaves an orphaned server, skips
+URL detection and proxying, and never reaches a preview.
+
+Start a server yourself only when no command below covers the framework, or as
+a last resort once the matching command has failed -- and tell the user that is
+what you are doing and why.
+
+**On Posit Workbench**, `localhost` URLs are not reachable from the user's
+browser, and several frameworks additionally need base-path or proxy
+configuration that these commands apply automatically. Running applications
+manually in this environment may lead to unexpected errors. Do not respond to
+an app that doesn't load there by modifying the app, changing its port, or
+adding workarounds -- re-run it with the matching command below.
+
+## Step-by-step
+
+1. **Identify the framework** from the app file's imports (`import dash`,
+   `from flask import`, `from shiny import`, `import marimo`,
+   `library(shiny)`, ...). If you cannot tell which framework a file uses, ask
+   the user rather than guessing.
+2. **Run the matching command** from the sections below, passing the app
+   file's URI. App startup can take a while, so the command may take a moment
+	 to come back.
+3. **Do not read the result as proof the app is up.** These commands return
+   nothing, and they return nothing whether the app is serving or failed to
+   start. You cannot read the app's terminal or console output either, and
+   Positron may have shown the user an error notification you cannot see, so
+   you have no evidence of your own about the app's state.
+4. **Say what you ran and where the preview should appear, then let the user
+   confirm.** Every command previews the app once Positron detects its URL --
+   in the Viewer pane by default, but the user's preview mode setting can point
+   it at an editor tab or their own browser instead, so name the Viewer only
+   when you know that is where it went (see "Settings"). Ask the user to paste
+	 the app's terminal (or console) output if nothing shows up. Do not re-run
+	 the command on a hunch: re-running restarts an app that may be perfectly fine.
+
+   Detection can also lag or lapse: a slow app can outrun the detection
+   timeout the user controls with `positron.runApp.urlDetectionTimeout`, and a
+   shell without shell integration disables detection entirely, so a
+   terminal-run app runs with nothing ever previewing. For an app run in the
+   console (Shiny for R), upon timeout  Positron notifies the
+   user and keeps watching, so the app may appear in the Viewer by itself a
+   little later. Re-running would only restart an app that was about to show
+   up.
+
+The Python commands run whatever file you pass without checking its framework,
+so a wrong URI or a mismatched command surfaces as a startup error in the app's
+terminal -- which you cannot see -- rather than as a failed call. When the user
+reports that nothing appeared, ask for that output, then fix the URI or command
+and re-run rather than switching to a raw terminal run. The Python commands
+have no precondition, so they never come back `disabled`; a `disabled` result
+from a Shiny command means the active editor's file was not recognized as a
+Shiny app.
+
+Lifecycle: re-running a command restarts the app (Positron closes the app's
+old terminal first). **You cannot stop a running app yourself**: no command
+here stops an app server or kills a terminal (`shiny.stopApp` for Shiny is
+the one exception). When the user wants an app stopped, tell them to press
+the stop button in the Viewer pane when the app was previewed there, or to
+kill the app's terminal -- it is named after the framework.
+
+## The app's URL
+
+These commands do not return the app's URL, and you cannot read it out of the
+app's terminal output, so you never have one to hand the user. Point them at
+the surface the app was previewed on instead (see "Settings")
+-- that is where they interact with it. Do not tell them to open a URL in order
+to see their app, and never guess at a port.
+
+**Elsewhere than Posit Workbench**, if the user specifically wants an address
+for a full browser tab, the app prints one in its terminal output: ask them to
+read it from there.
+
+**On Posit Workbench** that printed `localhost` URL is not reachable from the
+user's browser, so it is not the address to give them. Point them at the
+Workbench extension's Proxied Servers view instead.
+
+## Settings
+
+You do not have to guess at any of these: read them with
+`positronSettings.getConfiguredSettings`, filtered to `runApp` or `terminal`
+(see the Positron settings skill). A user who has set nothing is on the
+default. Each setting's own description in Positron's settings editor is the
+authoritative wording; the notes here cover only what changes how you work.
+
+### `positron.runApp.previewMode`
+
+Where the app is previewed once its URL is detected: the Viewer pane
+(`viewer`, the default), a Simple Browser editor tab (`editor`), the user's own
+browser (`external`), or nowhere (`none`). It applies to the Python framework
+commands; Shiny is governed separately by `shiny.previewType`.
+
+`none` is the one that changes how you work: it turns URL detection off
+entirely, so a healthy app produces no preview anywhere and waiting or
+re-running will not change that. `external` matters less but still makes
+"check the Viewer" the wrong thing to say. Read the setting before telling the
+user which pane to look at, and after a run the user says they cannot see.
+
+### `positron.runApp.urlDetectionTimeout`
+
+How long Positron waits for the app to print its URL. A slow app can outrun
+it: the app still runs, it just never gets previewed.
+
+### `terminal.integrated.shellIntegration.enabled`
+
+URL detection for terminal-run apps rides on shell integration. With it off the
+app still runs, but Positron never sees its URL and nothing previews.
+
+Neither the timeout nor shell integration is a reason to re-run. Ask the user
+what the app's terminal shows instead.
+
+## Posit Workbench
+
+Everything in this section applies only when the session is running on Posit
+Workbench. If the user asks whether their app will work there, this is the
+difference to mention: on Workbench an app must be run through the commands
+below to be reachable at all, and its code has to tolerate being served under
+a proxy path.
+
+### Write proxy-safe app code
+
+A running app is served through a path-rewriting proxy: the page the user
+sees lives under the proxied URL's path, not at the app's own root. The proxy
+strips that path before the request reaches the app and passes it along in the
+`X-Forwarded-Prefix` header. An app that reads the header generates correct
+URLs; an app that ignores it emits paths that escape the proxy path and land on
+a Workbench error page instead of the app.
+
+- **Flask: add Werkzeug's `ProxyFix`, then write ordinary Flask.** With the
+  middleware in place `url_for` and `redirect(url_for(...))` produce correctly
+  prefixed URLs, and `action="{{ url_for('add') }}"` is the right thing to put
+  in a form. Nothing else about the app has to change. Guard it on
+  `RS_SERVER_URL` so the same file still runs unchanged off Workbench:
+
+  ```python
+  app = Flask(__name__)
+  if os.environ.get('RS_SERVER_URL'):
+      from werkzeug.middleware.proxy_fix import ProxyFix
+      app.wsgi_app = ProxyFix(app.wsgi_app, x_prefix=1)
+  ```
+
+- **Other frameworks:** use relative paths for form actions and redirects
+  (`action="add"`, never `action="/add"`), unless the framework has its own way
+  to be told its mount point. Positron sets `DASH_URL_BASE_PATHNAME` for Dash
+  apps itself, so a Dash app must not set path-related `DASH_*` environment
+  variables.
+
+### Recognize proxy-related failures
+
+When an app misbehaves here, check whether the proxy path explains it before
+digging into the app's own logic.
+
+- **A Workbench sign-in page, or a 404, where the app should be.** A
+  root-absolute path escaped the proxy path: the browser asked the Workbench
+  origin for `/add` rather than `<prefix>/add`. This is the most common
+  failure and it usually appears on the second interaction (a form post, a
+  link), not on first load.
+- **The app loads but is unstyled, or images are missing.** The same cause,
+  for `src` and `href`.
+- **The prefix appears twice in a URL.** Over-correction: something is adding
+  the prefix to a path that already carries it, e.g. `ProxyFix` on top of a
+  hand-written prefix or a framework mount setting. Remove one of them, do not
+  add a third.
+- **A redirect or link lands on `localhost:<port>`.** An absolute URL built
+  from the app's own host leaked out. In Flask this is `url_for(...,
+  _external=True)`; add `x_host=1` to `ProxyFix`.
+- **The page renders but never connects** (a spinner, "Connecting...",
+  websocket errors in the browser console). This is the websocket, not HTTP,
+  and app code usually cannot fix it. Streamlit on Workbench with SSL enabled
+  is a known instance.
+- **FastAPI's `/docs` renders but reports "Failed to load API definition".**
+  Swagger fetches `/openapi.json` from the origin root. Fixing it needs
+  uvicorn's `--root-path`, which the run commands do not pass; report it as a
+  known limitation rather than editing the user's app.
+
+Not every URL-shaped symptom is the proxy. A page that displays a path as
+plain text is a Flask view returning `url_for(...)` where it should return
+`redirect(url_for(...))` -- a string return value is the response body.
+
+### Working on Posit Workbench
+
+- In-session requests to `localhost` do work: you may smoke-test a running
+  app with `curl http://localhost:<port>/...` from a terminal. Never pass that
+  `localhost` URL on to the user -- point them at the Proxied Servers view.
+- If the user insists on running from a terminal anyway, the app needs the
+  same proxy-safe code as above, and it is opened from the Workbench
+  extension's Proxied Servers view rather than the printed URL. See
+  Workbench's "Proxying Web Servers" documentation (docs.posit.co).
+
+## Python frameworks
+
+Each command runs an app file in a dedicated terminal: pass the file's URI
+and Positron runs it. The URI takes the same form `vscode.open` needs -- read
+[files.md]({{skill_dir}}/references/files.md) for the exact shape this
+environment requires (a relative path always names the wrong file). The file
+does not have to be open, and Positron leaves the user's editors as they are --
+do not open the file yourself first. All of them come from the Python
+extension, so expect `not-found` if Python support isn't loaded yet. None of
+them return the app's URL -- see steps 3 and 4 of "The flow" above for how to
+tell whether the app actually started.
+
+### `python.execDashInTerminal`
+
+{{command:python.execDashInTerminal}}
+
+### `python.execFastAPIInTerminal`
+
+Opens the interactive API docs (`/docs`) in the Viewer rather than a UI page,
+because a FastAPI app has no UI of its own.
+
+{{command:python.execFastAPIInTerminal}}
+
+### `python.execFlaskInTerminal`
+
+{{command:python.execFlaskInTerminal}}
+
+### `python.execGradioInTerminal`
+
+{{command:python.execGradioInTerminal}}
+
+### `python.execMarimoInTerminal`
+
+Serves a marimo notebook file as an app (`marimo run --headless`), so the user
+sees the app read-only rather than marimo's editable notebook. There is no
+command for the editable view (`marimo edit`) -- if the user wants that, say so
+and start it from a terminal.
+
+{{command:python.execMarimoInTerminal}}
+
+### `python.execStreamlitInTerminal`
+
+{{command:python.execStreamlitInTerminal}}
+
+## Shiny (Python and R)
+
+These come from the Shiny extension. Unlike the Python commands they run the
+**active editor's** file rather than a path you pass, so open the app file with
+`vscode.open` first. Read [files.md]({{skill_dir}}/references/files.md) before
+calling it -- it gives the exact argument shape this environment needs (a
+relative path always opens the wrong file). If the open errors or opens the
+wrong thing, fix the argument and re-open before running: the run commands act
+on whatever editor is focused, so a bad open makes the run fail too.
+
+The Shiny extension ships out of this repo and publishes no command metadata,
+so unlike the Python commands above these have no generated **Arguments** and
+**Returns** entries; what follows is hand-written. In the extension versions
+this skill covers they take no arguments. A newer Shiny release may accept the
+app file's URI directly; until this section documents that argument, keep
+opening the file first -- a version that ignores the argument would silently run
+whatever editor is focused instead.
+
+- **`shiny.python.runApp`** -- runs the active editor's file as a Shiny for
+  Python app in a dedicated terminal and previews it.
+- **`shiny.r.runApp`** -- runs the active editor's file as a Shiny for R app
+  in the R Console (R Shiny apps run in the console, not a terminal) and
+  previews it.
+- **`shiny.stopApp`** -- stops the running Shiny app.
+
+## Debugging an app
+
+Each Python framework also has a debug variant that starts the app under the
+Python debugger: `python.debugDashInTerminal`,
+`python.debugFastAPIInTerminal`, `python.debugFlaskInTerminal`,
+`python.debugGradioInTerminal`, `python.debugMarimoInTerminal`,
+`python.debugStreamlitInTerminal` (and `shiny.python.debugApp` for Shiny for
+Python). The Python debug variants take
+the same optional file argument as the run commands. Use one only when the
+user explicitly asks to debug their app -- the user sets breakpoints in the
+editor gutter; you cannot set them. To simply run or restart an app, always
+use the run commands above.

--- a/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillDrift.vitest.ts
+++ b/src/vs/workbench/contrib/positronAiFeatures/test/browser/agentSkillDrift.vitest.ts
@@ -65,11 +65,26 @@ const ALLOWED_PREFIXES = ['positron.', 'positronAssistant.', 'positronPackages.'
  * itself flagged as stale by the test below.
  */
 const KNOWN_EXTENSION_COMMANDS = new Set([
-	// All three declared in extensions/positron-python/src/client/common/constants.ts
+	// All declared in extensions/positron-python/src/client/common/constants.ts
 	'python.createEnvironmentAndRegister',
 	'python.installPythonViaUv',
 	'python.interpreterPath',
+	'python.execDashInTerminal',
+	'python.execFastAPIInTerminal',
+	'python.execFlaskInTerminal',
+	'python.execGradioInTerminal',
+	'python.execMarimoInTerminal',
+	'python.execStreamlitInTerminal',
 ]);
+
+/**
+ * Prefixes under which a dotted, `positron.`-prefixed prose token is a
+ * *setting* key rather than a command id, so the command scan must skip it.
+ * `positron.runApp.previewMode` and `positron.runApp.urlDetectionTimeout` are
+ * contributed by the positron-run-app extension and are named in the
+ * interactive-apps reference as settings to read, not commands to run.
+ */
+const SETTING_PREFIXES = ['positron.runApp.'];
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -167,6 +182,9 @@ function extractCandidates(skills: readonly SkillFile[]): Candidate[] {
 				continue;
 			}
 			if (!ALLOWED_PREFIXES.some(prefix => token.startsWith(prefix))) {
+				continue;
+			}
+			if (SETTING_PREFIXES.some(prefix => token.startsWith(prefix))) {
 				continue;
 			}
 			candidates.push({ id: token, skillName: skill.name });


### PR DESCRIPTION
Part #15704. Also need a similar PR to `shiny-vscode`.

Assistant can now start a web app: Dash, FastAPI, Flask, Gradio, marimo, Streamlit, or Shiny for Python and R, the way the play button does. The skill also includes Workbench-specific instructions.

The Python app commands' `enablement` clauses move to `menus.commandPalette` `when` clauses, so that Assistant can start an app even if it isn't open, but we still keep the same behavior for users.

### Demo

#### Desktop

This time it first didn't bother to select a Python interpreter or check if flask was installed. It also didn't know that the command failed (https://github.com/posit-dev/positron/issues/15848), but it did tell me that it was possible and where to check.

I told it the flask error and it recovered really well from there!

https://github.com/user-attachments/assets/d8850b62-685b-4771-8c02-4fee21d85e9c

#### Workbench

TBD. I had it working earlier but hit some hiccups with my Workbench dev environment.

### Known Issues

This gets as far as it can without changing the underlying commands. I'd like us to follow up with incremental improvements, not in this PR's scope:

- https://github.com/posit-dev/positron/issues/15948
- https://github.com/posit-dev/positron/issues/15953
- https://github.com/posit-dev/positron/issues/15941
- https://github.com/posit-dev/positron/issues/15848
- https://github.com/posit-dev/positron/issues/15940

I've also noticed a bunch of sharp edges with the apps feature that affect humans and agents, tracked in https://github.com/posit-dev/positron/issues/15938.

### Release Notes

#### New Features

- Assistant can run and preview web apps (Dash, FastAPI, Flask, Gradio, marimo, Streamlit, Shiny) using Positron's own app commands (#15704).

#### Bug Fixes

- N/A

### Validation Steps

@:apps @:viewer

<details>
<summary>Setup</summary>

Run this in a Positron terminal, from wherever you keep scratch work:

```bash
bash -euo pipefail <<'SETUP'
mkdir 15704-app-commands
cd 15704-app-commands

python3 -m venv .venv
.venv/bin/pip install flask shiny

cat > app.py <<'PY'
from flask import Flask

app = Flask(__name__)


@app.route("/")
def home():
    return "<h1>Flask</h1>"
PY

cat > shiny_app.py <<'PY'
from shiny import App, ui

app = App(ui.page_fluid(ui.h1("Shiny for Python")), lambda i, o, s: None)
PY

cat > app.R <<'R'
library(shiny)
shinyApp(ui = fluidPage(h1("Shiny for R")), server = function(input, output) {})
R
SETUP
```

Select `15704-app-commands/.venv` as the Python interpreter, then run `install.packages("shiny")` in the R Console (Positron's R session may not share a library with `Rscript`).

---

</details>

1. Open `app.py`. The editor title play button and the Python: Run Flask App in Terminal palette entry still appear, and the palette entry is still absent while a non-Flask Python file is focused.
2. Run it from the play button. It starts in a terminal and previews in the Viewer as before.
3. Close the running app and the file. Ask Assistant to run it by name ("run app.py using the positron-commands skill"). It calls `python.execFlaskInTerminal` with the file's URI rather than running a shell command, and the app previews without the file being the active editor.
4. Ask Assistant to run `app.R` and `shiny_app.py`. It opens the file first, then calls `shiny.r.runApp` / `shiny.python.runApp`; the R app runs in the R Console and the Python app in a terminal, and both preview.
5. On Posit Workbench, repeat step 3 and confirm the previewed URL loads in the browser (a manually started server's `localhost` URL would not).
6. Interact with the app in the Viewer and confirm that it works as expected.