### PR TITLE
e2e: unskip the R nanoparquet import test

### DIFF
--- a/test/e2e/tests/data-explorer/import-data.test.ts
+++ b/test/e2e/tests/data-explorer/import-data.test.ts
@@ -117,8 +117,7 @@ test.describe('Data Explorer - Import Data', {
 		await variables.expectVariableToBe('ap_math_enrollment', /61 rows x 23 columns/);
 	});
 
-	// need to merge this PR and rebuild the CI images first
-	test.skip('R nanoparquet - Verify importing a Parquet file creates a dataframe in the session', async function ({ app, openDataFile, r }) {
+	test('R nanoparquet - Verify importing a Parquet file creates a dataframe in the session', async function ({ app, openDataFile, r }) {
 		const { dataExplorer, variables } = app.workbench;
 
 		await openDataFile(join('data-files', 'misc-parquet', 'decimal_types.parquet'));


### PR DESCRIPTION
Unskips `R nanoparquet - Verify importing a Parquet file creates a dataframe in the session`, which #15861 landed as `test.skip` with a `// need to merge this PR and rebuild the CI images first` note.

`nanoparquet` has been in `test/e2e/test-files/DESCRIPTION` since #15861, and every OS Dockerfile curls DESCRIPTION from `raw.githubusercontent.com/posit-dev/positron/main/...` at build time. So no docker change was needed here -- just a rebuild of the existing images so they run `pak::local_install_dev_deps` against the current DESCRIPTION.

### CI images rebuilt

All 6 OS test images were rebuilt and re-pushed at the **existing** tag `24.18.0` (no `NODE_VERSION` and no `PPM_SNAPSHOT` change -- this is purely a re-run to pick up nanoparquet). Each is a multi-arch amd64+arm64 manifest, verified with `docker manifest inspect`:

| Image | Run | nanoparquet |
|---|---|---|
| `positron-ubuntu24:24.18.0` | [33897306887](https://github.com/posit-dev/positron/actions/runs/33897306887) | 0.5.1 |
| `positron-rocky8:24.18.0` | [33897319763](https://github.com/posit-dev/positron/actions/runs/33897319763) | 0.5.1 |
| `positron-rocky9:24.18.0` | [33899112926](https://github.com/posit-dev/positron/actions/runs/33899112926) | 0.5.1 |
| `positron-debian13:24.18.0` | [33897346261](https://github.com/posit-dev/positron/actions/runs/33897346261) | 0.4.3 |
| `positron-opensuse156:24.18.0` | [33899843577](https://github.com/posit-dev/positron/actions/runs/33899843577) | 0.5.1 |
| `positron-sles156:24.18.0` | [33901241337](https://github.com/posit-dev/positron/actions/runs/33901241337) | 0.5.1 |

`positron-postgres` was **not** rebuilt -- it has no R, so there was nothing for it to pick up.

Notes:
- **debian gets nanoparquet 0.4.3, not 0.5.1**, because its `PPM_SNAPSHOT` is intentionally frozen at `2026-03-01` (the terra/GDAL pin). The debian lane defaults to `@:critical` and this test is not tagged critical, so it won't run there by default -- but worth knowing if that lane is ever run with `@:data-explorer`.
- The Windows, macOS, and Connect lanes install from DESCRIPTION at job time rather than from a baked image, so they already had nanoparquet and needed no rebuild.
- rocky_9's first attempt failed on a Docker Hub `auth.docker.io/token: 500` while pulling `rockylinux:9`; it passed on a straight re-dispatch with no code change.

@:web @:win