### PR TITLE
Make the editor action bar checkbox accessible

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -37,6 +37,7 @@ export interface KeyboardModifiers {
 export interface ButtonProps {
 	readonly id?: string;
 	readonly ariaControls?: string;
+	readonly ariaChecked?: boolean;
 	/**
 	 * Marks the button unavailable while leaving it in the tab order.
 	 *
@@ -194,6 +195,7 @@ export const Button = (props: PropsWithChildren<ButtonProps>) => {
 	return (
 		<button
 			ref={buttonRef}
+			aria-checked={props.ariaChecked}
 			aria-controls={props.ariaControls}
 			aria-disabled={props.disabled || props.ariaDisabled ? 'true' : undefined}
 			aria-expanded={props.ariaExpanded}

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -11,26 +11,27 @@
 	align-items: center;
 }
 
+/*
+ * The button also carries Button's positron-button class, which supplies the cursor, the
+ * transparent background and the removal of the user agent border. What is left here is the box
+ * itself.
+ */
 .action-bar-checkbox .checkbox-button {
 	width: 16px;
 	height: 16px;
-	border: none;
+	padding: 0;
 	display: flex;
-	cursor: pointer;
 	border-radius: 3px;
+	align-items: center;
 	justify-content: center;
-	background-color: transparent;
 	color: var(--vscode-positronActionBar-foreground);
 	border: 1px solid var(--vscode-positronActionBar-checkboxBorder);
 }
 
-.action-bar-checkbox .checkbox-button:focus {
-	outline: none !important;
-}
-
+/* positron-button rounds the focus ring to 4px, which does not match this 16px box. */
 .action-bar-checkbox .checkbox-button:focus-visible {
 	outline-offset: 2px;
-	outline: 1px solid var(--vscode-focusBorder);
+	border-radius: 3px;
 }
 
 .action-bar-checkbox .checkbox-button .check-indicator {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
@@ -11,7 +11,6 @@ import { forwardRef, PropsWithChildren, useEffect, useImperativeHandle, useRef, 
 
 // Other dependencies.
 import { generateUuid } from '../../../../base/common/uuid.js';
-import { useRegisterWithActionBar } from '../useRegisterWithActionBar.js';
 
 /**
  * ActionBarCheckboxProps interface.
@@ -48,9 +47,6 @@ export const ActionBarCheckbox = forwardRef<
 	useEffect(() => {
 		setChecked(props.checked ?? false);
 	}, [props.checked]);
-
-	// Participate in roving tabindex.
-	useRegisterWithActionBar([buttonRef]);
 
 	// Click handler.
 	const clickHandler = () => {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
@@ -7,10 +7,12 @@
 import './actionBarCheckbox.css';
 
 // React.
-import { forwardRef, PropsWithChildren, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 // Other dependencies.
 import { generateUuid } from '../../../../base/common/uuid.js';
+import { usePositronActionBarContext } from '../positronActionBarContext.js';
+import { Button } from '../../../../base/browser/ui/positronComponents/button/button.js';
 
 /**
  * ActionBarCheckboxProps interface.
@@ -21,26 +23,30 @@ export interface ActionBarCheckboxProps {
 	readonly label?: string;
 	readonly tooltip?: string | (() => string | undefined);
 	readonly onChanged: (checked: boolean) => void;
+	ref?: React.Ref<HTMLButtonElement>;
 }
 
 /**
  * ActionBarCheckbox component.
+ *
+ * This is a `role='checkbox'` button rather than an `<input type='checkbox'>`, which is also what
+ * core's own checkbox is (see Toggle in `base/browser/ui/toggle/toggle.ts`). Button supplies the
+ * action bar's hover manager for tooltips, activates once per Space or Enter press rather than
+ * twice, and consumes mousedown so pressing the control does not move focus.
+ *
+ * The checkbox flips its own state on click and then reports the new value, which is what it has
+ * always done. The displayed state can therefore disagree with the command until the next render.
+ * Correcting that means reading the command's state instead, which is a separate change.
+ *
  * @param props An ActionBarCheckboxProps that contains the component properties.
- * @param ref A ref to the HTMLButtonElement.
  * @returns The rendered component.
  */
-export const ActionBarCheckbox = forwardRef<
-	HTMLButtonElement,
-	PropsWithChildren<ActionBarCheckboxProps>
->((props, ref) => {
-	// Reference hooks.
-	const buttonRef = useRef<HTMLButtonElement>(undefined!);
-
-	// Imperative handle to ref.
-	useImperativeHandle(ref, () => buttonRef.current);
+export const ActionBarCheckbox = (props: ActionBarCheckboxProps) => {
+	// Context hooks.
+	const context = usePositronActionBarContext();
 
 	// State hooks.
-	const [id] = useState(generateUuid());
+	const [id] = useState(() => generateUuid());
 	const [checked, setChecked] = useState(props.checked ?? false);
 
 	// Effect hook to update the checked state when the prop changes.
@@ -48,20 +54,25 @@ export const ActionBarCheckbox = forwardRef<
 		setChecked(props.checked ?? false);
 	}, [props.checked]);
 
-	// Click handler.
-	const clickHandler = () => {
-		buttonRef.current.setAttribute('aria-checked', !checked ? 'true' : 'false');
-		setChecked(!checked);
-		props.onChanged(!checked);
-	};
-
 	// Render.
 	return (
 		<div className='action-bar-checkbox'>
-			<button ref={buttonRef} aria-checked={checked} className='checkbox-button' id={id} role='checkbox' tabIndex={0} onClick={clickHandler}>
+			<Button
+				ref={props.ref}
+				ariaChecked={checked}
+				className='checkbox-button'
+				hoverManager={context.hoverManager}
+				id={id}
+				role='checkbox'
+				tooltip={props.tooltip}
+				onPressed={() => {
+					setChecked(!checked);
+					props.onChanged(!checked);
+				}}
+			>
 				{checked && <div className='check-indicator codicon codicon-check' />}
-			</button>
+			</Button>
 			<label className='checkbox-label' htmlFor={id}>{props.label}</label>
 		</div>
 	);
-});
+};

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
@@ -34,6 +34,11 @@ export interface ActionBarCheckboxProps {
  * action bar's hover manager for tooltips, activates once per Space or Enter press rather than
  * twice, and consumes mousedown so pressing the control does not move focus.
  *
+ * The name comes from ariaLabel rather than the visible <label>. A <label for> does not name a
+ * <button> under VoiceOver, and without a name of its own the button would be named by its
+ * contents, which is the check codicon: a private use character that reads as nothing when
+ * unchecked and as a stray glyph when checked. The label element keeps its click target.
+ *
  * The checkbox flips its own state on click and then reports the new value, which is what it has
  * always done. The displayed state can therefore disagree with the command until the next render.
  * Correcting that means reading the command's state instead, which is a separate change.
@@ -60,6 +65,7 @@ export const ActionBarCheckbox = (props: ActionBarCheckboxProps) => {
 			<Button
 				ref={props.ref}
 				ariaChecked={checked}
+				ariaLabel={props.ariaLabel ?? props.label}
 				className='checkbox-button'
 				hoverManager={context.hoverManager}
 				id={id}
@@ -70,9 +76,9 @@ export const ActionBarCheckbox = (props: ActionBarCheckboxProps) => {
 					props.onChanged(!checked);
 				}}
 			>
-				{checked && <div className='check-indicator codicon codicon-check' />}
+				{checked && <div aria-hidden='true' className='check-indicator codicon codicon-check' />}
 			</Button>
-			<label className='checkbox-label' htmlFor={id}>{props.label}</label>
+			{props.label && <label className='checkbox-label' htmlFor={id}>{props.label}</label>}
 		</div>
 	);
 };

--- a/src/vs/platform/positronActionBar/test/browser/actionBarCheckbox.vitest.tsx
+++ b/src/vs/platform/positronActionBar/test/browser/actionBarCheckbox.vitest.tsx
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ActionBarCheckbox } from '../../browser/components/actionBarCheckbox.js';
+import { setupRTLRenderer } from '../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../test/vitest/positronTestContainer.js';
+
+// The checkbox reads the action bar's hover manager out of context, so it needs the provider tree
+// that setupRTLRenderer puts around it. The assertions go through the accessibility tree rather
+// than the DOM, because the point of the component is what a screen reader is told about it.
+describe('ActionBarCheckbox', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	const renderCheckbox = (overrides?: Partial<React.ComponentProps<typeof ActionBarCheckbox>>) => {
+		const onChanged = vi.fn();
+		const { rerender } = rtl.render(
+			<ActionBarCheckbox
+				checked={false}
+				label='Word Wrap'
+				onChanged={onChanged}
+				{...overrides}
+			/>
+		);
+		return { onChanged, rerender, checkbox: screen.getByRole('checkbox') };
+	};
+
+	it('is named by its label and reports its checked state', () => {
+		const { checkbox } = renderCheckbox({ checked: true });
+
+		expect(checkbox).toHaveAccessibleName('Word Wrap');
+		expect(checkbox).toBeChecked();
+	});
+
+	it('prefers an explicit ariaLabel over the visible label', () => {
+		const { checkbox } = renderCheckbox({ ariaLabel: 'Wrap long lines' });
+
+		expect(checkbox).toHaveAccessibleName('Wrap long lines');
+		expect(checkbox).not.toBeChecked();
+	});
+
+	it('keeps the same name when it is checked', () => {
+		const { checkbox, rerender } = renderCheckbox();
+
+		expect(checkbox).toHaveAccessibleName('Word Wrap');
+
+		// Without a name of its own the button would be named by its contents, and the only
+		// content is the check codicon. The name would then appear and change as it is toggled.
+		rerender(<ActionBarCheckbox checked={true} label='Word Wrap' onChanged={vi.fn()} />);
+		expect(screen.getByRole('checkbox')).toHaveAccessibleName('Word Wrap');
+	});
+
+	it('flips its own state on click and reports the new value', async () => {
+		const user = userEvent.setup();
+		const { onChanged, checkbox } = renderCheckbox();
+
+		await user.click(checkbox);
+
+		// The checkbox owns its state and moves before the command has done anything. Replacing
+		// this with the command's own state is a separate change.
+		expect(checkbox).toBeChecked();
+		expect(onChanged).toHaveBeenCalledWith(true);
+	});
+
+	it('follows the checked prop when it changes', () => {
+		const { checkbox, rerender } = renderCheckbox();
+
+		expect(checkbox).not.toBeChecked();
+
+		rerender(<ActionBarCheckbox checked={true} label='Word Wrap' onChanged={vi.fn()} />);
+		expect(screen.getByRole('checkbox')).toBeChecked();
+	});
+
+	it('keeps its own flip when the prop it is given has not changed', async () => {
+		const user = userEvent.setup();
+		const { checkbox, rerender } = renderCheckbox({ checked: true });
+
+		await user.click(checkbox);
+		expect(checkbox).not.toBeChecked();
+
+		// The owner still says checked, and the checkbox goes on showing unchecked, because the
+		// sync effect only runs when the prop's value changes. So the control can sit disagreeing
+		// with the command that owns it. Making the checkbox read the command's state instead is
+		// a separate change; this test records the behavior until then.
+		rerender(<ActionBarCheckbox checked={true} label='Word Wrap' onChanged={vi.fn()} />);
+		expect(screen.getByRole('checkbox')).not.toBeChecked();
+	});
+
+	it('activates on Space and Enter', async () => {
+		const user = userEvent.setup();
+		const { onChanged, checkbox } = renderCheckbox();
+
+		checkbox.focus();
+		await user.keyboard('[Space]');
+		await user.keyboard('[Enter]');
+
+		// Two activations, not four: neither key may also fire the click the browser synthesizes
+		// for a native <button>.
+		expect(onChanged).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/vs/workbench/contrib/positronControlGallery/browser/galleries/galleries.ts
+++ b/src/vs/workbench/contrib/positronControlGallery/browser/galleries/galleries.ts
@@ -5,5 +5,6 @@
 
 // Side-effect imports. Each module registers a ControlGalleryEntry into the registry at
 // load time. Adding a new control's harness is a single-line addition here.
+import './positronActionBarControlsGallery.js';
 import './positronListGallery.js';
 import './positronTreeGallery.js';

--- a/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronActionBarControlsGallery.css
+++ b/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronActionBarControlsGallery.css
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.action-bar-controls-harness {
+	gap: 24px;
+	width: 100%;
+	display: flex;
+	padding: 16px 0;
+	flex-direction: column;
+}
+
+.action-bar-controls-harness-section {
+	display: flex;
+	flex-direction: column;
+}
+
+.action-bar-controls-harness-section-title {
+	font-weight: 600;
+	padding: 0 16px 4px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.action-bar-controls-harness-toolbar {
+	gap: 16px;
+	display: flex;
+	flex-wrap: wrap;
+	padding: 8px 16px;
+	align-items: center;
+}
+
+.action-bar-controls-harness-knob {
+	gap: 6px;
+	font-size: 0.9em;
+	align-items: center;
+	display: inline-flex;
+}
+
+.action-bar-controls-harness-knob input {
+	width: 100px;
+	padding: 2px 6px;
+	border-radius: 2px;
+	color: var(--vscode-input-foreground);
+	background-color: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border, transparent);
+}
+
+.action-bar-controls-harness-checkbox input {
+	width: auto;
+	padding: 0;
+	border: none;
+	background-color: transparent;
+}

--- a/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronActionBarControlsGallery.tsx
+++ b/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronActionBarControlsGallery.tsx
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './positronActionBarControlsGallery.css';
+
+// React.
+import { PropsWithChildren, useRef, useState } from 'react';
+
+// Other dependencies.
+import { controlGalleryRegistry } from '../controlGalleryRegistry.js';
+import { PositronActionBar } from '../../../../../platform/positronActionBar/browser/positronActionBar.js';
+import { useRegisterWithActionBar } from '../../../../../platform/positronActionBar/browser/useRegisterWithActionBar.js';
+import { PositronActionBarContextProvider } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
+import { ActionBarCheckbox } from '../../../../../platform/positronActionBar/browser/components/actionBarCheckbox.js';
+
+/**
+ * TextKnob component. A labelled text field.
+ */
+const TextKnob = (props: {
+	readonly label: string;
+	readonly value: string;
+	readonly onChange: (value: string) => void;
+}) => (
+	<label className='action-bar-controls-harness-knob'>
+		<span>{props.label}</span>
+		<input
+			type='text'
+			value={props.value}
+			onChange={e => props.onChange(e.target.value)}
+		/>
+	</label>
+);
+
+/**
+ * CheckKnob component. A labelled checkbox.
+ */
+const CheckKnob = (props: {
+	readonly label: string;
+	readonly value: boolean;
+	readonly onChange: (value: boolean) => void;
+}) => (
+	<label className='action-bar-controls-harness-knob action-bar-controls-harness-checkbox'>
+		<input
+			checked={props.value}
+			type='checkbox'
+			onChange={e => props.onChange(e.target.checked)}
+		/>
+		<span>{props.label}</span>
+	</label>
+);
+
+/**
+ * PreviewBar component. A real action bar wrapped around a single control, so the control gets
+ * the roving tabindex and the hover manager it would have in the workbench. Each control gets its
+ * own bar and its own context, so focus and tab order in one cannot affect the other.
+ */
+const PreviewBar = (props: PropsWithChildren) => (
+	<PositronActionBarContextProvider>
+		{/* eslint-disable-next-line no-restricted-syntax -- the harness shows one control at a fixed width; overflow behavior is PositronDynamicActionBar's concern, not what this fixture is for. */}
+		<PositronActionBar borderBottom borderTop paddingLeft={8} paddingRight={8}>
+			{props.children}
+		</PositronActionBar>
+	</PositronActionBarContextProvider>
+);
+
+/**
+ * Section component. One control: its knobs above, its preview bar below.
+ */
+const Section = (props: PropsWithChildren<{
+	readonly title: string;
+	readonly knobs: React.ReactNode;
+}>) => (
+	<div className='action-bar-controls-harness-section'>
+		<div className='action-bar-controls-harness-section-title'>{props.title}</div>
+		<div className='action-bar-controls-harness-toolbar'>{props.knobs}</div>
+		<div className='action-bar-controls-harness-preview'>{props.children}</div>
+	</div>
+);
+
+/**
+ * CheckboxSection component.
+ */
+const CheckboxSection = () => {
+	// State hooks.
+	const [checked, setChecked] = useState(false);
+	const [label, setLabel] = useState('Check Me!');
+
+	// Reference hooks.
+	const checkboxRef = useRef<HTMLButtonElement>(undefined!);
+
+	// Render.
+	return (
+		<Section
+			knobs={
+				<>
+					<TextKnob label='Label' value={label} onChange={setLabel} />
+					<CheckKnob label='Checked' value={checked} onChange={setChecked} />
+				</>
+			}
+			title='Checkbox'
+		>
+			<PreviewBar>
+				<RegisteredCheckbox
+					ref={checkboxRef}
+					checked={checked}
+					label={label}
+					onChanged={setChecked}
+				/>
+			</PreviewBar>
+		</Section>
+	);
+};
+
+/**
+ * RegisteredCheckbox component. Registers the checkbox with its bar, which in the workbench is
+ * ActionBarActionCheckbox's job.
+ */
+const RegisteredCheckbox = (props: {
+	readonly checked: boolean;
+	readonly label: string;
+	readonly onChanged: (checked: boolean) => void;
+	readonly ref: React.RefObject<HTMLButtonElement>;
+}) => {
+	// Participate in roving tabindex.
+	useRegisterWithActionBar([props.ref]);
+
+	// Render.
+	return (
+		<ActionBarCheckbox
+			ref={props.ref}
+			checked={props.checked}
+			label={props.label}
+			tooltip={props.label}
+			onChanged={props.onChanged}
+		/>
+	);
+};
+
+/**
+ * PositronActionBarControlsHarness component. A configurable fixture for the action bar checkbox.
+ * Nothing in the workbench renders the control today, so this is the only place its markup, CSS
+ * and screen reader output can be checked.
+ */
+const PositronActionBarControlsHarness = () => (
+	<div className='action-bar-controls-harness'>
+		<CheckboxSection />
+	</div>
+);
+
+controlGalleryRegistry.register({
+	id: 'positronActionBarControls',
+	label: 'Action Bar Controls',
+	description: 'The checkbox that extensions can put on the Editor Action Bar.',
+	render: () => <PositronActionBarControlsHarness />
+});


### PR DESCRIPTION
Addresses #7289. That issue covers the toggle too, which lands in a separate PR.

#7237 added a checkbox that extensions can put in the editor action bar. Quarto's **Render on Save** checkbox in `.qmd` files is the only thing using it. Testing against it turned up six problems: no accessible name, no tooltip, a tab stop the whole bar can lose, arrow keys that skip past it, arrow keys that need two presses to leave it, and a focus ring around the 16px box only. This PR fixes all six without changing how the checkbox tracks its state.

A quick primer on the four files involved, since only three of them change here:

- `actionBarCheckbox.tsx` is the React component that draws the control. It knows nothing about commands or menus.
- `actionBarActionCheckbox.tsx` sits above it and maps a menu item contributed by an extension onto the component's props.
- `useRegisterWithActionBar.tsx` is the hook every control in the bar calls to join the bar's keyboard navigation. It belongs to the bar, not to the checkbox.
- `positronActionBar.tsx` is the bar itself, and it owns the arrow keys.

This PR touches the component, the hook and the bar. It leaves the wrapper alone. The last two problems are the bar's, not the checkbox's; Quarto's checkbox is just where they show up.

What was wrong:

- **It had no accessible name.** The visible text lives in a `<label>` next to the button, and a `<label for>` does not name a `<button>` -- a button is named by what is inside it. The only thing inside is the checkmark icon, which is a private use character in an icon font. So VoiceOver announced nothing when unchecked, a stray glyph when checked, and the name changed as you toggled it.
- **It had no tooltip.** The component accepted a `tooltip` prop and never rendered it, so `actionBarActionCheckbox` built a real tooltip with the command's keybinding and it went straight on the floor. This was the only control in the bar without one.
- **It could take the whole action bar out of the Tab order.** The bar makes exactly one of its controls reachable by Tab and moves between the rest with the arrow keys. A control claims that single tab stop by registering with the bar, and whoever registers while the list is still empty gets it.

  The checkbox registered twice for the same button: once from `ActionBarCheckbox` and once from `ActionBarActionCheckbox` above it. React runs the child's registration first, so the button took the tab stop. The second registration then saw a non-empty list, assumed some other control already held the tab stop, and set that same button back to unreachable. Nobody was left holding it and Tab skipped the bar. The fix is to register from the wrapper only, which is what `ActionBarButton` already does.
- **The arrow keys stalled on it.** Moving right off **Render on Save** took two presses. This one is the bar's fault rather than the checkbox's, and it is in `useRegisterWithActionBar`.

  A control leaves the bar by removing itself from the bar's list on the way out, and the code that does that read `ref.current`, which React has already cleared by then. So nothing was removed, and the list kept a button that had left the document. Focusing a node that is no longer in the document does nothing, so one arrow press moved the bar's place in the list onto that dead entry and focus did not move. The next press moved for real.

  The same lines had a second problem: the effect listed an array literal in its dependencies, so it re-ran on every render, which set the control's tabindex back to -1 and moved it to the end of the arrow-key order. A control that re-rendered from its own state while holding the tab stop therefore dropped it. `ActionBarCommandButton` does exactly that whenever a command's precondition flips.

  Both go away by holding the refs in a ref, so the effect runs once per mount, and by capturing the elements when they register so the removal has something real to remove.
- **The arrow keys skipped it.** Arrowing right from **Preview** landed on the button at the far right of the bar, past **Render on Save**. Reaching the checkbox meant arrowing through every other control first, which reads as the control being unreachable.

  Controls join the bar's list as they mount, and the arrow keys walked that list. Quarto activates after the bar is already on screen, so its checkbox mounts last and sits at the end of the list wherever it sits on screen. The arrow keys now sort the list by document position, so they follow what is on screen.

  This one and the one above it have to land together. Before the fix above, the list was emptied and rebuilt in tree order on every render of the bar, which kept the order right by accident. Once a control registers once per mount, it keeps the place it registered in, and the sort is what makes that place correct.
- **A press was lost leaving it.** With focus on the checkbox, moving one control to the right took two presses of the arrow key. The control to its right in a `.qmd` file is a disabled **Save**, and `ActionBarActionButton` renders a command whose precondition is false as a `disabled` button. A disabled button cannot take focus at all, so `focus()` on it does nothing: the first press moved the bar's place onto a control that never took the ring, and only the second press moved focus. The arrow keys now leave those controls out, which is what upstream's action bar does under its `focusOnlyEnabledItems` option.
- **The focus ring went around the box, not the control.** The label sat outside the button as a sibling `<label for>`, so the ring enclosed the 16px box on its own. A 1px ring around a 16px square is easy to miss, and it does not show that the text belongs to the control you are on. The box and the label now both sit inside the button, as they did on the pre-split branch, so the ring goes around the whole thing and clicking either half toggles it without `<label for>` forwarding the click. What a screen reader is told does not change: the inner markup is hidden from assistive technology and the name still comes from `ariaLabel`.

### Why the checkbox now renders through `Button`

The raw `<button>` is gone and the component renders through the shared `Button` instead. This is worth justifying, because it looks like more change than the bug needs. It is actually less:

- The tooltip needs the action bar's hover manager, the shared object that shows and hides tooltips. `Button` already wires it up. Doing it by hand means copying the mouse-enter state, the effect and both mouse handlers into this file -- roughly thirty lines that already exist in one place, and the part most likely to drift.
- Space and Enter each have to activate the checkbox exactly once. A native `<button>` already synthesizes a click for both, so a hand-rolled key handler without `preventDefault` gives two activations per press. `Button` already gets this right.
- Pressing the control should not move focus. `Button` consumes `mousedown` for exactly that reason (#5737). The raw button did not.

`ActionBarButton`, the closest sibling component, already renders through `Button`. This makes the checkbox match it rather than keep its own copy of the same behavior.

`Button` gains an `ariaChecked` prop, mirroring the `ariaSelected` it already has. Two lines, additive, no effect on existing callers.

### What this PR does not do

The checkbox still flips its own state on click before the command has run, exactly as it does on `main`.

There is no `disabled` handling. The component has never had any, and wiring it up greys out Quarto's checkbox in the visual editor, so it ships alongside a fix on the Quarto side.

### Screenshots

(to be added: the checkbox in light and dark themes, the new tooltip on hover, the focus ring around the whole control, and a VoiceOver capture of the announced name and state)

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Make the editor action bar checkbox usable with a screen reader (#7289)
- Fix the editor action bar's arrow keys skipping controls, losing a press, and losing their tab stop (#7289)
- Draw the editor action bar checkbox's focus ring around the label as well as the box (#7289)

### Validation Steps

@:editor-action-bar @:accessibility @:quarto

SETUP: install the Quarto extension and open a `.qmd` file.

1. **It still looks and behaves the same.** Click **Render on Save** in the editor action bar. The checkmark appears, and the control looks as it does in a release build -- same box, same label to its right, same spacing.
2. **It has a tooltip now.** Hover **Render on Save**. A tooltip appears with the command name. Before this change there was none.
3. **Tab reaches the bar.** Run **Developer: Open Control Gallery**, go to **Action Bar Controls**, and press Tab. Focus lands on the checkbox. Before this change that bar had no tab stop at all, so Tab skipped straight past it.
4. **Space and Enter each fire once.** With the checkbox focused, press Space, then Enter. Each press toggles it exactly once, not twice.
5. **The arrow keys follow the bar.** In the `.qmd` file, Tab to the editor action bar and walk right along it with the right arrow. Focus reaches **Render on Save** in the place it appears on screen, between the controls either side of it, and every press moves the ring to the next control it can focus. A greyed out control, such as **Save** with nothing to save, is passed over rather than costing a press. Before this change the checkbox came after every other control, and both the press onto it and the press off it could do nothing at all.
6. **The focus ring goes around the whole control.** With **Render on Save** focused, the ring encloses the box and its label together, not the box on its own.
5. **VoiceOver announces it properly.** Turn VoiceOver on and focus the checkbox. It announces the label, that it is a checkbox, and whether it is checked. Toggle it and confirm the name itself does not change.
6. **The visual editor is unaffected.** Switch the `.qmd` to the visual editor. **Render on Save** is still enabled and clickable, not greyed out.



