### PR TITLE
Add supervisor attachment boundary logging

### DIFF
--- a/extensions/positron-supervisor/src/HandshakeSocket.ts
+++ b/extensions/positron-supervisor/src/HandshakeSocket.ts
@@ -198,49 +198,26 @@ export class HandshakeSocket implements vscode.Disposable {
 	public static connect(socketPath: string, timeoutMs: number): Promise<KallichoreServerState> {
 		const handles = new PromiseHandles<KallichoreServerState>();
 
-		let bytesReceived = 0;
 		console.log(
 			`[HandshakeSocket] connect: starting cached-handshake retrieval from ` +
 			`${socketPath} (timeout ${timeoutMs}ms)`);
 
-		const socket = net.connect(socketPath, () => {
-			console.log(`[HandshakeSocket] connect: socket connected to ${socketPath}`);
-		});
+		const socket = net.connect(socketPath);
 		let text = '';
-		let firstByteLogged = false;
 		socket.setEncoding('utf8');
-		socket.on('data', (chunk: string) => {
-			text += chunk;
-			bytesReceived += Buffer.byteLength(chunk, 'utf8');
-			if (!firstByteLogged) {
-				firstByteLogged = true;
-				console.log(
-					`[HandshakeSocket] connect: first data received from ${socketPath}`);
-			}
-		});
+		socket.on('data', (chunk: string) => { text += chunk; });
 		socket.on('end', () => {
 			try {
 				handles.resolve(JSON.parse(text) as KallichoreServerState);
 				console.log(
-					`[HandshakeSocket] connect: parsed handshake payload from ` +
-					`${socketPath} (${bytesReceived} bytes total)`);
+					`[HandshakeSocket] connect: cached handshake received from ${socketPath}`);
 			} catch (err) {
-				console.log(
-					`[HandshakeSocket] connect: failed to parse handshake payload from ` +
-					`${socketPath} (${bytesReceived} bytes total): ${err}`);
 				handles.reject(new Error(`Failed to parse handshake payload: ${err}`));
 			}
 		});
-		socket.on('error', (err) => {
-			console.log(
-				`[HandshakeSocket] connect: socket error on ${socketPath}: ${err}`);
-			handles.reject(err);
-		});
+		socket.on('error', (err) => handles.reject(err));
 
 		const timer = setTimeout(() => {
-			console.log(
-				`[HandshakeSocket] connect: timed out reading handshake payload from ` +
-				`${socketPath} (timeout ${timeoutMs}ms, ${bytesReceived} bytes received so far)`);
 			socket.destroy();
 			handles.reject(new Error(
 				`Timed out reading handshake payload from ${socketPath} after ${timeoutMs}ms`));

--- a/extensions/positron-supervisor/src/HandshakeSocket.ts
+++ b/extensions/positron-supervisor/src/HandshakeSocket.ts
@@ -198,20 +198,16 @@ export class HandshakeSocket implements vscode.Disposable {
 	public static connect(socketPath: string, timeoutMs: number): Promise<KallichoreServerState> {
 		const handles = new PromiseHandles<KallichoreServerState>();
 
-		// Monotonic clock for elapsed timing, plus a wall clock timestamp so the
-		// operation can be correlated with other log sources (e.g. the server
-		// broker's own logs).
-		const start = performance.now();
-		const startedAt = new Date().toISOString();
+		// Log paired boundary events (start/end) rather than elapsed durations;
+		// the surrounding log capture already timestamps each line, so a
+		// separate elapsed-time computation here would be redundant.
 		let bytesReceived = 0;
 		console.log(
 			`[HandshakeSocket] connect: starting cached-handshake retrieval from ` +
-			`${socketPath} at ${startedAt} (timeout ${timeoutMs}ms)`);
+			`${socketPath} (timeout ${timeoutMs}ms)`);
 
 		const socket = net.connect(socketPath, () => {
-			console.log(
-				`[HandshakeSocket] connect: socket connected to ${socketPath} ` +
-				`after ${(performance.now() - start).toFixed(1)}ms`);
+			console.log(`[HandshakeSocket] connect: socket connected to ${socketPath}`);
 		});
 		let text = '';
 		let firstByteLogged = false;
@@ -222,36 +218,32 @@ export class HandshakeSocket implements vscode.Disposable {
 			if (!firstByteLogged) {
 				firstByteLogged = true;
 				console.log(
-					`[HandshakeSocket] connect: first data from ${socketPath} ` +
-					`after ${(performance.now() - start).toFixed(1)}ms (${bytesReceived} bytes so far)`);
+					`[HandshakeSocket] connect: first data received from ${socketPath}`);
 			}
 		});
 		socket.on('end', () => {
-			const elapsed = (performance.now() - start).toFixed(1);
 			try {
 				handles.resolve(JSON.parse(text) as KallichoreServerState);
 				console.log(
 					`[HandshakeSocket] connect: parsed handshake payload from ` +
-					`${socketPath} after ${elapsed}ms (${bytesReceived} bytes total)`);
+					`${socketPath} (${bytesReceived} bytes total)`);
 			} catch (err) {
 				console.log(
 					`[HandshakeSocket] connect: failed to parse handshake payload from ` +
-					`${socketPath} after ${elapsed}ms (${bytesReceived} bytes total): ${err}`);
+					`${socketPath} (${bytesReceived} bytes total): ${err}`);
 				handles.reject(new Error(`Failed to parse handshake payload: ${err}`));
 			}
 		});
 		socket.on('error', (err) => {
 			console.log(
-				`[HandshakeSocket] connect: socket error on ${socketPath} after ` +
-				`${(performance.now() - start).toFixed(1)}ms: ${err}`);
+				`[HandshakeSocket] connect: socket error on ${socketPath}: ${err}`);
 			handles.reject(err);
 		});
 
 		const timer = setTimeout(() => {
 			console.log(
 				`[HandshakeSocket] connect: timed out reading handshake payload from ` +
-				`${socketPath} after ${(performance.now() - start).toFixed(1)}ms ` +
-				`(timeout ${timeoutMs}ms, ${bytesReceived} bytes received so far)`);
+				`${socketPath} (timeout ${timeoutMs}ms, ${bytesReceived} bytes received so far)`);
 			socket.destroy();
 			handles.reject(new Error(
 				`Timed out reading handshake payload from ${socketPath} after ${timeoutMs}ms`));

--- a/extensions/positron-supervisor/src/HandshakeSocket.ts
+++ b/extensions/positron-supervisor/src/HandshakeSocket.ts
@@ -198,9 +198,6 @@ export class HandshakeSocket implements vscode.Disposable {
 	public static connect(socketPath: string, timeoutMs: number): Promise<KallichoreServerState> {
 		const handles = new PromiseHandles<KallichoreServerState>();
 
-		// Log paired boundary events (start/end) rather than elapsed durations;
-		// the surrounding log capture already timestamps each line, so a
-		// separate elapsed-time computation here would be redundant.
 		let bytesReceived = 0;
 		console.log(
 			`[HandshakeSocket] connect: starting cached-handshake retrieval from ` +

--- a/extensions/positron-supervisor/src/HandshakeSocket.ts
+++ b/extensions/positron-supervisor/src/HandshakeSocket.ts
@@ -198,20 +198,60 @@ export class HandshakeSocket implements vscode.Disposable {
 	public static connect(socketPath: string, timeoutMs: number): Promise<KallichoreServerState> {
 		const handles = new PromiseHandles<KallichoreServerState>();
 
-		const socket = net.connect(socketPath);
+		// Monotonic clock for elapsed timing, plus a wall clock timestamp so the
+		// operation can be correlated with other log sources (e.g. the server
+		// broker's own logs).
+		const start = performance.now();
+		const startedAt = new Date().toISOString();
+		let bytesReceived = 0;
+		console.log(
+			`[HandshakeSocket] connect: starting cached-handshake retrieval from ` +
+			`${socketPath} at ${startedAt} (timeout ${timeoutMs}ms)`);
+
+		const socket = net.connect(socketPath, () => {
+			console.log(
+				`[HandshakeSocket] connect: socket connected to ${socketPath} ` +
+				`after ${(performance.now() - start).toFixed(1)}ms`);
+		});
 		let text = '';
+		let firstByteLogged = false;
 		socket.setEncoding('utf8');
-		socket.on('data', (chunk: string) => { text += chunk; });
+		socket.on('data', (chunk: string) => {
+			text += chunk;
+			bytesReceived += Buffer.byteLength(chunk, 'utf8');
+			if (!firstByteLogged) {
+				firstByteLogged = true;
+				console.log(
+					`[HandshakeSocket] connect: first data from ${socketPath} ` +
+					`after ${(performance.now() - start).toFixed(1)}ms (${bytesReceived} bytes so far)`);
+			}
+		});
 		socket.on('end', () => {
+			const elapsed = (performance.now() - start).toFixed(1);
 			try {
 				handles.resolve(JSON.parse(text) as KallichoreServerState);
+				console.log(
+					`[HandshakeSocket] connect: parsed handshake payload from ` +
+					`${socketPath} after ${elapsed}ms (${bytesReceived} bytes total)`);
 			} catch (err) {
+				console.log(
+					`[HandshakeSocket] connect: failed to parse handshake payload from ` +
+					`${socketPath} after ${elapsed}ms (${bytesReceived} bytes total): ${err}`);
 				handles.reject(new Error(`Failed to parse handshake payload: ${err}`));
 			}
 		});
-		socket.on('error', (err) => handles.reject(err));
+		socket.on('error', (err) => {
+			console.log(
+				`[HandshakeSocket] connect: socket error on ${socketPath} after ` +
+				`${(performance.now() - start).toFixed(1)}ms: ${err}`);
+			handles.reject(err);
+		});
 
 		const timer = setTimeout(() => {
+			console.log(
+				`[HandshakeSocket] connect: timed out reading handshake payload from ` +
+				`${socketPath} after ${(performance.now() - start).toFixed(1)}ms ` +
+				`(timeout ${timeoutMs}ms, ${bytesReceived} bytes received so far)`);
 			socket.destroy();
 			handles.reject(new Error(
 				`Timed out reading handshake payload from ${socketPath} after ${timeoutMs}ms`));

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -1170,7 +1170,18 @@ export class KCApi implements PositronSupervisorApi {
 		// succeeds even if our saved bearer token is stale; that lets us detect
 		// a stale connection here, before we make any authenticated calls that
 		// would fail with a confusing 401.
-		const status = await this._api.api.serverStatus();
+		const statusStart = performance.now();
+		this.log(`Requesting server status from ${connectionInfo} to verify reconnect target`);
+		let status: Awaited<ReturnType<typeof this._api.api.serverStatus>>;
+		try {
+			status = await this._api.api.serverStatus();
+			this.log(`Received server status from ${connectionInfo} after ` +
+				`${(performance.now() - statusStart).toFixed(1)}ms`);
+		} catch (err) {
+			this.log(`serverStatus() request to ${connectionInfo} failed after ` +
+				`${(performance.now() - statusStart).toFixed(1)}ms: ${summarizeError(err)}`);
+			throw err;
+		}
 
 		// If the server reports a different identity than the one we saved, the
 		// original server has gone away and something else is now answering at

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -1170,16 +1170,13 @@ export class KCApi implements PositronSupervisorApi {
 		// succeeds even if our saved bearer token is stale; that lets us detect
 		// a stale connection here, before we make any authenticated calls that
 		// would fail with a confusing 401.
-		const statusStart = performance.now();
 		this.log(`Requesting server status from ${connectionInfo} to verify reconnect target`);
 		let status: Awaited<ReturnType<typeof this._api.api.serverStatus>>;
 		try {
 			status = await this._api.api.serverStatus();
-			this.log(`Received server status from ${connectionInfo} after ` +
-				`${(performance.now() - statusStart).toFixed(1)}ms`);
+			this.log(`Received server status from ${connectionInfo}`);
 		} catch (err) {
-			this.log(`serverStatus() request to ${connectionInfo} failed after ` +
-				`${(performance.now() - statusStart).toFixed(1)}ms: ${summarizeError(err)}`);
+			this.log(`serverStatus() request to ${connectionInfo} failed: ${summarizeError(err)}`);
 			throw err;
 		}
 

--- a/src/server-supervisor-handshake.ts
+++ b/src/server-supervisor-handshake.ts
@@ -50,6 +50,15 @@ export class SupervisorHandshakeBroker {
 
 	private _disposed = false;
 
+	/**
+	 * Monotonic timestamp (`performance.now()`) at which this broker started
+	 * listening, used as the origin for elapsed-time logging below.
+	 */
+	private readonly _createdAt = performance.now();
+
+	/** Number of connections accepted so far, used to label log lines. */
+	private _connectionCount = 0;
+
 	private constructor(
 		private readonly _server: net.Server,
 		/**
@@ -83,19 +92,62 @@ export class SupervisorHandshakeBroker {
 	 * window's extension host reading the cached payload back out.
 	 */
 	private _onConnection(socket: net.Socket): void {
-		if (this._cached === undefined) {
+		const connectionId = ++this._connectionCount;
+		const acceptedAt = performance.now();
+		const isReportIn = this._cached === undefined;
+		console.log(
+			`[SupervisorHandshakeBroker] connection #${connectionId} accepted ` +
+			`${(acceptedAt - this._createdAt).toFixed(1)}ms after broker start; ` +
+			`classified as ${isReportIn ? 'kcserver report-in' : 'cached replay'}`);
+
+		if (isReportIn) {
 			// kcserver reporting in: read the payload to EOF and cache it.
 			let text = '';
+			let bytesReceived = 0;
 			socket.setEncoding('utf8');
-			socket.on('data', (chunk: string) => { text += chunk; });
+			socket.on('data', (chunk: string) => {
+				text += chunk;
+				bytesReceived += Buffer.byteLength(chunk, 'utf8');
+			});
 			socket.on('end', () => {
 				this._cached = text;
+				console.log(
+					`[SupervisorHandshakeBroker] connection #${connectionId}: cached ` +
+					`report-in payload (${bytesReceived} bytes) after ` +
+					`${(performance.now() - acceptedAt).toFixed(1)}ms`);
 				this._readyResolve();
 			});
-			socket.on('error', (err) => this._readyReject(err));
+			socket.on('close', () => {
+				console.log(
+					`[SupervisorHandshakeBroker] connection #${connectionId}: report-in ` +
+					`socket closed after ${(performance.now() - acceptedAt).toFixed(1)}ms`);
+			});
+			socket.on('error', (err) => {
+				console.log(
+					`[SupervisorHandshakeBroker] connection #${connectionId}: report-in ` +
+					`socket error after ${(performance.now() - acceptedAt).toFixed(1)}ms: ${err}`);
+				this._readyReject(err);
+			});
 		} else {
 			// A window reading the cached payload back out: replay and close.
-			socket.end(this._cached);
+			const cached = this._cached ?? '';
+			const payloadBytes = Buffer.byteLength(cached, 'utf8');
+			socket.end(cached, () => {
+				console.log(
+					`[SupervisorHandshakeBroker] connection #${connectionId}: replayed ` +
+					`cached payload (${payloadBytes} bytes) after ` +
+					`${(performance.now() - acceptedAt).toFixed(1)}ms`);
+			});
+			socket.on('close', () => {
+				console.log(
+					`[SupervisorHandshakeBroker] connection #${connectionId}: replay ` +
+					`socket closed after ${(performance.now() - acceptedAt).toFixed(1)}ms`);
+			});
+			socket.on('error', (err) => {
+				console.log(
+					`[SupervisorHandshakeBroker] connection #${connectionId}: replay ` +
+					`socket error after ${(performance.now() - acceptedAt).toFixed(1)}ms: ${err}`);
+			});
 		}
 	}
 
@@ -164,9 +216,13 @@ export class SupervisorHandshakeBroker {
 	 * @throws An error if kcserver does not report in within the timeout.
 	 */
 	public async ready(timeoutMs: number): Promise<void> {
+		const start = performance.now();
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		const timeout = new Promise<never>((_, reject) => {
 			timer = setTimeout(() => {
+				console.log(
+					`[SupervisorHandshakeBroker] ready(): timed out after ` +
+					`${(performance.now() - start).toFixed(1)}ms (timeout ${timeoutMs}ms)`);
 				reject(new Error(
 					`Timed out waiting for the supervisor to connect to the ` +
 					`handshake socket after ${timeoutMs}ms`));
@@ -174,6 +230,9 @@ export class SupervisorHandshakeBroker {
 		});
 		try {
 			await Promise.race([this._ready, timeout]);
+			console.log(
+				`[SupervisorHandshakeBroker] ready(): supervisor reported in after ` +
+				`${(performance.now() - start).toFixed(1)}ms`);
 		} finally {
 			if (timer !== undefined) {
 				clearTimeout(timer);

--- a/src/server-supervisor-handshake.ts
+++ b/src/server-supervisor-handshake.ts
@@ -50,9 +50,6 @@ export class SupervisorHandshakeBroker {
 
 	private _disposed = false;
 
-	/** Number of connections accepted so far, used to label log lines. */
-	private _connectionCount = 0;
-
 	private constructor(
 		private readonly _server: net.Server,
 		/**
@@ -86,56 +83,22 @@ export class SupervisorHandshakeBroker {
 	 * window's extension host reading the cached payload back out.
 	 */
 	private _onConnection(socket: net.Socket): void {
-		const connectionId = ++this._connectionCount;
-		const isReportIn = this._cached === undefined;
-		console.log(
-			`[SupervisorHandshakeBroker] connection #${connectionId} accepted on ` +
-			`${this.socketPath}; classified as ${isReportIn ? 'kcserver report-in' : 'cached replay'}`);
-
-		if (isReportIn) {
+		if (this._cached === undefined) {
 			// kcserver reporting in: read the payload to EOF and cache it.
 			let text = '';
-			let bytesReceived = 0;
 			socket.setEncoding('utf8');
-			socket.on('data', (chunk: string) => {
-				text += chunk;
-				bytesReceived += Buffer.byteLength(chunk, 'utf8');
-			});
+			socket.on('data', (chunk: string) => { text += chunk; });
 			socket.on('end', () => {
 				this._cached = text;
-				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: cached ` +
-					`report-in payload (${bytesReceived} bytes)`);
 				this._readyResolve();
 			});
-			socket.on('close', () => {
-				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: report-in socket closed`);
-			});
-			socket.on('error', (err) => {
-				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: report-in ` +
-					`socket error: ${err}`);
-				this._readyReject(err);
-			});
+			socket.on('error', (err) => this._readyReject(err));
 		} else {
 			// A window reading the cached payload back out: replay and close.
-			const cached = this._cached ?? '';
-			const payloadBytes = Buffer.byteLength(cached, 'utf8');
-			console.log(
-				`[SupervisorHandshakeBroker] connection #${connectionId}: replaying ` +
-				`cached payload (${payloadBytes} bytes)`);
+			const cached = this._cached;
+			console.log('[SupervisorHandshakeBroker] cached-handshake replay requested');
 			socket.end(cached, () => {
-				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: replay write completed`);
-			});
-			socket.on('close', () => {
-				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: replay socket closed`);
-			});
-			socket.on('error', (err) => {
-				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: replay socket error: ${err}`);
+				console.log('[SupervisorHandshakeBroker] cached-handshake replay completed');
 			});
 		}
 	}
@@ -205,15 +168,9 @@ export class SupervisorHandshakeBroker {
 	 * @throws An error if kcserver does not report in within the timeout.
 	 */
 	public async ready(timeoutMs: number): Promise<void> {
-		console.log(
-			`[SupervisorHandshakeBroker] ready(): waiting for the supervisor to report in ` +
-			`(timeout ${timeoutMs}ms)`);
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		const timeout = new Promise<never>((_, reject) => {
 			timer = setTimeout(() => {
-				console.log(
-					`[SupervisorHandshakeBroker] ready(): timed out waiting for the supervisor ` +
-					`to report in (timeout ${timeoutMs}ms)`);
 				reject(new Error(
 					`Timed out waiting for the supervisor to connect to the ` +
 					`handshake socket after ${timeoutMs}ms`));
@@ -221,7 +178,6 @@ export class SupervisorHandshakeBroker {
 		});
 		try {
 			await Promise.race([this._ready, timeout]);
-			console.log(`[SupervisorHandshakeBroker] ready(): supervisor reported in`);
 		} finally {
 			if (timer !== undefined) {
 				clearTimeout(timer);

--- a/src/server-supervisor-handshake.ts
+++ b/src/server-supervisor-handshake.ts
@@ -50,12 +50,6 @@ export class SupervisorHandshakeBroker {
 
 	private _disposed = false;
 
-	/**
-	 * Monotonic timestamp (`performance.now()`) at which this broker started
-	 * listening, used as the origin for elapsed-time logging below.
-	 */
-	private readonly _createdAt = performance.now();
-
 	/** Number of connections accepted so far, used to label log lines. */
 	private _connectionCount = 0;
 
@@ -93,12 +87,10 @@ export class SupervisorHandshakeBroker {
 	 */
 	private _onConnection(socket: net.Socket): void {
 		const connectionId = ++this._connectionCount;
-		const acceptedAt = performance.now();
 		const isReportIn = this._cached === undefined;
 		console.log(
-			`[SupervisorHandshakeBroker] connection #${connectionId} accepted ` +
-			`${(acceptedAt - this._createdAt).toFixed(1)}ms after broker start; ` +
-			`classified as ${isReportIn ? 'kcserver report-in' : 'cached replay'}`);
+			`[SupervisorHandshakeBroker] connection #${connectionId} accepted on ` +
+			`${this.socketPath}; classified as ${isReportIn ? 'kcserver report-in' : 'cached replay'}`);
 
 		if (isReportIn) {
 			// kcserver reporting in: read the payload to EOF and cache it.
@@ -113,40 +105,37 @@ export class SupervisorHandshakeBroker {
 				this._cached = text;
 				console.log(
 					`[SupervisorHandshakeBroker] connection #${connectionId}: cached ` +
-					`report-in payload (${bytesReceived} bytes) after ` +
-					`${(performance.now() - acceptedAt).toFixed(1)}ms`);
+					`report-in payload (${bytesReceived} bytes)`);
 				this._readyResolve();
 			});
 			socket.on('close', () => {
 				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: report-in ` +
-					`socket closed after ${(performance.now() - acceptedAt).toFixed(1)}ms`);
+					`[SupervisorHandshakeBroker] connection #${connectionId}: report-in socket closed`);
 			});
 			socket.on('error', (err) => {
 				console.log(
 					`[SupervisorHandshakeBroker] connection #${connectionId}: report-in ` +
-					`socket error after ${(performance.now() - acceptedAt).toFixed(1)}ms: ${err}`);
+					`socket error: ${err}`);
 				this._readyReject(err);
 			});
 		} else {
 			// A window reading the cached payload back out: replay and close.
 			const cached = this._cached ?? '';
 			const payloadBytes = Buffer.byteLength(cached, 'utf8');
+			console.log(
+				`[SupervisorHandshakeBroker] connection #${connectionId}: replaying ` +
+				`cached payload (${payloadBytes} bytes)`);
 			socket.end(cached, () => {
 				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: replayed ` +
-					`cached payload (${payloadBytes} bytes) after ` +
-					`${(performance.now() - acceptedAt).toFixed(1)}ms`);
+					`[SupervisorHandshakeBroker] connection #${connectionId}: replay write completed`);
 			});
 			socket.on('close', () => {
 				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: replay ` +
-					`socket closed after ${(performance.now() - acceptedAt).toFixed(1)}ms`);
+					`[SupervisorHandshakeBroker] connection #${connectionId}: replay socket closed`);
 			});
 			socket.on('error', (err) => {
 				console.log(
-					`[SupervisorHandshakeBroker] connection #${connectionId}: replay ` +
-					`socket error after ${(performance.now() - acceptedAt).toFixed(1)}ms: ${err}`);
+					`[SupervisorHandshakeBroker] connection #${connectionId}: replay socket error: ${err}`);
 			});
 		}
 	}
@@ -216,13 +205,15 @@ export class SupervisorHandshakeBroker {
 	 * @throws An error if kcserver does not report in within the timeout.
 	 */
 	public async ready(timeoutMs: number): Promise<void> {
-		const start = performance.now();
+		console.log(
+			`[SupervisorHandshakeBroker] ready(): waiting for the supervisor to report in ` +
+			`(timeout ${timeoutMs}ms)`);
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		const timeout = new Promise<never>((_, reject) => {
 			timer = setTimeout(() => {
 				console.log(
-					`[SupervisorHandshakeBroker] ready(): timed out after ` +
-					`${(performance.now() - start).toFixed(1)}ms (timeout ${timeoutMs}ms)`);
+					`[SupervisorHandshakeBroker] ready(): timed out waiting for the supervisor ` +
+					`to report in (timeout ${timeoutMs}ms)`);
 				reject(new Error(
 					`Timed out waiting for the supervisor to connect to the ` +
 					`handshake socket after ${timeoutMs}ms`));
@@ -230,9 +221,7 @@ export class SupervisorHandshakeBroker {
 		});
 		try {
 			await Promise.race([this._ready, timeout]);
-			console.log(
-				`[SupervisorHandshakeBroker] ready(): supervisor reported in after ` +
-				`${(performance.now() - start).toFixed(1)}ms`);
+			console.log(`[SupervisorHandshakeBroker] ready(): supervisor reported in`);
 		} finally {
 			if (timer !== undefined) {
 				clearTimeout(timer);


### PR DESCRIPTION
## Summary

Adds six boundary events around the two operations used to attach to a prestarted supervisor:

- cached-handshake retrieval starts and completes in the extension host;
- cached-handshake replay starts and completes in the server broker;
- `serverStatus()` verification starts and completes or fails.

The existing log timestamps can be compared to determine whether time was spent reaching the broker, replaying or receiving the cached handshake, reaching the status handler, or waiting for its response. No handshake payloads or bearer tokens are logged.

## Testing

- `npx vitest run src/server-supervisor-handshake.vitest.ts`
- `npm run build-check -- --pretty false`