### PR TITLE
Add AWS IAM authorization to the Redshift data connection driver

### DIFF
--- a/extensions/positron-data-driver-redshift/package-lock.json
+++ b/extensions/positron-data-driver-redshift/package-lock.json
@@ -8,6 +8,9 @@
       "name": "positron-data-driver-redshift",
       "version": "0.0.1",
       "dependencies": {
+        "@aws-sdk/client-redshift": "^3.734.0",
+        "@aws-sdk/client-redshift-serverless": "^3.734.0",
+        "@aws-sdk/credential-providers": "^3.734.0",
         "pg": "^8.20.0"
       },
       "devDependencies": {
@@ -42,6 +45,340 @@
       "dev": true,
       "devDependencies": {
         "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift": {
+      "version": "3.1126.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-redshift/-/client-redshift-3.1126.0.tgz",
+      "integrity": "sha512-KukD/inEGQGapQXj28QqhJw+8VWh/KC6EFRlTcxkDk2RVfqBdxwD2idrmDkZ0SGIzgy7pui7gYZxkuSbZDynEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.82",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift-serverless": {
+      "version": "3.1126.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-redshift-serverless/-/client-redshift-serverless-3.1126.0.tgz",
+      "integrity": "sha512-+pwp+vUtgKZUhXk3mUFCoXA0I3yRQ8EF9gOckOjX1uVhnRoYlCwaqrQAgEVuabErIxcyKKnL0iZXEVVmQmyZHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.82",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.69.tgz",
+      "integrity": "sha512-vpsh9VWmQVC/nsdzf72F2yUMBOFT1aq+hoLseYV03zjVXVHkjqSNJskFRKPFxc3MRFrHNbSSmOwsbYE15u9ecw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.1126.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1126.0.tgz",
+      "integrity": "sha512-OWu4fqH48e6yUceFs1r0fgC88gpuD/MaFggKoRXXTrjT2VicQQSO9tqlCWd2qmQNAXbwfV8/HGeRm6l9P4FSRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.69",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-node": "^3.972.82",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -705,6 +1042,87 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@textlint/ast-node-types": {
@@ -1594,6 +2012,12 @@
       "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
@@ -6126,7 +6550,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {

--- a/extensions/positron-data-driver-redshift/package.json
+++ b/extensions/positron-data-driver-redshift/package.json
@@ -19,6 +19,9 @@
   },
   "contributes": {},
   "dependencies": {
+    "@aws-sdk/client-redshift": "^3.734.0",
+    "@aws-sdk/client-redshift-serverless": "^3.734.0",
+    "@aws-sdk/credential-providers": "^3.734.0",
     "pg": "^8.20.0"
   },
   "devDependencies": {

--- a/extensions/positron-data-driver-redshift/src/redshiftClient.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftClient.ts
@@ -21,12 +21,15 @@
 
 import { Client, QueryResult } from 'pg';
 import { ConnectionOptions } from 'tls';
+import { RedshiftCredentialProvider } from './redshiftIamCredentials.js';
 
 /**
  * The discrete connection fields for a Redshift connection. Host, port, database, and user identify
- * the cluster and login; the password is optional only in that future auth mechanisms (IAM, Okta)
- * will mint a temporary one. SSL defaults on because Redshift endpoints expect an encrypted
- * connection.
+ * the cluster and login. SSL defaults on because Redshift endpoints expect an encrypted connection.
+ *
+ * Under IAM, `user` and `password` are left empty and `credentialProvider` supplies both instead:
+ * Redshift derives the database user from the federated identity and returns it alongside the
+ * password, so neither is known until the credentials have been minted.
  */
 export interface RedshiftFieldConfig {
 	host: string;
@@ -35,6 +38,12 @@ export interface RedshiftFieldConfig {
 	user: string;
 	password?: string;
 	ssl?: boolean;
+	/**
+	 * Mints temporary credentials, overriding `user` and `password` when present. Carried on the
+	 * config rather than passed separately so that everything the pg client is built from travels
+	 * together, and so adding it costs no change to the PgClientFactory signature.
+	 */
+	credentialProvider?: RedshiftCredentialProvider;
 }
 
 /**
@@ -124,6 +133,21 @@ function isFatalConnectionError(err: unknown): boolean {
 }
 
 /**
+ * Whether an error is the server rejecting our credentials. Under IAM this is what expiry looks
+ * like: the socket is fine, so isFatalConnectionError() correctly says no, but the temporary
+ * password minted earlier is no longer accepted. Deliberately narrow -- the PostgreSQL
+ * invalid-authorization class only -- because the response is to discard the cached credentials and
+ * mint new ones, which is pointless for any other failure.
+ */
+export function isAuthenticationError(err: unknown): boolean {
+	if (!err || typeof err !== 'object') {
+		return false;
+	}
+	const { code } = err as { code?: string };
+	return code === '28000' || code === '28P01';
+}
+
+/**
  * A pg Client that survives an idle socket dropping out from under it. Presents the small slice of
  * the pg Client surface the rest of the driver uses -- connect(), query(), end() -- and swaps the
  * underlying pg Client transparently when a query hits a dead connection. Callers hold a stable
@@ -136,6 +160,14 @@ export class RedshiftClient {
 	// In-flight reconnect, shared so concurrent queries that all hit the dead socket rebuild the
 	// client once rather than racing to create several.
 	private _reconnecting: Promise<void> | null = null;
+
+	// The database user most recently minted by the credential provider, for logging. Unset when
+	// connecting with a configured user and password.
+	private _resolvedUser: string | undefined;
+
+	// Set by end(), to tell a deliberate close apart from a reconnect that failed. Both leave _pg
+	// null, but only the latter should be rebuilt on the next query.
+	private _closed = false;
 
 	/**
 	 * @param _config The connection configuration.
@@ -154,9 +186,14 @@ export class RedshiftClient {
 	 * transient connection failure with backoff so a resuming serverless workgroup is waited out; a
 	 * terminal error (bad auth, unknown host) or exhausting the attempts propagates.
 	 */
-	private async _open(): Promise<void> {
+	private async _open(forceRefresh = false): Promise<void> {
 		for (let attempt = 1; ; attempt++) {
-			const pg = this._createPgClient(this._config);
+			// Resolve credentials inside the retry loop, not outside it. Temporary IAM credentials
+			// last 900 seconds by default, and the backoff below can span a minute waiting out a
+			// resuming serverless workgroup, so a set fetched once up front can expire before the
+			// attempt that finally succeeds uses it. Only the first attempt forces a re-mint; the
+			// later ones reuse what it fetched rather than calling AWS once per retry.
+			const pg = this._createPgClient(await this._resolveConfig(forceRefresh && attempt === 1));
 			// When the socket dies while no query is in flight, the pg Client emits an asynchronous
 			// 'error' event. With no listener that becomes an unhandled 'error' and takes down the
 			// extension host, so absorb it here; the next query() observes the broken client and
@@ -180,6 +217,28 @@ export class RedshiftClient {
 		}
 	}
 
+	/**
+	 * The config to build a pg client from. Without a credential provider this is the config as
+	 * given. With one, the minted user and password replace the configured ones -- Redshift derives
+	 * the database user from the IAM identity, so it is not ours to choose.
+	 */
+	private async _resolveConfig(forceRefresh: boolean): Promise<RedshiftFieldConfig> {
+		if (!this._config.credentialProvider) {
+			return this._config;
+		}
+		const credentials = await this._config.credentialProvider(forceRefresh);
+		this._resolvedUser = credentials.user;
+		return { ...this._config, user: credentials.user, password: credentials.password };
+	}
+
+	/**
+	 * The database user this client last connected as. Under IAM this is only known after the first
+	 * connect, since AWS returns it; undefined before then.
+	 */
+	get resolvedUser(): string | undefined {
+		return this._resolvedUser ?? (this._config.user || undefined);
+	}
+
 	/** Establishes the connection. Must be called before query(). */
 	async connect(): Promise<void> {
 		await this._open();
@@ -190,13 +249,26 @@ export class RedshiftClient {
 	 * error (bad SQL, permissions) is thrown without a retry.
 	 */
 	async query(text: string, params?: unknown[]): Promise<QueryResult> {
+		// A previous reconnect may have failed part way through -- minting credentials can fail on
+		// its own, leaving no pg client behind. That is recoverable, and it must be retried here:
+		// the resulting "client is closed" is neither a socket error nor an auth error, so the
+		// catch below would not rebuild it and the connection would stay dead even after the user
+		// fixed whatever broke (an expired SSO session, say). end() sets _closed so a deliberate
+		// disconnect is never resurrected.
+		if (!this._pg && !this._closed) {
+			await this._reconnect();
+		}
 		try {
 			return await this._queryOnce(text, params);
 		} catch (err) {
-			if (!isFatalConnectionError(err)) {
+			// A dead socket, or -- under IAM only -- credentials the server no longer accepts.
+			// Expired temporary credentials are not a connection error, so they need their own
+			// test; reconnecting mints a fresh set on the way through _resolveConfig().
+			const rejectedCredentials = this._config.credentialProvider !== undefined && isAuthenticationError(err);
+			if (!isFatalConnectionError(err) && !rejectedCredentials) {
 				throw err;
 			}
-			await this._reconnect();
+			await this._reconnect(rejectedCredentials);
 			return await this._queryOnce(text, params);
 		}
 	}
@@ -214,7 +286,7 @@ export class RedshiftClient {
 	 * reconnect; the old client is closed best-effort (it has already errored, so failures to end it
 	 * are expected and ignored).
 	 */
-	private _reconnect(): Promise<void> {
+	private _reconnect(forceRefresh = false): Promise<void> {
 		if (!this._reconnecting) {
 			this._reconnecting = (async () => {
 				const old = this._pg;
@@ -226,7 +298,7 @@ export class RedshiftClient {
 						// The socket is already broken; nothing to clean up.
 					}
 				}
-				await this._open();
+				await this._open(forceRefresh);
 			})().finally(() => { this._reconnecting = null; });
 		}
 		return this._reconnecting;
@@ -236,6 +308,7 @@ export class RedshiftClient {
 	async end(): Promise<void> {
 		const pg = this._pg;
 		this._pg = null;
+		this._closed = true;
 		if (pg) {
 			try {
 				await pg.end();

--- a/extensions/positron-data-driver-redshift/src/redshiftConnection.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftConnection.ts
@@ -10,7 +10,9 @@
 // absent here. The top-level nodes are always the schemas of the connected database.
 
 import * as positron from 'positron';
-import { RedshiftClient, RedshiftFieldConfig } from './redshiftClient.js';
+import * as vscode from 'vscode';
+import { isAuthenticationError, PgClientFactory, RedshiftClient, RedshiftFieldConfig } from './redshiftClient.js';
+import { createIamCredentialProvider, RedshiftCredentialFetcher, RedshiftIamConfig } from './redshiftIamCredentials.js';
 import { createDatabasesGroupNode, createSchemasGroupNode, IRedshiftPreviewHost } from './redshiftNodes.js';
 import { IRedshiftDataExplorerHost, REDSHIFT_DATA_EXPLORER_PROVIDER_ID } from './redshiftDataExplorerRpcHandler.js';
 
@@ -18,10 +20,26 @@ import { IRedshiftDataExplorerHost, REDSHIFT_DATA_EXPLORER_PROVIDER_ID } from '.
 let nextConnectionId = 1;
 
 /**
- * Connection configuration passed from the driver. Only the discrete-fields form is supported today;
- * the `kind` discriminant leaves room for a connection-string form later without changing callers.
+ * Connection configuration passed from the driver. `fields` is a user-supplied host, user, and
+ * password; `iam` carries the AWS target instead, and the user and password are minted from the
+ * caller's IAM identity on each connect. The `kind` discriminant also leaves room for a
+ * connection-string form later without changing callers.
  */
-export type RedshiftConnectionConfig = { kind: 'fields' } & RedshiftFieldConfig;
+export type RedshiftConnectionConfig =
+	| ({ kind: 'fields' } & RedshiftFieldConfig)
+	| ({ kind: 'iam'; iam: RedshiftIamConfig } & RedshiftFieldConfig);
+
+/**
+ * The connection's outward-facing dependencies. Both default to the real implementations; a test
+ * supplies fakes so the whole chain -- config to credential provider to pg client -- runs without a
+ * cluster or an AWS account.
+ */
+export interface RedshiftConnectionDependencies {
+	/** Builds the underlying pg client. */
+	pgClientFactory?: PgClientFactory;
+	/** Mints IAM credentials. Ignored for a `fields` connection. */
+	credentialFetcher?: RedshiftCredentialFetcher;
+}
 
 /**
  * A live Amazon Redshift connection implementing the DataConnection interface. Connects via a
@@ -48,13 +66,27 @@ export class RedshiftConnection implements positron.DataConnection, IRedshiftPre
 	 * @param _config The connection configuration.
 	 * @param _dataExplorerHandler Hosts table views previewed in the Data Explorer.
 	 * @param _logger Optional diagnostic log sink for connection lifecycle and query events.
+	 * @param _options Overrides for the two dependencies that reach outside the process, so tests
+	 * can exercise the real wiring -- including the IAM credential path -- without a cluster or an
+	 * AWS account.
 	 */
 	constructor(
 		private readonly _config: RedshiftConnectionConfig,
 		private readonly _dataExplorerHandler: IRedshiftDataExplorerHost,
-		private readonly _logger?: positron.DataConnectionLogger
+		private readonly _logger?: positron.DataConnectionLogger,
+		private readonly _options?: RedshiftConnectionDependencies
 	) {
-		this._client = new RedshiftClient(this._config);
+		// Under IAM the credentials are minted per connect rather than configured, so hand the client
+		// a provider instead of a password.
+		this._client = new RedshiftClient(
+			this._config.kind === 'iam'
+				? {
+					...this._config,
+					credentialProvider: createIamCredentialProvider(
+						this._config.iam, this._logger, this._options?.credentialFetcher),
+				}
+				: this._config,
+			this._options?.pgClientFactory);
 	}
 
 	/** Establishes the connection. Must be called before any other method. */
@@ -62,19 +94,51 @@ export class RedshiftConnection implements positron.DataConnection, IRedshiftPre
 		if (!this._client) {
 			throw new Error('Redshift connection has been disconnected');
 		}
-		this._logger?.info(`Connecting to ${this._config.host}:${this._config.port}/${this._config.database} as ${this._config.user}`);
+		// Under IAM there is no user to name yet: AWS derives it from the federated identity and
+		// returns it during connect, so it is only known afterwards.
+		const target = `${this._config.host}:${this._config.port}/${this._config.database}`;
+		this._logger?.info(this._config.kind === 'iam'
+			? `Connecting to ${target} with AWS IAM credentials`
+			: `Connecting to ${target} as ${this._config.user}`);
 		try {
 			await this._client.connect();
 		} catch (err: any) {
 			this._client = null;
-			const error = new Error(`Failed to connect to Redshift at ${this._config.host}:${this._config.port}: ${err.message}`);
+			const error = new Error(`Failed to connect to Redshift at ${this._config.host}:${this._config.port}: ${err.message}${this._missingDatabaseUserHint(err)}`);
 			this._logger?.error(error.message);
 			throw error;
 		}
 		// Detect cross-database support once the connection is up. A failure here is non-fatal: the
 		// connection still works, it just browses the single connected database.
 		this._crossDatabase = await this._detectCrossDatabase();
-		this._logger?.info(`Connected to ${this._config.host}:${this._config.port} (cross-database ${this._crossDatabase ? 'available' : 'unavailable'})`);
+		const connectedAs = this._client.resolvedUser;
+		this._logger?.info(`Connected to ${this._config.host}:${this._config.port}${connectedAs ? ` as ${connectedAs}` : ''} (cross-database ${this._crossDatabase ? 'available' : 'unavailable'})`);
+	}
+
+	/**
+	 * Extra guidance for the one provisioned-cluster failure that is predictable.
+	 *
+	 * With AutoCreate off -- the AWS default, and what this driver asks for so that connecting never
+	 * silently creates a database user -- GetClusterCredentials *succeeds* for a user that does not
+	 * exist, and the login is what fails. So the cause is an AWS-side decision but the symptom is a
+	 * bare authentication error from Postgres, which points nowhere useful. Under IAM the password
+	 * was minted rather than typed, so an authentication failure cannot be a wrong password: the
+	 * identity simply is not a user in the database.
+	 *
+	 * Returns an empty string when the failure is anything else, so the message is unchanged.
+	 */
+	private _missingDatabaseUserHint(err: unknown): string {
+		if (this._config.kind !== 'iam' || this._config.iam.kind !== 'provisioned') {
+			return '';
+		}
+		// Same predicate the client uses to decide a credential was rejected, so the retry set and
+		// this hint cannot drift apart.
+		if (!isAuthenticationError(err)) {
+			return '';
+		}
+		return ' ' + vscode.l10n.t(
+			"The IAM credentials were issued, but the database user '{0}' may not exist in cluster '{1}'. Redshift does not create it. Create the user in the database, or use a database user that already exists.",
+			this._config.iam.dbUser ?? '', this._config.iam.name);
 	}
 
 	/**

--- a/extensions/positron-data-driver-redshift/src/redshiftDriver.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftDriver.ts
@@ -16,6 +16,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { RedshiftConnection } from './redshiftConnection.js';
 import { RedshiftDataExplorerRpcHandler } from './redshiftDataExplorerRpcHandler.js';
+import { RedshiftIamConfig } from './redshiftIamCredentials.js';
 
 /** The Redshift default port. */
 const DEFAULT_PORT = 5439;
@@ -64,6 +65,70 @@ export function parseRedshiftEndpoint(input: string): { host: string; port?: num
 }
 
 /**
+ * Which flavour of Redshift an endpoint points at. The two mint temporary credentials through
+ * different APIs -- `redshift-serverless:GetCredentials` keyed on a workgroup, versus
+ * `redshift:GetClusterCredentials` keyed on a cluster identifier -- so IAM authorization has to know
+ * which one it is talking to before it can ask for anything.
+ */
+export type RedshiftEndpointKind = 'serverless' | 'provisioned' | 'unknown';
+
+/**
+ * The IAM-relevant identifiers carried by a Redshift endpoint hostname. AWS encodes the workgroup
+ * (or cluster) and its region into the endpoint itself:
+ *
+ *     <workgroup>.<account>.<region>.redshift-serverless.amazonaws.com
+ *     <cluster>.<id>.<region>.redshift.amazonaws.com
+ *
+ * so pasting the console endpoint already supplies everything the credential call needs, and the
+ * user is never asked to restate which flavour of Redshift they are on. Both fields are left
+ * undefined for a host that is not a recognizable AWS endpoint -- an SSH tunnel, a proxy, a private
+ * DNS alias -- so the caller can fall back to asking rather than guessing wrong.
+ */
+export interface RedshiftEndpointDetails {
+	kind: RedshiftEndpointKind;
+	/** The workgroup name (serverless) or cluster identifier (provisioned). */
+	name?: string;
+	/**
+	 * The region hosting the workgroup or cluster. Note this is not necessarily the region the
+	 * caller authenticates against: with IAM Identity Center, the SSO region is configured in the
+	 * AWS profile and is unrelated to where the workgroup lives.
+	 */
+	region?: string;
+}
+
+/**
+ * Extracts the flavour, name, and region from a Redshift endpoint hostname. Takes the bare host, so
+ * run the input through parseRedshiftEndpoint() first if it may carry a port or database.
+ */
+export function describeRedshiftEndpoint(host: string): RedshiftEndpointDetails {
+	const labels = host.trim().toLowerCase().split('.');
+
+	// Anchor on the AWS domain rather than searching for the service label. Two reasons: a private
+	// host that merely contains a `redshift` label (warehouse.corp.redshift.example.com) must not
+	// be mistaken for an endpoint and have `corp` sent to AWS as a region; and a workgroup whose
+	// own name happens to be `redshift` must not shadow the real service label. Matching the
+	// `amazonaws` label instead of a full suffix keeps the regional variants (amazonaws.com.cn,
+	// GovCloud) working without enumerating them.
+	const suffix = labels.slice(-3).join('.');
+	if (suffix !== 'amazonaws.com.cn' && labels.slice(-2).join('.') !== 'amazonaws.com') {
+		return { kind: 'unknown' };
+	}
+
+	// The service label always sits immediately before `amazonaws`, the region before that, and the
+	// workgroup or cluster name is the first label.
+	const serviceIndex = labels.lastIndexOf('amazonaws') - 1;
+	const service = labels[serviceIndex];
+	if (serviceIndex < 2 || (service !== 'redshift-serverless' && service !== 'redshift')) {
+		return { kind: 'unknown' };
+	}
+	return {
+		kind: service === 'redshift-serverless' ? 'serverless' : 'provisioned',
+		name: labels[0] || undefined,
+		region: labels[serviceIndex - 1] || undefined,
+	};
+}
+
+/**
  * Escapes a value for embedding in a double-quoted Python or R string literal. Both languages treat
  * backslash as an escape character in double-quoted strings, so values containing backslashes or
  * quotes must be escaped.
@@ -77,6 +142,55 @@ function escapeDoubleQuoted(value: string): string {
  * the connect/generate switches, so they stay in sync.
  */
 const PASSWORD_MECHANISM_ID = 'password';
+
+/**
+ * The id of the AWS IAM connection mechanism. One mechanism covers both serverless workgroups and
+ * provisioned clusters: the endpoint says which is which, so there is nothing for the user to pick
+ * between, and two near-identical entries in the mechanism list would only invite picking wrong.
+ */
+const IAM_MECHANISM_ID = 'iam';
+
+/**
+ * Resolves the AWS target from the connection parameters, or explains why it could not. IAM needs
+ * the flavour, name, and region, all of which are encoded in a standard Redshift endpoint; a host
+ * that is not one (an SSH tunnel, a proxy, a private DNS alias) cannot be resolved and is reported
+ * rather than guessed at.
+ */
+export function iamTargetFromParams(params: positron.DataConnectionParameterValues): { host: string; port: number; database: string; iam: RedshiftIamConfig } {
+	const hostInput = params.host;
+	if (!isNonEmptyString(hostInput)) {
+		throw new Error(vscode.l10n.t('Host is required'));
+	}
+	const databaseInput = params.database;
+	if (!isNonEmptyString(databaseInput)) {
+		throw new Error(vscode.l10n.t('Database is required'));
+	}
+	const endpoint = parseRedshiftEndpoint(hostInput);
+	const details = describeRedshiftEndpoint(endpoint.host);
+	if (details.kind === 'unknown' || !details.name || !details.region) {
+		throw new Error(vscode.l10n.t("'{0}' is not a recognized Redshift endpoint, so the workgroup or cluster to request credentials for cannot be determined. Paste the endpoint shown in the AWS console, or use the User & Password mechanism.", endpoint.host));
+	}
+	const database = endpoint.database ?? databaseInput;
+	// Provisioned clusters mint credentials for a named database user; serverless derives the user
+	// from the IAM identity, so the field is ignored there.
+	const dbUser = isNonEmptyString(params.dbUser) ? params.dbUser : undefined;
+	if (details.kind === 'provisioned' && !dbUser) {
+		throw new Error(vscode.l10n.t("'{0}' is a provisioned cluster, which requires a database user.", details.name));
+	}
+	return {
+		host: endpoint.host,
+		port: endpoint.port ?? (typeof params.port === 'number' ? params.port : DEFAULT_PORT),
+		database,
+		iam: {
+			kind: details.kind,
+			name: details.name,
+			region: details.region,
+			database,
+			profile: isNonEmptyString(params.profile) ? params.profile : undefined,
+			dbUser,
+		},
+	};
+}
 
 /**
  * Normalized Redshift connection fields, independent of any client library. The renderers map these
@@ -148,6 +262,65 @@ function passwordConnectionFields(params: positron.DataConnectionParameterValues
 		user,
 		password: isNonEmptyString(params.password) ? params.password : undefined,
 		ssl: params.ssl !== false,
+	};
+}
+
+/**
+ * Renders redshift_connector code for IAM. The library mints the credentials itself given `iam=True`
+ * plus the target, so no user or password appears in the generated code -- which is the point: the
+ * snippet stays valid after the temporary credentials behind the live connection have expired.
+ */
+export function renderIamRedshiftConnectorCode(host: string, port: number, iam: RedshiftIamConfig, ssl?: boolean): positron.ConnectionCodeVariant {
+	const args: string[] = ['iam=True'];
+	if (iam.kind === 'serverless') {
+		args.push('is_serverless=True');
+		args.push(`serverless_work_group="${escapeDoubleQuoted(iam.name)}"`);
+	} else {
+		args.push(`cluster_identifier="${escapeDoubleQuoted(iam.name)}"`);
+		if (iam.dbUser) { args.push(`db_user="${escapeDoubleQuoted(iam.dbUser)}"`); }
+	}
+	args.push(`region="${escapeDoubleQuoted(iam.region)}"`);
+	args.push(`host="${escapeDoubleQuoted(host)}"`);
+	args.push(`port=${port}`);
+	args.push(`database="${escapeDoubleQuoted(iam.database)}"`);
+	if (iam.profile) { args.push(`profile="${escapeDoubleQuoted(iam.profile)}"`); }
+	if (ssl === false) { args.push(`ssl=False`); }
+	return {
+		id: 'redshift_connector',
+		label: 'redshift_connector',
+		code: `import redshift_connector\n\nconn = redshift_connector.connect(\n${args.map(arg => `\t${arg},`).join('\n')}\n)\n`,
+	};
+}
+
+/**
+ * Renders DBI/RPostgres code for IAM. RPostgres has no IAM support of its own -- it only takes a
+ * password -- so the snippet mints credentials with paws first and feeds the returned user and
+ * password into the ordinary connection. Note the user comes from the response rather than being
+ * chosen, exactly as it does for the live connection.
+ */
+export function renderIamDbiCode(host: string, port: number, iam: RedshiftIamConfig, ssl?: boolean): positron.ConnectionCodeVariant {
+	const profileLine = iam.profile
+		? `Sys.setenv(AWS_PROFILE = "${escapeDoubleQuoted(iam.profile)}")\n\n`
+		: '';
+	const credentials = iam.kind === 'serverless'
+		? `creds <- paws::redshiftserverless(\n\tconfig = list(region = "${escapeDoubleQuoted(iam.region)}")\n)$get_credentials(\n\tworkgroupName = "${escapeDoubleQuoted(iam.name)}",\n\tdbName = "${escapeDoubleQuoted(iam.database)}"\n)\n`
+		: `creds <- paws::redshift(\n\tconfig = list(region = "${escapeDoubleQuoted(iam.region)}")\n)$get_cluster_credentials(\n\tClusterIdentifier = "${escapeDoubleQuoted(iam.name)}",\n\tDbUser = "${escapeDoubleQuoted(iam.dbUser ?? '')}",\n\tDbName = "${escapeDoubleQuoted(iam.database)}"\n)\n`;
+	const user = iam.kind === 'serverless' ? 'creds$dbUser' : 'creds$DbUser';
+	const password = iam.kind === 'serverless' ? 'creds$dbPassword' : 'creds$DbPassword';
+	const args: string[] = [
+		'RPostgres::Postgres()',
+		`host = "${escapeDoubleQuoted(host)}"`,
+		`port = ${port}`,
+		`dbname = "${escapeDoubleQuoted(iam.database)}"`,
+		`user = ${user}`,
+		`password = ${password}`,
+	];
+	if (ssl !== false) { args.push(`sslmode = "require"`); }
+	return {
+		id: 'dbi',
+		label: 'DBI',
+		// R does not allow a trailing comma, so join the arguments with commas.
+		code: `library(paws)\nlibrary(DBI)\n\n${profileLine}${credentials}\ncon <- dbConnect(\n${args.map(arg => `\t${arg}`).join(',\n')}\n)\n`,
 	};
 }
 
@@ -236,6 +409,59 @@ export function createRedshiftDriver(
 		],
 	};
 
+	// AWS IAM mechanism. Deliberately shorter than the password mechanism: the workgroup or cluster
+	// name and its region are read out of the endpoint, and the database user is returned by AWS
+	// rather than chosen, so the only things left to ask for are where to connect and which AWS
+	// profile to authenticate with.
+	const iamMechanism: positron.DataConnectionMechanism = {
+		id: IAM_MECHANISM_ID,
+		label: vscode.l10n.t('AWS IAM'),
+		description: vscode.l10n.t('Connect using temporary credentials from your AWS identity. No database password is needed.'),
+		parameters: [
+			{
+				id: 'host',
+				label: vscode.l10n.t('Host'),
+				description: vscode.l10n.t('The cluster or workgroup endpoint, as shown in the AWS console. The workgroup or cluster name and its region are read from it.'),
+				type: positron.DataConnectionParameterType.String,
+				required: true,
+			},
+			{
+				id: 'port',
+				label: vscode.l10n.t('Port'),
+				type: positron.DataConnectionParameterType.Number,
+				required: true,
+				defaultValue: DEFAULT_PORT,
+			},
+			{
+				id: 'database',
+				label: vscode.l10n.t('Database'),
+				type: positron.DataConnectionParameterType.String,
+				required: true,
+				defaultValue: 'dev',
+			},
+			{
+				id: 'profile',
+				label: vscode.l10n.t('AWS Profile'),
+				description: vscode.l10n.t('The profile to authenticate with. Leave empty to use the default AWS credential chain.'),
+				type: positron.DataConnectionParameterType.String,
+			},
+			{
+				id: 'dbUser',
+				label: vscode.l10n.t('Database User'),
+				description: vscode.l10n.t('Only for provisioned clusters, which mint credentials for a named user. Serverless workgroups derive the user from your AWS identity, so leave this empty.'),
+				type: positron.DataConnectionParameterType.String,
+			},
+			{
+				id: 'ssl',
+				label: vscode.l10n.t('Use SSL'),
+				type: positron.DataConnectionParameterType.Boolean,
+				// The temporary credential travels as the connection password, so encryption is not
+				// optional in practice.
+				defaultValue: true,
+			},
+		],
+	};
+
 	// Return the driver.
 	return {
 		id: 'positron-data-driver-redshift',
@@ -243,7 +469,7 @@ export function createRedshiftDriver(
 		description: vscode.l10n.t('Connect to a Redshift cluster or workgroup'),
 		iconSvg,
 		supportedLanguageIds: ['python', 'r'],
-		mechanisms: [passwordMechanism],
+		mechanisms: [passwordMechanism, iamMechanism],
 		async connect(mechanismId: string, params: positron.DataConnectionParameterValues): Promise<positron.DataConnection> {
 			switch (mechanismId) {
 				case PASSWORD_MECHANISM_ID: {
@@ -283,6 +509,22 @@ export function createRedshiftDriver(
 					// Return the connection.
 					return connection;
 				}
+				case IAM_MECHANISM_ID: {
+					// The endpoint identifies the workgroup or cluster; AWS supplies the user and
+					// password, minted fresh on each connect by the connection's credential provider.
+					const target = iamTargetFromParams(params);
+					const connection = new RedshiftConnection({
+						kind: 'iam',
+						host: target.host,
+						port: target.port,
+						database: target.database,
+						user: '',
+						ssl: params.ssl !== false,
+						iam: target.iam,
+					}, dataExplorerHandler, logger);
+					await connection.connect();
+					return connection;
+				}
 				default:
 					return Promise.reject(new Error(vscode.l10n.t("Unknown connection mechanism '{0}'.", mechanismId)));
 			}
@@ -291,6 +533,25 @@ export function createRedshiftDriver(
 			switch (mechanismId) {
 				case PASSWORD_MECHANISM_ID:
 					return generateConnectionCodeForFields(languageId, passwordConnectionFields(params));
+				case IAM_MECHANISM_ID: {
+					// Code generation runs against whatever is currently typed in the dialog, which
+					// may not yet resolve to an AWS target. Offer nothing rather than a broken
+					// snippet until it does.
+					let target;
+					try {
+						target = iamTargetFromParams(params);
+					} catch {
+						return [];
+					}
+					switch (languageId) {
+						case 'python':
+							return [renderIamRedshiftConnectorCode(target.host, target.port, target.iam, params.ssl !== false)];
+						case 'r':
+							return [renderIamDbiCode(target.host, target.port, target.iam, params.ssl !== false)];
+						default:
+							return [];
+					}
+				}
 				default:
 					return [];
 			}

--- a/extensions/positron-data-driver-redshift/src/redshiftIamCredentials.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftIamCredentials.ts
@@ -1,0 +1,300 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Mints the temporary database credentials Redshift issues to an IAM identity. Redshift has no
+// "enable IAM auth" switch: IAM database authorization is always available, and whether it works is
+// purely a question of the calling principal's policy. What it does have is two different APIs
+// depending on the flavour of Redshift, which must not be conflated:
+//
+//   Serverless   redshift-serverless:GetCredentials      keyed on a workgroup name
+//   Provisioned  redshift:GetClusterCredentials          keyed on a cluster identifier + db user
+//
+// Two properties of the result shape the rest of the driver:
+//
+//   1. The username comes back, it is not supplied. For serverless, Redshift derives the database
+//      user from the federated identity and returns it (`IAMR:AWSReservedSSO_PowerUser_<hash>` for
+//      an Identity Center principal). Asking the user to type a username and then fetching only a
+//      password would connect as the wrong role, or fail outright.
+//
+//   2. The credentials are short-lived -- 900 seconds by default, 3600 at most. That is well inside
+//      the lifetime of an ordinary browsing session, so nothing may cache them once at connect time;
+//      every reconnect has to be able to mint a fresh pair. See RedshiftClient, which resolves
+//      credentials immediately before building each pg client rather than capturing them.
+//
+// The returned password goes in the ordinary password slot of the PostgreSQL wire protocol -- it is
+// a password, not a bearer token -- so TLS matters more here than usual.
+
+import { GetClusterCredentialsCommand, GetClusterCredentialsCommandInput, GetClusterCredentialsCommandOutput, RedshiftClient as RedshiftApiClient } from '@aws-sdk/client-redshift';
+import { GetCredentialsCommand, GetCredentialsCommandInput, GetCredentialsCommandOutput, RedshiftServerlessClient } from '@aws-sdk/client-redshift-serverless';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+
+/**
+ * Temporary database credentials minted by AWS. Both the user and the password are derived from the
+ * IAM identity; neither is supplied by the person connecting.
+ */
+export interface RedshiftIamCredentials {
+	user: string;
+	password: string;
+	/** When these credentials stop working. */
+	expiresAt: Date;
+}
+
+/**
+ * Mints a set of credentials. Called before each connect rather than once per connection, so a
+ * connection that outlives its credentials can still reconnect.
+ *
+ * Pass `forceRefresh` when the server has actually rejected the current credentials. Expiry is
+ * normally anticipated from the timestamp AWS returns, but that can be wrong -- a revoked policy or
+ * a skewed clock rejects credentials the cache still believes in -- and without this the retry would
+ * present the same rejected pair again.
+ */
+export type RedshiftCredentialProvider = (forceRefresh?: boolean) => Promise<RedshiftIamCredentials>;
+
+/** What the credential call needs to know, once the endpoint has been parsed. */
+export interface RedshiftIamConfig {
+	/** Which API to call. */
+	kind: 'serverless' | 'provisioned';
+	/** The workgroup name (serverless) or cluster identifier (provisioned). */
+	name: string;
+	/** The region hosting the workgroup or cluster, which is not necessarily the SSO region. */
+	region: string;
+	/** The database the credentials are scoped to. */
+	database: string;
+	/** The AWS profile to authenticate with. Omitted to use the default provider chain. */
+	profile?: string;
+	/** The database user to assume. Required for provisioned clusters, unused for serverless. */
+	dbUser?: string;
+}
+
+/**
+ * The lifetime to request, in seconds. AWS permits 900 (the default) to 3600, and the credentials
+ * cannot outlive the caller's own session regardless. Asking for the maximum minimizes how often a
+ * browsing session has to stop and re-mint.
+ */
+const REQUESTED_DURATION_SECONDS = 3600;
+
+/**
+ * How long before expiry to treat credentials as already stale. Covers the round trip of opening a
+ * connection with them, so a set that would expire mid-handshake is replaced rather than used.
+ */
+const EXPIRY_MARGIN_MS = 60_000;
+
+/**
+ * Why a connection attempt failed, as far as the remedy is concerned.
+ *
+ * `expired` and `missing` are both credential problems rather than Redshift problems, but they are
+ * worth keeping apart because their fixes have nothing in common: an expired session is fixed by
+ * signing in again, whereas no credentials at all usually means no profile was named and the
+ * default chain came up empty. Reporting the second as the first sends people to re-run a sign-in
+ * that already worked. With IAM Identity Center there are no long-lived access keys to fall back
+ * on, so an unset profile reliably produces `missing` rather than quietly working.
+ */
+type CredentialFailureKind = 'expired' | 'missing' | 'other';
+
+/** Classifies an AWS failure by what would actually fix it. */
+function classifyFailure(err: unknown): CredentialFailureKind {
+	if (!err || typeof err !== 'object') {
+		return 'other';
+	}
+	const { name, message } = err as { name?: string; message?: string };
+	const lower = (message ?? '').toLowerCase();
+
+	// Expiry is checked first: the SDK reports an expired SSO token as a CredentialsProviderError
+	// too, so testing the name before the message would classify every expiry as `missing`.
+	if (name === 'ExpiredTokenException' || name === 'TokenRefreshRequired' ||
+		lower.includes('token has expired') ||
+		lower.includes('has expired or is otherwise invalid') ||
+		lower.includes('sso session associated with this profile has expired') ||
+		lower.includes('refresh failed')) {
+		return 'expired';
+	}
+	if (name === 'CredentialsProviderError' ||
+		lower.includes('could not load credentials') ||
+		lower.includes('is not authorized to perform: sso')) {
+		return 'missing';
+	}
+	return 'other';
+}
+
+/**
+ * Rewrites an AWS failure into something that names the actual remedy. Otherwise a credential
+ * problem surfaces as a bare connection failure and sends people looking at the cluster.
+ */
+function describeFailure(err: unknown, config: RedshiftIamConfig): Error {
+	const detail = err instanceof Error ? err.message : String(err);
+	switch (classifyFailure(err)) {
+		case 'expired':
+			return new Error(config.profile
+				? vscode.l10n.t("Your AWS session for profile '{0}' has expired. Run 'aws sso login --profile {0}' and try again. ({1})", config.profile, detail)
+				: vscode.l10n.t("Your AWS session has expired. Run 'aws sso login' and try again. ({0})", detail));
+		case 'missing':
+			// Name the profile field explicitly. An empty one is the most common cause, and the
+			// message it used to produce blamed an SSO session that was working fine.
+			return new Error(config.profile
+				? vscode.l10n.t("No AWS credentials found for profile '{0}'. Check that the profile exists in ~/.aws/config, then run 'aws sso login --profile {0}'. ({1})", config.profile, detail)
+				: vscode.l10n.t("No AWS credentials found. This connection has no AWS Profile set, so the default credential chain was used; either set the profile or configure a [default] profile in ~/.aws/config. ({0})", detail));
+		case 'other':
+			break;
+	}
+	return new Error(config.kind === 'serverless'
+		? vscode.l10n.t("Could not get temporary credentials for Redshift Serverless workgroup '{0}' in {1}: {2}", config.name, config.region, detail)
+		: vscode.l10n.t("Could not get temporary credentials for Redshift cluster '{0}' in {1}: {2}", config.name, config.region, detail));
+}
+
+/**
+ * Issues the two AWS calls. These are the only pieces of this module that touch the network, so
+ * they are the injection seam: the functions below build the request and map the response, and take
+ * a sender so tests can assert what would have been sent and answer with a fixed response. Same
+ * reasoning as PgClientFactory on RedshiftClient -- everything except the transport stays testable
+ * without live infrastructure.
+ */
+export type ServerlessCredentialsSender =
+	(config: RedshiftIamConfig, input: GetCredentialsCommandInput) => Promise<GetCredentialsCommandOutput>;
+export type ClusterCredentialsSender =
+	(config: RedshiftIamConfig, input: GetClusterCredentialsCommandInput) => Promise<GetClusterCredentialsCommandOutput>;
+
+/** Builds the AWS client options shared by both APIs. */
+function clientOptions(config: RedshiftIamConfig) {
+	return {
+		region: config.region,
+		// The provider chain covers SSO cache, environment variables, and instance/container roles.
+		// With IAM Identity Center there are no long-lived keys, so this is the only way in.
+		credentials: fromNodeProviderChain({ profile: config.profile }),
+	};
+}
+
+/** The real serverless sender. */
+const sendServerlessCredentials: ServerlessCredentialsSender = async (config, input) => {
+	const client = new RedshiftServerlessClient(clientOptions(config));
+	try {
+		return await client.send(new GetCredentialsCommand(input));
+	} finally {
+		client.destroy();
+	}
+};
+
+/** The real provisioned sender. */
+const sendClusterCredentials: ClusterCredentialsSender = async (config, input) => {
+	const client = new RedshiftApiClient(clientOptions(config));
+	try {
+		return await client.send(new GetClusterCredentialsCommand(input));
+	} finally {
+		client.destroy();
+	}
+};
+
+/** The expiry to assume when AWS does not report one. */
+function fallbackExpiry(): Date {
+	return new Date(Date.now() + REQUESTED_DURATION_SECONDS * 1000);
+}
+
+/**
+ * Mints credentials for a serverless workgroup. Note the camelCase response fields, which differ
+ * from the provisioned API's PascalCase ones.
+ */
+export async function getServerlessCredentials(
+	config: RedshiftIamConfig,
+	send: ServerlessCredentialsSender = sendServerlessCredentials
+): Promise<RedshiftIamCredentials> {
+	const response = await send(config, {
+		workgroupName: config.name,
+		dbName: config.database,
+		durationSeconds: REQUESTED_DURATION_SECONDS,
+	});
+	if (!response.dbUser || !response.dbPassword) {
+		throw new Error(vscode.l10n.t('AWS returned no credentials.'));
+	}
+	return {
+		user: response.dbUser,
+		password: response.dbPassword,
+		expiresAt: response.expiration ?? fallbackExpiry(),
+	};
+}
+
+/**
+ * Mints credentials for a provisioned cluster. Unlike serverless, this API takes the database user
+ * to assume, and returns it prefixed (`IAM:<user>`, or `IAMA:<user>` when auto-created) -- so the
+ * returned value is used rather than the one that was asked for. AutoCreate is left off so
+ * connecting never silently creates a database user.
+ */
+export async function getClusterCredentials(
+	config: RedshiftIamConfig,
+	send: ClusterCredentialsSender = sendClusterCredentials
+): Promise<RedshiftIamCredentials> {
+	if (!config.dbUser) {
+		throw new Error(vscode.l10n.t('A database user is required to connect to a provisioned Redshift cluster with IAM.'));
+	}
+	const response = await send(config, {
+		ClusterIdentifier: config.name,
+		DbName: config.database,
+		DbUser: config.dbUser,
+		DurationSeconds: REQUESTED_DURATION_SECONDS,
+		AutoCreate: false,
+	});
+	if (!response.DbUser || !response.DbPassword) {
+		throw new Error(vscode.l10n.t('AWS returned no credentials.'));
+	}
+	return {
+		user: response.DbUser,
+		password: response.DbPassword,
+		expiresAt: response.Expiration ?? fallbackExpiry(),
+	};
+}
+
+/**
+ * Mints credentials for whichever flavour the config names. Injectable into the provider below so
+ * its caching and refresh behaviour can be tested without reaching either AWS API.
+ */
+export type RedshiftCredentialFetcher = (config: RedshiftIamConfig) => Promise<RedshiftIamCredentials>;
+
+/** The real fetcher: dispatches on the flavour. */
+export const defaultCredentialFetcher: RedshiftCredentialFetcher = config =>
+	config.kind === 'serverless' ? getServerlessCredentials(config) : getClusterCredentials(config);
+
+/**
+ * Creates a credential provider for the given Redshift target. The provider caches the credentials
+ * it mints and reuses them until they are close enough to expiry to be risky, so reconnecting a few
+ * times in quick succession does not make a call per attempt.
+ * @param config Identifies the workgroup or cluster and how to authenticate to AWS.
+ * @param logger Optional diagnostic log sink.
+ * @param fetch Mints the credentials. Defaults to the real AWS calls; overridden in tests.
+ */
+export function createIamCredentialProvider(
+	config: RedshiftIamConfig,
+	logger?: positron.DataConnectionLogger,
+	fetch: RedshiftCredentialFetcher = defaultCredentialFetcher
+): RedshiftCredentialProvider {
+	let cached: RedshiftIamCredentials | undefined;
+	let inFlight: Promise<RedshiftIamCredentials> | undefined;
+
+	return async (forceRefresh?: boolean) => {
+		if (forceRefresh) {
+			cached = undefined;
+		}
+		if (cached && cached.expiresAt.getTime() - Date.now() > EXPIRY_MARGIN_MS) {
+			return cached;
+		}
+		// Coalesce concurrent callers onto one AWS call, the same way RedshiftClient coalesces
+		// concurrent reconnects.
+		if (!inFlight) {
+			inFlight = (async () => {
+				logger?.info(`Requesting temporary Redshift credentials for ${config.kind} '${config.name}' in ${config.region}`);
+				try {
+					const credentials = await fetch(config);
+					logger?.info(`Received temporary credentials for '${credentials.user}', expiring ${credentials.expiresAt.toISOString()}`);
+					cached = credentials;
+					return credentials;
+				} catch (err) {
+					const failure = describeFailure(err, config);
+					logger?.error(failure.message);
+					throw failure;
+				}
+			})().finally(() => { inFlight = undefined; });
+		}
+		return inFlight;
+	};
+}

--- a/extensions/positron-data-driver-redshift/src/test/redshiftDriver.test.ts
+++ b/extensions/positron-data-driver-redshift/src/test/redshiftDriver.test.ts
@@ -8,7 +8,14 @@ import * as positron from 'positron';
 import { RedshiftConnection, RedshiftConnectionConfig } from '../redshiftConnection.js';
 import { PgClientFactory, RedshiftClient, RedshiftFieldConfig } from '../redshiftClient.js';
 import { createDatabaseNode, createSchemaNode } from '../redshiftNodes.js';
-import { parseRedshiftEndpoint } from '../redshiftDriver.js';
+import {
+	describeRedshiftEndpoint,
+	iamTargetFromParams,
+	parseRedshiftEndpoint,
+	renderIamDbiCode,
+	renderIamRedshiftConnectorCode,
+} from '../redshiftDriver.js';
+import { RedshiftIamConfig } from '../redshiftIamCredentials.js';
 
 // Default config for tests -- not used to connect, just to construct.
 const TEST_CONFIG: RedshiftConnectionConfig = {
@@ -625,5 +632,179 @@ suite('Redshift Endpoint Parsing', () => {
 
 	test('surrounding whitespace is trimmed', () => {
 		assert.deepStrictEqual(parseRedshiftEndpoint(`  ${host}:5439/dev  `), { host, port: 5439, database: 'dev' });
+	});
+});
+
+suite('Redshift Endpoint Description', () => {
+
+	test('a serverless endpoint yields the workgroup and its region', () => {
+		assert.deepStrictEqual(
+			describeRedshiftEndpoint('positron-redshift-dev-test.749683154838.us-east-2.redshift-serverless.amazonaws.com'),
+			{ kind: 'serverless', name: 'positron-redshift-dev-test', region: 'us-east-2' });
+	});
+
+	test('a provisioned endpoint yields the cluster identifier and its region', () => {
+		assert.deepStrictEqual(
+			describeRedshiftEndpoint('my-cluster.abc123xyz.us-west-2.redshift.amazonaws.com'),
+			{ kind: 'provisioned', name: 'my-cluster', region: 'us-west-2' });
+	});
+
+	test('the regional variants parse without being enumerated', () => {
+		assert.deepStrictEqual(
+			describeRedshiftEndpoint('wg.123.cn-north-1.redshift-serverless.amazonaws.com.cn'),
+			{ kind: 'serverless', name: 'wg', region: 'cn-north-1' });
+	});
+
+	test('hostnames are matched case-insensitively', () => {
+		assert.deepStrictEqual(
+			describeRedshiftEndpoint('WG.123.US-EAST-2.REDSHIFT-SERVERLESS.AMAZONAWS.COM'),
+			{ kind: 'serverless', name: 'wg', region: 'us-east-2' });
+	});
+
+	test('a private host merely containing a redshift label is not an endpoint', () => {
+		// Without an amazonaws anchor this resolved to region 'corp', which would then be sent to
+		// AWS as a real region.
+		assert.deepStrictEqual(
+			describeRedshiftEndpoint('warehouse.corp.redshift.example.com'), { kind: 'unknown' });
+		assert.deepStrictEqual(
+			describeRedshiftEndpoint('redshift-serverless.internal.example.com'), { kind: 'unknown' });
+	});
+
+	test('a workgroup named redshift does not shadow the service label', () => {
+		assert.deepStrictEqual(
+			describeRedshiftEndpoint('redshift.123456789012.us-east-2.redshift-serverless.amazonaws.com'),
+			{ kind: 'serverless', name: 'redshift', region: 'us-east-2' });
+	});
+
+	test('an AWS host for some other service is not a Redshift endpoint', () => {
+		assert.deepStrictEqual(
+			describeRedshiftEndpoint('mydb.abc123.us-east-1.rds.amazonaws.com'), { kind: 'unknown' });
+	});
+
+	test('a host that is not an AWS endpoint is reported unknown rather than guessed at', () => {
+		// A tunnel, proxy, or private alias carries no workgroup or region to read.
+		assert.deepStrictEqual(describeRedshiftEndpoint('localhost'), { kind: 'unknown' });
+		assert.deepStrictEqual(describeRedshiftEndpoint('redshift.internal.example.com'), { kind: 'unknown' });
+	});
+});
+
+suite('Redshift IAM Target Resolution', () => {
+
+	const SERVERLESS_HOST = 'my-workgroup.123456789012.us-east-2.redshift-serverless.amazonaws.com';
+
+	test('the target is derived from the endpoint, not asked for', () => {
+		const target = iamTargetFromParams({ host: SERVERLESS_HOST, port: 5439, database: 'dev', profile: 'work' });
+
+		assert.deepStrictEqual(target.iam, {
+			kind: 'serverless',
+			name: 'my-workgroup',
+			region: 'us-east-2',
+			database: 'dev',
+			profile: 'work',
+			dbUser: undefined,
+		});
+	});
+
+	test('a database embedded in the endpoint wins over the field', () => {
+		const target = iamTargetFromParams({ host: `${SERVERLESS_HOST}:5555/analytics`, port: 5439, database: 'dev' });
+
+		assert.strictEqual(target.port, 5555);
+		assert.strictEqual(target.database, 'analytics');
+		assert.strictEqual(target.iam.database, 'analytics');
+	});
+
+	test('a provisioned endpoint requires a database user', () => {
+		const host = 'my-cluster.abc123xyz.us-west-2.redshift.amazonaws.com';
+
+		assert.throws(() => iamTargetFromParams({ host, port: 5439, database: 'dev' }), /requires a database user/i);
+		assert.strictEqual(
+			iamTargetFromParams({ host, port: 5439, database: 'dev', dbUser: 'analyst' }).iam.dbUser,
+			'analyst');
+	});
+
+	test('an unrecognized host is refused rather than guessed at', () => {
+		assert.throws(
+			() => iamTargetFromParams({ host: 'tunnel.example.com', port: 5439, database: 'dev' }),
+			/not a recognized Redshift endpoint/i);
+	});
+
+	test('host and database are required', () => {
+		assert.throws(() => iamTargetFromParams({ port: 5439, database: 'dev' }), /Host is required/i);
+		assert.throws(() => iamTargetFromParams({ host: SERVERLESS_HOST, port: 5439 }), /Database is required/i);
+	});
+});
+
+suite('Redshift IAM Connection Code', () => {
+
+	const SERVERLESS: RedshiftIamConfig = {
+		kind: 'serverless',
+		name: 'my-workgroup',
+		region: 'us-east-2',
+		database: 'dev',
+		profile: 'work',
+	};
+
+	const PROVISIONED: RedshiftIamConfig = {
+		kind: 'provisioned',
+		name: 'my-cluster',
+		region: 'us-west-2',
+		database: 'dev',
+		dbUser: 'analyst',
+	};
+
+	test('serverless Python code asks the library to mint credentials, and names no user', () => {
+		const code = renderIamRedshiftConnectorCode('host.example.com', 5439, SERVERLESS).code;
+
+		assert.match(code, /iam=True/);
+		assert.match(code, /is_serverless=True/);
+		assert.match(code, /serverless_work_group="my-workgroup"/);
+		assert.match(code, /profile="work"/);
+		// No credentials are embedded, so the snippet outlives the session's temporary password.
+		assert.doesNotMatch(code, /password/);
+		assert.doesNotMatch(code, /db_user/);
+	});
+
+	test('provisioned Python code identifies the cluster and its database user', () => {
+		const code = renderIamRedshiftConnectorCode('host.example.com', 5439, PROVISIONED).code;
+
+		assert.match(code, /cluster_identifier="my-cluster"/);
+		assert.match(code, /db_user="analyst"/);
+		assert.doesNotMatch(code, /is_serverless/);
+		// No profile was configured, so none is pinned in the snippet.
+		assert.doesNotMatch(code, /profile=/);
+	});
+
+	test('serverless R code fetches credentials with paws and reads the returned user', () => {
+		const code = renderIamDbiCode('host.example.com', 5439, SERVERLESS).code;
+
+		assert.match(code, /paws::redshiftserverless/);
+		assert.match(code, /workgroupName = "my-workgroup"/);
+		// RPostgres has no IAM of its own, so the minted pair is passed through.
+		assert.match(code, /user = creds\$dbUser/);
+		assert.match(code, /password = creds\$dbPassword/);
+		assert.match(code, /AWS_PROFILE = "work"/);
+	});
+
+	test('the IAM renderers honor the Use SSL parameter', () => {
+		// The live connection honors `ssl`, so generated code must agree with it.
+		const pythonOff = renderIamRedshiftConnectorCode('host.example.com', 5439, SERVERLESS, false).code;
+		const pythonOn = renderIamRedshiftConnectorCode('host.example.com', 5439, SERVERLESS, true).code;
+		const rOff = renderIamDbiCode('host.example.com', 5439, SERVERLESS, false).code;
+		const rOn = renderIamDbiCode('host.example.com', 5439, SERVERLESS, true).code;
+
+		assert.match(pythonOff, /ssl=False/);
+		assert.doesNotMatch(pythonOn, /ssl=False/);
+		assert.doesNotMatch(rOff, /sslmode/);
+		assert.match(rOn, /sslmode = "require"/);
+	});
+
+	test('provisioned R code uses the cluster API and its PascalCase fields', () => {
+		const code = renderIamDbiCode('host.example.com', 5439, PROVISIONED).code;
+
+		assert.match(code, /paws::redshift\(/);
+		assert.match(code, /get_cluster_credentials/);
+		assert.match(code, /ClusterIdentifier = "my-cluster"/);
+		assert.match(code, /user = creds\$DbUser/);
+		assert.match(code, /password = creds\$DbPassword/);
 	});
 });

--- a/extensions/positron-data-driver-redshift/src/test/redshiftIamCredentials.test.ts
+++ b/extensions/positron-data-driver-redshift/src/test/redshiftIamCredentials.test.ts
@@ -1,0 +1,728 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Covers IAM authorization without reaching AWS. The credential module's only network-touching
+// pieces are its two senders, so injecting those leaves the request building, the response mapping,
+// and the provider's caching and refresh logic fully exercised here.
+//
+// The two APIs are tested separately on purpose: they differ in the case of every field
+// (`dbUser` versus `DbUser`) and in whether a database user is supplied or derived, which is exactly
+// the kind of difference that would otherwise only show up against live infrastructure.
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { PgClientFactory, RedshiftClient, RedshiftFieldConfig } from '../redshiftClient.js';
+import { RedshiftConnection } from '../redshiftConnection.js';
+import { createRedshiftDriver } from '../redshiftDriver.js';
+import {
+	ClusterCredentialsSender,
+	createIamCredentialProvider,
+	getClusterCredentials,
+	getServerlessCredentials,
+	RedshiftIamConfig,
+	RedshiftIamCredentials,
+	ServerlessCredentialsSender,
+} from '../redshiftIamCredentials.js';
+
+/** A serverless target, matching the shape the driver derives from an endpoint. */
+const SERVERLESS: RedshiftIamConfig = {
+	kind: 'serverless',
+	name: 'my-workgroup',
+	region: 'us-east-2',
+	database: 'dev',
+	profile: 'PowerUser-123456789012',
+};
+
+/** A provisioned target. Unlike serverless, this one names the database user to assume. */
+const PROVISIONED: RedshiftIamConfig = {
+	kind: 'provisioned',
+	name: 'my-cluster',
+	region: 'us-east-1',
+	database: 'dev',
+	profile: 'PowerUser-123456789012',
+	dbUser: 'analyst',
+};
+
+/** An expiry far enough out that the provider treats the credentials as usable. */
+function farFuture(): Date {
+	return new Date(Date.now() + 3_600_000);
+}
+
+suite('Redshift IAM Credentials - Serverless', () => {
+
+	test('builds the GetCredentials request from the target', async () => {
+		const seen: unknown[] = [];
+		const send: ServerlessCredentialsSender = async (_config, input) => {
+			seen.push(input);
+			return { dbUser: 'IAMR:x', dbPassword: 'p', expiration: farFuture(), $metadata: {} };
+		};
+
+		await getServerlessCredentials(SERVERLESS, send);
+
+		// The maximum lifetime is requested rather than accepting the 900s default, so a browsing
+		// session re-mints as rarely as AWS allows.
+		assert.deepStrictEqual(seen, [{
+			workgroupName: 'my-workgroup',
+			dbName: 'dev',
+			durationSeconds: 3600,
+		}]);
+	});
+
+	test('maps the camelCase response', async () => {
+		const expiration = farFuture();
+		const send: ServerlessCredentialsSender = async () => ({
+			dbUser: 'IAMR:AWSReservedSSO_PowerUser_abc',
+			dbPassword: 'temporary-password',
+			expiration,
+			$metadata: {},
+		});
+
+		const credentials = await getServerlessCredentials(SERVERLESS, send);
+
+		assert.deepStrictEqual(credentials, {
+			user: 'IAMR:AWSReservedSSO_PowerUser_abc',
+			password: 'temporary-password',
+			expiresAt: expiration,
+		});
+	});
+
+	test('falls back to the requested lifetime when AWS reports no expiry', async () => {
+		const send: ServerlessCredentialsSender = async () => ({ dbUser: 'u', dbPassword: 'p', $metadata: {} });
+
+		const before = Date.now();
+		const credentials = await getServerlessCredentials(SERVERLESS, send);
+
+		// Roughly an hour out, without asserting an exact instant.
+		const seconds = (credentials.expiresAt.getTime() - before) / 1000;
+		assert.ok(seconds > 3500 && seconds <= 3600, `expected ~3600s, got ${seconds}`);
+	});
+
+	test('throws when the response carries no password', async () => {
+		const send: ServerlessCredentialsSender = async () => ({ dbUser: 'u', $metadata: {} });
+
+		await assert.rejects(() => getServerlessCredentials(SERVERLESS, send), /no credentials/i);
+	});
+});
+
+suite('Redshift IAM Credentials - Provisioned', () => {
+
+	test('builds the GetClusterCredentials request, with auto-create off', async () => {
+		const seen: unknown[] = [];
+		const send: ClusterCredentialsSender = async (_config, input) => {
+			seen.push(input);
+			return { DbUser: 'IAM:analyst', DbPassword: 'p', Expiration: farFuture(), $metadata: {} };
+		};
+
+		await getClusterCredentials(PROVISIONED, send);
+
+		// AutoCreate stays false so connecting never silently creates a database user.
+		assert.deepStrictEqual(seen, [{
+			ClusterIdentifier: 'my-cluster',
+			DbName: 'dev',
+			DbUser: 'analyst',
+			DurationSeconds: 3600,
+			AutoCreate: false,
+		}]);
+	});
+
+	test('maps the PascalCase response, preferring the returned prefixed user', async () => {
+		const Expiration = farFuture();
+		const send: ClusterCredentialsSender = async () => ({
+			// AWS returns the user prefixed, which is not what was asked for.
+			DbUser: 'IAM:analyst',
+			DbPassword: 'temporary-password',
+			Expiration,
+			$metadata: {},
+		});
+
+		const credentials = await getClusterCredentials(PROVISIONED, send);
+
+		assert.deepStrictEqual(credentials, {
+			user: 'IAM:analyst',
+			password: 'temporary-password',
+			expiresAt: Expiration,
+		});
+	});
+
+	test('rejects a target with no database user before calling AWS', async () => {
+		let called = false;
+		const send: ClusterCredentialsSender = async () => {
+			called = true;
+			return { $metadata: {} };
+		};
+		const { dbUser, ...withoutUser } = PROVISIONED;
+
+		await assert.rejects(() => getClusterCredentials(withoutUser, send), /database user is required/i);
+		assert.strictEqual(called, false, 'should not reach AWS without a database user');
+	});
+
+	test('throws when the response carries no password', async () => {
+		const send: ClusterCredentialsSender = async () => ({ DbUser: 'IAM:analyst', $metadata: {} });
+
+		await assert.rejects(() => getClusterCredentials(PROVISIONED, send), /no credentials/i);
+	});
+});
+
+suite('Redshift IAM Credential Provider', () => {
+
+	// Records how often credentials were minted and with what refresh flag, and hands back
+	// credentials whose expiry the test controls.
+	function fakeFetcher(expiresAt: () => Date = farFuture) {
+		let calls = 0;
+		return {
+			get calls() { return calls; },
+			fetch: async (): Promise<RedshiftIamCredentials> => {
+				calls++;
+				return { user: `user-${calls}`, password: `password-${calls}`, expiresAt: expiresAt() };
+			},
+		};
+	}
+
+	test('reuses credentials that are still valid', async () => {
+		const fetcher = fakeFetcher();
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, fetcher.fetch);
+
+		const first = await provider();
+		const second = await provider();
+
+		assert.strictEqual(fetcher.calls, 1);
+		assert.deepStrictEqual(second, first);
+	});
+
+	test('re-mints when asked to force a refresh', async () => {
+		const fetcher = fakeFetcher();
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, fetcher.fetch);
+
+		await provider();
+		const refreshed = await provider(true);
+
+		assert.strictEqual(fetcher.calls, 2);
+		assert.strictEqual(refreshed.user, 'user-2');
+	});
+
+	test('re-mints credentials that are about to expire', async () => {
+		// Inside the margin that covers the connect round trip, so these count as already stale.
+		const fetcher = fakeFetcher(() => new Date(Date.now() + 30_000));
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, fetcher.fetch);
+
+		await provider();
+		await provider();
+
+		assert.strictEqual(fetcher.calls, 2);
+	});
+
+	test('credentials just outside the margin are still reused', async () => {
+		// Pins the boundary from the other side, so a margin change cannot silently start
+		// re-minting on every call.
+		const fetcher = fakeFetcher(() => new Date(Date.now() + 120_000));
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, fetcher.fetch);
+
+		await provider();
+		await provider();
+
+		assert.strictEqual(fetcher.calls, 1);
+	});
+
+	test('coalesces concurrent callers onto one AWS call', async () => {
+		const fetcher = fakeFetcher();
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, fetcher.fetch);
+
+		const results = await Promise.all([provider(), provider(), provider()]);
+
+		assert.strictEqual(fetcher.calls, 1);
+		assert.deepStrictEqual(results[1], results[0]);
+		assert.deepStrictEqual(results[2], results[0]);
+	});
+
+	test('a credential-resolution failure points at the profile and signing in again', async () => {
+		const err = Object.assign(new Error('Could not load credentials from any providers'), {
+			name: 'CredentialsProviderError',
+		});
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, async () => { throw err; });
+
+		// The remedy is an SSO sign-in for a named profile, which has nothing to do with Redshift.
+		await assert.rejects(provider, (thrown: Error) => {
+			assert.match(thrown.message, /PowerUser-123456789012/);
+			assert.match(thrown.message, /aws sso login/);
+			return true;
+		});
+	});
+
+	test('an expired session is reported as expired, not as missing credentials', async () => {
+		// The shape the SDK produces once the SSO cache has aged out.
+		const err = Object.assign(
+			new Error('Error when retrieving token from sso: Token has expired and refresh failed'),
+			{ name: 'CredentialsProviderError' });
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, async () => { throw err; });
+
+		await assert.rejects(provider, (thrown: Error) => {
+			assert.match(thrown.message, /has expired/i);
+			assert.match(thrown.message, /aws sso login --profile PowerUser-123456789012/);
+			// Signing in is the fix, so do not send the reader off to inspect their config.
+			assert.doesNotMatch(thrown.message, /No AWS credentials found/i);
+			return true;
+		});
+	});
+
+	test('no credentials with no profile set names the profile field, not an expired session', async () => {
+		// The case that is easy to misdiagnose: the session is fine, but nothing named a profile,
+		// and with IAM Identity Center the default chain has no long-lived keys to fall back on.
+		const err = Object.assign(new Error('Could not load credentials from any providers'), {
+			name: 'CredentialsProviderError',
+		});
+		const { profile, ...withoutProfile } = SERVERLESS;
+		const provider = createIamCredentialProvider(withoutProfile, undefined, async () => { throw err; });
+
+		await assert.rejects(provider, (thrown: Error) => {
+			assert.match(thrown.message, /No AWS credentials found/i);
+			assert.match(thrown.message, /AWS Profile/);
+			assert.match(thrown.message, /\[default\] profile/);
+			// The session was never the problem, so claiming expiry would be wrong.
+			assert.doesNotMatch(thrown.message, /expired/i);
+			return true;
+		});
+	});
+
+	test('no credentials for a named profile does not claim the session expired', async () => {
+		const err = Object.assign(new Error('Profile PowerUser-123456789012 could not be found'), {
+			name: 'CredentialsProviderError',
+		});
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, async () => { throw err; });
+
+		await assert.rejects(provider, (thrown: Error) => {
+			assert.match(thrown.message, /No AWS credentials found for profile 'PowerUser-123456789012'/);
+			assert.doesNotMatch(thrown.message, /has expired/i);
+			return true;
+		});
+	});
+
+	test('a workgroup failure names the workgroup and region instead of blaming sign-in', async () => {
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, async () => {
+			throw new Error('Serverless workgroup my-workgroup not found.');
+		});
+
+		await assert.rejects(provider, (thrown: Error) => {
+			assert.match(thrown.message, /my-workgroup/);
+			assert.match(thrown.message, /us-east-2/);
+			assert.doesNotMatch(thrown.message, /aws sso login/);
+			return true;
+		});
+	});
+
+	test('a provisioned failure is described as a cluster', async () => {
+		const provider = createIamCredentialProvider(PROVISIONED, undefined, async () => {
+			throw new Error('ClusterNotFound');
+		});
+
+		await assert.rejects(provider, (thrown: Error) => {
+			assert.match(thrown.message, /cluster 'my-cluster'/);
+			return true;
+		});
+	});
+
+	test('a failure is not cached, so the next attempt tries again', async () => {
+		let calls = 0;
+		const provider = createIamCredentialProvider(SERVERLESS, undefined, async () => {
+			calls++;
+			if (calls === 1) {
+				throw new Error('transient');
+			}
+			return { user: 'u', password: 'p', expiresAt: farFuture() };
+		});
+
+		await assert.rejects(provider);
+		const credentials = await provider();
+
+		assert.strictEqual(calls, 2);
+		assert.strictEqual(credentials.user, 'u');
+	});
+});
+
+suite('Redshift IAM Credential Refresh in the Client', () => {
+
+	const IAM_FIELDS: RedshiftFieldConfig = {
+		host: 'my-workgroup.123456789012.us-east-2.redshift-serverless.amazonaws.com',
+		port: 5439,
+		database: 'dev',
+		// Empty under IAM: AWS derives the user and returns it.
+		user: '',
+		ssl: true,
+	};
+
+	// A fake pg Client whose per-instance handler may throw to simulate a failure.
+	class FakeClient {
+		constructor(private readonly _handler: (sql: string) => { rows: unknown[] }) { }
+		async connect() { }
+		async query(sql: string) { return this._handler(sql); }
+		async end() { }
+		on() { return this; }
+	}
+
+	// Builds a factory that records the config each client was built from, so a test can see which
+	// credentials were actually handed to pg.
+	function recordingFactory(handlers: Array<(sql: string) => { rows: unknown[] }>) {
+		const configs: RedshiftFieldConfig[] = [];
+		const factory: PgClientFactory = config => {
+			const client = new FakeClient(handlers[configs.length] ?? (() => ({ rows: [] })));
+			configs.push(config);
+			// eslint-disable-next-line local/code-no-any-casts
+			return client as any;
+		};
+		return { factory, configs };
+	}
+
+	// A provider that mints a new pair each time and records the refresh flag it was passed.
+	function recordingProvider() {
+		const forced: Array<boolean | undefined> = [];
+		let issued = 0;
+		return {
+			get forced() { return forced; },
+			provider: async (forceRefresh?: boolean): Promise<RedshiftIamCredentials> => {
+				forced.push(forceRefresh);
+				issued++;
+				return { user: `IAMR:user-${issued}`, password: `secret-${issued}`, expiresAt: farFuture() };
+			},
+		};
+	}
+
+	test('mints credentials and hands them to pg in place of the configured ones', async () => {
+		const { factory, configs } = recordingFactory([]);
+		const { provider } = recordingProvider();
+		const client = new RedshiftClient({ ...IAM_FIELDS, credentialProvider: provider }, factory);
+
+		await client.connect();
+
+		assert.strictEqual(configs.length, 1);
+		assert.strictEqual(configs[0].user, 'IAMR:user-1');
+		assert.strictEqual(configs[0].password, 'secret-1');
+		assert.strictEqual(client.resolvedUser, 'IAMR:user-1');
+	});
+
+	test('re-mints on reconnect, so credentials cannot outlive the connection', async () => {
+		const { factory, configs } = recordingFactory([
+			() => { throw new Error('Connection terminated unexpectedly'); },
+			() => ({ rows: [{ ok: true }] }),
+		]);
+		const { provider } = recordingProvider();
+		const client = new RedshiftClient({ ...IAM_FIELDS, credentialProvider: provider }, factory);
+
+		await client.connect();
+		await client.query('SELECT 1');
+
+		// The second pg client was built from freshly minted credentials, not the first pair.
+		assert.strictEqual(configs.length, 2);
+		assert.strictEqual(configs[1].password, 'secret-2');
+	});
+
+	test('rejected credentials trigger a forced re-mint and one retry', async () => {
+		const { factory, configs } = recordingFactory([
+			// Expiry does not look like a dead socket; it comes back as an auth failure.
+			() => { throw Object.assign(new Error('password authentication failed'), { code: '28P01' }); },
+			() => ({ rows: [{ ok: true }] }),
+		]);
+		const recorder = recordingProvider();
+		const client = new RedshiftClient({ ...IAM_FIELDS, credentialProvider: recorder.provider }, factory);
+
+		await client.connect();
+		const result = await client.query('SELECT 1');
+
+		assert.deepStrictEqual(result.rows, [{ ok: true }]);
+		// The refresh is forced: the cached pair was just rejected, so reusing it would fail again.
+		assert.deepStrictEqual(recorder.forced, [false, true]);
+		assert.strictEqual(configs[1].password, 'secret-2');
+	});
+
+	test('the other invalid-authorization code also forces a re-mint', async () => {
+		const { factory } = recordingFactory([
+			() => { throw Object.assign(new Error('invalid authorization specification'), { code: '28000' }); },
+			() => ({ rows: [{ ok: true }] }),
+		]);
+		const recorder = recordingProvider();
+		const client = new RedshiftClient({ ...IAM_FIELDS, credentialProvider: recorder.provider }, factory);
+
+		await client.connect();
+		await client.query('SELECT 1');
+
+		assert.deepStrictEqual(recorder.forced, [false, true]);
+	});
+
+	test('resolvedUser falls back to the configured user when nothing is minted', async () => {
+		const { factory } = recordingFactory([]);
+		const client = new RedshiftClient({ ...IAM_FIELDS, user: 'someone' }, factory);
+
+		await client.connect();
+
+		assert.strictEqual(client.resolvedUser, 'someone');
+	});
+
+	test('a connection survives a reconnect whose credential mint failed', async () => {
+		const { factory, configs } = recordingFactory([
+			() => { throw new Error('Connection terminated unexpectedly'); },
+			() => ({ rows: [{ ok: true }] }),
+		]);
+		let attempts = 0;
+		const client = new RedshiftClient({
+			...IAM_FIELDS,
+			credentialProvider: async () => {
+				attempts++;
+				// The mint fails once -- an expired SSO session, say -- then starts working again.
+				if (attempts === 2) {
+					throw new Error('Token has expired and refresh failed');
+				}
+				return { user: 'IAMR:u', password: `secret-${attempts}`, expiresAt: farFuture() };
+			},
+		}, factory);
+
+		await client.connect();
+		// The reconnect this triggers cannot mint, so it leaves no pg client behind.
+		await assert.rejects(() => client.query('SELECT 1'));
+
+		// Once the user fixes their session the connection must come back. Without a retry here the
+		// failure is permanent, because "client is closed" is neither a socket nor an auth error.
+		const result = await client.query('SELECT 1');
+		assert.deepStrictEqual(result.rows, [{ ok: true }]);
+		assert.strictEqual(configs[1].password, 'secret-3');
+	});
+
+	test('a deliberate close is not resurrected by a later query', async () => {
+		const { factory } = recordingFactory([]);
+		const client = new RedshiftClient({ ...IAM_FIELDS, user: 'someone' }, factory);
+
+		await client.connect();
+		await client.end();
+
+		await assert.rejects(() => client.query('SELECT 1'), /closed/i);
+	});
+
+	test('an auth failure without a credential provider is not retried', async () => {
+		const { factory, configs } = recordingFactory([
+			() => { throw Object.assign(new Error('password authentication failed'), { code: '28P01' }); },
+		]);
+		const client = new RedshiftClient({ ...IAM_FIELDS, user: 'someone', password: 'static' }, factory);
+
+		await client.connect();
+
+		// Nothing to re-mint, so a wrong password is a real error rather than a refresh opportunity.
+		await assert.rejects(() => client.query('SELECT 1'), /password authentication failed/);
+		assert.strictEqual(configs.length, 1);
+	});
+});
+
+suite('Redshift IAM Connection Wiring', () => {
+
+	// A no-op Data Explorer host; these tests exercise connecting, not previewing.
+	const noopHost = {
+		previewObject: async () => 'noop-dataset',
+		previewColumn: async () => 'noop-dataset',
+		openTableView: async () => { },
+		openColumnView: async () => { },
+		closeTableView: () => { },
+	};
+
+	/** The extension context, needed only so the driver can read its icon off disk. */
+	function testContext(): vscode.ExtensionContext {
+		const extension = vscode.extensions.getExtension('positron.positron-data-driver-redshift');
+		assert.ok(extension, 'the Redshift driver extension should be present');
+		// eslint-disable-next-line local/code-no-any-casts
+		return { extensionPath: extension.extensionPath } as any;
+	}
+
+	// A pg client that answers the cross-database probe, recording the config it was built from.
+	function recordingFactory() {
+		const configs: RedshiftFieldConfig[] = [];
+		const factory: PgClientFactory = config => {
+			configs.push(config);
+			// eslint-disable-next-line local/code-no-any-casts
+			return {
+				connect: async () => { },
+				query: async () => ({ rows: [{ ok: 1 }] }),
+				end: async () => { },
+				on() { return this; },
+			} as any;
+		};
+		return { factory, configs };
+	}
+
+	test('an IAM connection mints credentials and connects as the returned user', async () => {
+		const { factory, configs } = recordingFactory();
+		// The whole chain runs for real here: config -> credential provider -> pg client. Only the
+		// AWS call and the socket are faked.
+		const connection = new RedshiftConnection({
+			kind: 'iam',
+			host: 'my-workgroup.123456789012.us-east-2.redshift-serverless.amazonaws.com',
+			port: 5439,
+			database: 'dev',
+			user: '',
+			ssl: true,
+			iam: SERVERLESS,
+		}, noopHost, undefined, {
+			pgClientFactory: factory,
+			credentialFetcher: async () => ({
+				user: 'IAMR:AWSReservedSSO_PowerUser_abc',
+				password: 'minted',
+				expiresAt: farFuture(),
+			}),
+		});
+
+		await connection.connect();
+
+		// The credentials AWS returned, not the empty ones the config carried.
+		assert.strictEqual(configs[0].user, 'IAMR:AWSReservedSSO_PowerUser_abc');
+		assert.strictEqual(configs[0].password, 'minted');
+		await connection.disconnect();
+	});
+
+	test('a fields connection never reaches the credential path', async () => {
+		const { factory, configs } = recordingFactory();
+		let minted = false;
+		const connection = new RedshiftConnection({
+			kind: 'fields',
+			host: 'my-cluster.abc.us-east-1.redshift.amazonaws.com',
+			port: 5439,
+			database: 'dev',
+			user: 'admin',
+			password: 'static',
+			ssl: true,
+		}, noopHost, undefined, {
+			pgClientFactory: factory,
+			credentialFetcher: async () => { minted = true; throw new Error('should not be called'); },
+		});
+
+		await connection.connect();
+
+		assert.strictEqual(minted, false, 'password auth must not mint IAM credentials');
+		assert.strictEqual(configs[0].user, 'admin');
+		await connection.disconnect();
+	});
+
+	test('a credential failure surfaces as a connect failure with the remedy intact', async () => {
+		const { factory } = recordingFactory();
+		const connection = new RedshiftConnection({
+			kind: 'iam',
+			host: 'my-workgroup.123456789012.us-east-2.redshift-serverless.amazonaws.com',
+			port: 5439,
+			database: 'dev',
+			user: '',
+			ssl: true,
+			iam: SERVERLESS,
+		}, noopHost, undefined, {
+			pgClientFactory: factory,
+			credentialFetcher: async () => {
+				throw Object.assign(new Error('Token has expired and refresh failed'), {
+					name: 'CredentialsProviderError',
+				});
+			},
+		});
+
+		// The advice must survive being wrapped by the connection's own error message.
+		await assert.rejects(() => connection.connect(), /has expired.*aws sso login --profile/s);
+	});
+
+	test('a provisioned login rejection explains that the database user may not exist', async () => {
+		const factory: PgClientFactory = () => {
+			// AutoCreate is off, so AWS issued credentials for a user the cluster never had; the
+			// login is what fails.
+			// eslint-disable-next-line local/code-no-any-casts
+			return {
+				connect: async () => {
+					throw Object.assign(new Error('password authentication failed for user "IAM:analyst"'),
+						{ code: '28P01' });
+				},
+				query: async () => ({ rows: [] }),
+				end: async () => { },
+				on() { return this; },
+			} as any;
+		};
+		const connection = new RedshiftConnection({
+			kind: 'iam',
+			host: 'my-cluster.abc.us-east-1.redshift.amazonaws.com',
+			port: 5439,
+			database: 'dev',
+			user: '',
+			ssl: true,
+			iam: PROVISIONED,
+		}, noopHost, undefined, {
+			pgClientFactory: factory,
+			credentialFetcher: async () => ({ user: 'IAM:analyst', password: 'minted', expiresAt: farFuture() }),
+		});
+
+		await assert.rejects(() => connection.connect(), (err: Error) => {
+			// The raw driver error is kept, with the actual cause appended.
+			assert.match(err.message, /password authentication failed/);
+			assert.match(err.message, /database user 'analyst' may not exist in cluster 'my-cluster'/);
+			return true;
+		});
+	});
+
+	test('a serverless login rejection gets no cluster-user hint', async () => {
+		const factory: PgClientFactory = () => {
+			// eslint-disable-next-line local/code-no-any-casts
+			return {
+				connect: async () => {
+					throw Object.assign(new Error('password authentication failed'), { code: '28P01' });
+				},
+				query: async () => ({ rows: [] }),
+				end: async () => { },
+				on() { return this; },
+			} as any;
+		};
+		const connection = new RedshiftConnection({
+			kind: 'iam',
+			host: 'my-workgroup.123456789012.us-east-2.redshift-serverless.amazonaws.com',
+			port: 5439,
+			database: 'dev',
+			user: '',
+			ssl: true,
+			iam: SERVERLESS,
+		}, noopHost, undefined, {
+			pgClientFactory: factory,
+			credentialFetcher: async () => ({ user: 'IAMR:x', password: 'minted', expiresAt: farFuture() }),
+		});
+
+		// Serverless derives the user, so there is no user to create and no advice to give.
+		await assert.rejects(() => connection.connect(), (err: Error) => {
+			assert.doesNotMatch(err.message, /may not exist/);
+			return true;
+		});
+	});
+
+	test('the driver offers an AWS IAM mechanism that asks for no password', () => {
+		const driver = createRedshiftDriver(testContext(), noopHost as never);
+		const iam = driver.mechanisms.find(m => m.id === 'iam');
+
+		assert.ok(iam, 'the driver should offer an IAM mechanism');
+		const ids = iam.parameters.map(p => p.id);
+		assert.deepStrictEqual(ids, ['host', 'port', 'database', 'profile', 'dbUser', 'ssl']);
+		// Nothing secret is collected: AWS supplies both halves of the credential.
+		assert.strictEqual(iam.parameters.some(p => p.id === 'password'), false);
+	});
+
+	test('the driver generates IAM code for both languages', async () => {
+		const driver = createRedshiftDriver(testContext(), noopHost as never);
+		const params = {
+			host: 'my-workgroup.123456789012.us-east-2.redshift-serverless.amazonaws.com',
+			port: 5439,
+			database: 'dev',
+			profile: 'work',
+		};
+
+		const python = await driver.generateConnectionCode!('iam', 'python', params);
+		const r = await driver.generateConnectionCode!('iam', 'r', params);
+
+		assert.match(python[0].code, /iam=True/);
+		assert.match(r[0].code, /paws::redshiftserverless/);
+	});
+
+	test('the driver offers no IAM code until the endpoint resolves', async () => {
+		const driver = createRedshiftDriver(testContext(), noopHost as never);
+
+		// A half-typed host is not an error to show the user, just nothing to generate yet.
+		const code = await driver.generateConnectionCode!('iam', 'python', {
+			host: 'my-workgroup', port: 5439, database: 'dev',
+		});
+
+		assert.deepStrictEqual(code, []);
+	});
+});


### PR DESCRIPTION
Adds AWS IAM as a second connection mechanism to the Redshift driver, alongside User & Password. Redshift issues short-lived database credentials to an IAM identity, so this connects with no database password at all.

<p>
<img width="517" height="338" alt="image" src="https://github.com/user-attachments/assets/8ee33a80-4541-4695-a984-a4842f65f0cc" />
</p>

<p>
<img width="557" height="620" alt="image" src="https://github.com/user-attachments/assets/4631f9ee-aec4-4092-a3bb-708c670e519b" />
</p>

## How it works

Pick **AWS IAM**, paste the endpoint from the AWS console, and give an AWS profile. The driver reads the workgroup (or cluster) name and its region out of the endpoint hostname, so there is nothing to restate:

```
<workgroup>.<account>.<region>.redshift-serverless.amazonaws.com
<cluster>.<id>.<region>.redshift.amazonaws.com
```

The `.redshift-serverless.` versus `.redshift.` segment also selects the API, so the user is never asked which flavour of Redshift they are on. One mechanism covers both rather than two near-identical entries in the list.

| | API | Keyed on |
| --- | --- | --- |
| Serverless | `redshift-serverless:GetCredentials` | workgroup name |
| Provisioned | `redshift:GetClusterCredentials` | cluster identifier + database user |

Credentials come from the standard AWS provider chain, which covers the SSO cache, environment variables, and instance or container roles. With IAM Identity Center there are no long-lived access keys, so that chain is the only way in.

Parsing is anchored on the `amazonaws` label rather than searching for a `redshift` one, so a private host that merely contains that label (`warehouse.corp.redshift.example.com`) is refused rather than parsed into a bogus region, and a workgroup whose own name is `redshift` does not shadow the service label.

## Two properties of the API that shaped the design

**The username is returned, not supplied.** Redshift derives the database user from the federated identity (`IAMR:AWSReservedSSO_PowerUser_<hash>` for an Identity Center principal) and hands it back with the password. A dialog that asked for a username and then fetched only a password would connect as the wrong role or fail outright, so the IAM mechanism does not ask for one. Provisioned clusters are the exception: that API takes a database user, and returns it prefixed, so the returned value is what gets used.

**Credentials are short-lived.** 900 seconds by default, 3600 at most, which is well inside an ordinary browsing session. Nothing may capture them once at connect time. `RedshiftClient` now resolves credentials immediately before building each pg client, *inside* the connect-retry loop rather than outside it -- a resuming serverless workgroup can take tens of seconds to accept a connection, so a set fetched once up front can expire before the attempt that finally succeeds uses it.

Expiry does not look like a dropped socket, so it needs its own recovery path: an invalid-authorization failure (`28000`/`28P01`) discards the cached credentials, re-mints, and retries once. The same failure without a credential provider is not retried, so a genuinely wrong password stays an error. A reconnect whose *mint* fails is also recoverable -- it leaves no pg client behind, and the resulting "client is closed" is neither a socket nor an auth error, so without an explicit retry the connection would stay dead even after the user fixed their session. A deliberate `end()` is never resurrected.

## Error messages

Three failures that look alike from the outside are now reported apart, because their remedies have nothing in common:

- **Expired session** -- "Your AWS session for profile 'X' has expired. Run `aws sso login --profile X`."
- **No credentials found** -- names the AWS Profile field, and that an empty one falls through to the default chain, which needs a `[default]` profile. This is the common case and the old message misdiagnosed it as expiry.
- **Redshift rejecting the request** -- names the workgroup or cluster and its region, and does not mention signing in.

Ordering matters here: the SDK reports an expired SSO token as a `CredentialsProviderError` too, so the expiry patterns are matched before the error name, or every real expiry would be classified as "missing".

One further case is specific to provisioned clusters. With `AutoCreate` off -- the AWS default, and what this driver asks for so connecting never silently creates a database user -- `GetClusterCredentials` *succeeds* for a user that does not exist and the login is what fails. The cause is an AWS-side decision but the symptom is a bare authentication error pointing nowhere useful, so that failure now appends the actual cause. Keying on the SQLSTATE alone is safe because under IAM the password was minted rather than typed, so an authentication failure cannot be a wrong password.

## Generated code

Python uses `redshift_connector` with `iam=True` and embeds no credentials, so the snippet stays valid after the live connection's temporary password has expired. R uses `paws` to mint credentials and feeds the returned user and password into `RPostgres`, since RPostgres has no IAM support of its own. Both honor the Use SSL parameter, so generated code cannot contradict the connection it came from.

## Testing

**93 passing.** Verified live against a Redshift Serverless workgroup: credentials minted, connected as the returned `IAMR:` user, cross-database browsing working, and the 3600s request honoured at exactly 60 minutes.

Everything else is covered without infrastructure. The credential module's only network-touching pieces are its two senders, so those are the injection seam -- tests assert the request that *would* be sent, not just the response that comes back. That is what pins down `AutoCreate: false` and `DurationSeconds: 3600` being on the wire.

| Area | Covered |
| --- | --- |
| Serverless API | request shape, camelCase mapping, expiry fallback, empty response |
| Provisioned API | request shape incl. `AutoCreate: false`, PascalCase mapping, returned `IAM:` prefix preferred over the requested user, database-user precondition short-circuiting before AWS |
| Provider caching | reuse, forced refresh, expiry margin pinned from both sides, concurrent coalescing, failures not cached |
| Expiry recovery | re-mint on reconnect, `28000` and `28P01` forcing a re-mint and one retry, no retry without a provider, recovery from a reconnect whose mint failed, deliberate close staying closed |
| Failure messages | expired vs. missing vs. API, with negative assertions both ways |
| Endpoint parsing | serverless, provisioned, `amazonaws.com.cn`, case-insensitivity, unknown hosts, private hosts containing a `redshift` label, a workgroup named `redshift`, other AWS services |
| Target resolution | inference, embedded-database precedence, database-user requirement, unrecognized host refused |
| Code generation | both languages by both flavours, the Use SSL parameter, and the empty-array fallback |
| End-to-end wiring | IAM connection reaching pg with minted credentials, `fields` connection never touching AWS, error advice surviving being wrapped |

`RedshiftConnection` gained an optional dependencies bag (`pgClientFactory`, `credentialFetcher`) so the whole chain -- config to credential provider to pg client -- runs in tests with only the AWS call and the socket faked. Without it the IAM wiring was unreachable: the existing tests replace `_client` after construction, which skips it.

**Not exercised against AWS:** the provisioned path. A real `GetClusterCredentials` round trip, IAM authorization against the `dbuser:<cluster>/<user>` ARN, and one provisioned handshake need a cluster, and the test account has none -- it is Serverless only. The request and response shapes are enforced by the SDK's TypeScript types on top of the tests above, so what remains unverified is environment configuration rather than code. Also unobserved live is the refresh at the one-hour mark; it is covered by test but no real credential has yet expired under this code.

**Known gaps, deliberately out of scope:** `DbGroups` is unsupported, so a user needing group membership at logon cannot get it. `CustomDomainName` is unsupported, and a cluster reached through a custom domain will not match the endpoint parser -- that degrades gracefully, since unrecognized hosts are refused with a message pointing at User & Password. The AWS Profile field is free text; populating it from `~/.aws/config` the way the ODBC driver populates DSNs is the obvious follow-up.

## Dependencies

Adds `@aws-sdk/client-redshift`, `@aws-sdk/client-redshift-serverless`, and `@aws-sdk/credential-providers` (all `^3.734.0`, matching the version already used by the `authentication` extension). Together about 12 MB on disk, costing roughly 27 ms and 12 MB of heap at activation. Loading them lazily would drop that to zero for password-only connections; not done here.
