### PR TITLE
Remember the last plot save directory for the current session

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -51,7 +51,7 @@ import { DynamicPlotInstance } from './components/dynamicPlotInstance.js';
 import { plotOriginFromCodeLocation } from './plotUtils.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ISettableObservable, observableValue } from '../../../../base/common/observable.js';
-import { joinPath } from '../../../../base/common/resources.js';
+import { dirname, joinPath } from '../../../../base/common/resources.js';
 import { PositronPlotRenderQueue } from '../../../services/languageRuntime/common/positronPlotRenderQueue.js';
 
 /** The maximum number of recent executions to store. */
@@ -217,6 +217,9 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 
 	/** The current plot rendering settings. */
 	private readonly _plotsRenderSettings: ISettableObservable<PlotRenderSettings>;
+
+	/** The last directory used to save a plot during the current session. */
+	private _lastSavePlotDirectory?: URI;
 
 	/** Creates the Positron plots service instance */
 	constructor(
@@ -1387,34 +1390,32 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			this._notificationService.error(localize('positronPlots.noPlotSelected', 'No plot selected.'));
 			return;
 		}
-		this._fileDialogService.defaultFilePath()
-			.then(defaultPath => {
-				const suggestedPath = defaultPath;
-				if (plotClient) {
-					if (plotClient instanceof StaticPlotClient) {
-						// if it's a static plot, save the image to disk
-						const uri = plotClient.uri;
-						this.showSavePlotDialog(uri, plotClient.metadata.suggested_file_name);
-					} else if (plotClient instanceof PlotClientInstance) {
-						// if it's a dynamic plot, present options dialog
-						showSavePlotModalDialog(
-							this._selectedSizingPolicy,
-							plotClient,
-							this.savePlotAs,
-							suggestedPath
-						);
-					} else {
-						// if it's a webview plot, do nothing
-						return;
-					}
-				}
-			})
-			.catch((error) => {
-				throw new Error(`Error saving plot: ${error.message}`);
-			});
+		if (plotClient instanceof StaticPlotClient) {
+			// if it's a static plot, save the image to disk
+			this.showSavePlotDialog(plotClient.uri, plotClient.metadata.suggested_file_name);
+			return;
+		}
+		if (plotClient instanceof PlotClientInstance) {
+			this.getSavePlotDirectory()
+				.then(defaultPath => {
+					// if it's a dynamic plot, present options dialog
+					showSavePlotModalDialog(
+						this._selectedSizingPolicy,
+						plotClient,
+						this.savePlotAs,
+						defaultPath
+					);
+				})
+				.catch((error) => {
+					throw new Error(`Error saving plot: ${error.message}`);
+				});
+			return;
+		}
+		// if it's a webview plot, do nothing
 	}
 
 	private savePlotAs = (options: SavePlotOptions) => {
+		this.rememberSavePlotDirectory(options.path);
 		const htmlFileSystemProvider = this._fileService.getProvider(options.path.scheme) as HTMLFileSystemProvider;
 		// Decode both base64 and URL-encoded image data.
 		const decoded = decodeImageDataUrl(options.uri);
@@ -1439,7 +1440,7 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		// Derive the extension from the MIME type; image/svg+xml maps to .svg.
 		const extension = getImageExtensionForMimeType(parsed.mimeType).substring(1);
 
-		this._fileDialogService.defaultFilePath().then(defaultPath => {
+		this.getSavePlotDirectory().then(defaultPath => {
 			const defaultUri = joinPath(defaultPath, suggestedFileName ?? 'plot');
 			this._fileDialogService.showSaveDialog({
 				title: localize('positron.savePlot', "Save Plot"),
@@ -1457,6 +1458,14 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 				}
 			});
 		});
+	}
+
+	private async getSavePlotDirectory(): Promise<URI> {
+		return this._lastSavePlotDirectory ?? this._fileDialogService.defaultFilePath();
+	}
+
+	private rememberSavePlotDirectory(path: URI): void {
+		this._lastSavePlotDirectory = dirname(path);
 	}
 
 	private async copyPlotToClipboard(plotClient: IPositronPlotClient): Promise<void> {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -1461,7 +1461,11 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	}
 
 	private async getSavePlotDirectory(): Promise<URI> {
-		return this._lastSavePlotDirectory ?? this._fileDialogService.defaultFilePath();
+		if (this._lastSavePlotDirectory && await this._fileService.exists(this._lastSavePlotDirectory)) {
+			return this._lastSavePlotDirectory;
+		}
+
+		return this._fileDialogService.defaultFilePath();
 	}
 
 	private rememberSavePlotDirectory(path: URI): void {

--- a/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
+++ b/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
@@ -27,6 +27,7 @@ import { PlotSizingPolicyFill } from '../../../../services/positronPlots/common/
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
+import { IFileService } from '../../../../../platform/files/common/files.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 
 describe('Positron - Plots Service', () => {
@@ -347,9 +348,11 @@ describe('Positron - Plots Service', () => {
 
 	describe('save plot directory', () => {
 		let fileDialogService: IFileDialogService;
+		let fileService: IFileService;
 
 		beforeEach(() => {
 			fileDialogService = ctx.instantiationService.invokeFunction(accessor => accessor.get(IFileDialogService));
+			fileService = ctx.instantiationService.invokeFunction(accessor => accessor.get(IFileService));
 		});
 
 		it('falls back to the file dialog default path when nothing has been remembered', async () => {
@@ -366,6 +369,7 @@ describe('Positron - Plots Service', () => {
 		it('reuses the last saved plot directory for subsequent saves', async () => {
 			const savedPlotPath = URI.file('/tmp/positron-plots/nested/plot.png');
 			const defaultFilePathSpy = vi.spyOn(fileDialogService, 'defaultFilePath');
+			vi.spyOn(fileService, 'exists').mockResolvedValue(true);
 
 			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
 			(plotsService as any).rememberSavePlotDirectory(savedPlotPath);
@@ -376,21 +380,36 @@ describe('Positron - Plots Service', () => {
 			expect(defaultFilePathSpy).not.toHaveBeenCalled();
 		});
 
+		it('falls back to the default path when the remembered directory no longer exists', async () => {
+			const defaultDirectory = URI.file('/tmp/positron-default-plots');
+			const defaultFilePathSpy = vi.spyOn(fileDialogService, 'defaultFilePath').mockResolvedValue(defaultDirectory);
+			vi.spyOn(fileService, 'exists').mockResolvedValue(false);
+
+			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
+			(plotsService as any).rememberSavePlotDirectory(URI.file('/tmp/positron-plots/stale/plot.png'));
+			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
+			const saveDirectory = await (plotsService as any).getSavePlotDirectory();
+
+			expect(saveDirectory.toString()).toBe(defaultDirectory.toString());
+			expect(defaultFilePathSpy).toHaveBeenCalledOnce();
+		});
+
 		it('uses the remembered directory when opening the static save dialog', async () => {
 			const defaultFilePathSpy = vi.spyOn(fileDialogService, 'defaultFilePath');
 			const showSaveDialogSpy = vi.spyOn(fileDialogService, 'showSaveDialog').mockResolvedValue(undefined);
+			vi.spyOn(fileService, 'exists').mockResolvedValue(true);
 
 			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
 			(plotsService as any).rememberSavePlotDirectory(URI.file('/tmp/positron-plots/reused/plot.svg'));
 			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
 			(plotsService as any).showSavePlotDialog('data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%3E%3C/svg%3E', 'plot');
 
-			await Promise.resolve();
-
-			expect(defaultFilePathSpy).not.toHaveBeenCalled();
-			expect(showSaveDialogSpy).toHaveBeenCalledWith(expect.objectContaining({
-				defaultUri: URI.file('/tmp/positron-plots/reused/plot'),
-			}));
+			await vi.waitFor(() => {
+				expect(defaultFilePathSpy).not.toHaveBeenCalled();
+				expect(showSaveDialogSpy).toHaveBeenCalledWith(expect.objectContaining({
+					defaultUri: URI.file('/tmp/positron-plots/reused/plot'),
+				}));
+			});
 		});
 	});
 

--- a/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
+++ b/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
@@ -26,6 +26,7 @@ import { PlotSizingPolicyAuto } from '../../../../services/positronPlots/common/
 import { PlotSizingPolicyFill } from '../../../../services/positronPlots/common/sizingPolicyFill.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IFileDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 
 describe('Positron - Plots Service', () => {
@@ -341,6 +342,55 @@ describe('Positron - Plots Service', () => {
 				plotsService.setDefaultOpenTarget(target);
 				expect(plotsService.getPreferredEditorGroup()).toBe(expectedGroup);
 			}
+		});
+	});
+
+	describe('save plot directory', () => {
+		let fileDialogService: IFileDialogService;
+
+		beforeEach(() => {
+			fileDialogService = ctx.instantiationService.invokeFunction(accessor => accessor.get(IFileDialogService));
+		});
+
+		it('falls back to the file dialog default path when nothing has been remembered', async () => {
+			const defaultDirectory = URI.file('/tmp/positron-default-plots');
+			const defaultFilePathSpy = vi.spyOn(fileDialogService, 'defaultFilePath').mockResolvedValue(defaultDirectory);
+
+			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
+			const saveDirectory = await (plotsService as any).getSavePlotDirectory();
+
+			expect(saveDirectory.toString()).toBe(defaultDirectory.toString());
+			expect(defaultFilePathSpy).toHaveBeenCalledOnce();
+		});
+
+		it('reuses the last saved plot directory for subsequent saves', async () => {
+			const savedPlotPath = URI.file('/tmp/positron-plots/nested/plot.png');
+			const defaultFilePathSpy = vi.spyOn(fileDialogService, 'defaultFilePath');
+
+			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
+			(plotsService as any).rememberSavePlotDirectory(savedPlotPath);
+			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
+			const saveDirectory = await (plotsService as any).getSavePlotDirectory();
+
+			expect(saveDirectory.toString()).toBe(URI.file('/tmp/positron-plots/nested').toString());
+			expect(defaultFilePathSpy).not.toHaveBeenCalled();
+		});
+
+		it('uses the remembered directory when opening the static save dialog', async () => {
+			const defaultFilePathSpy = vi.spyOn(fileDialogService, 'defaultFilePath');
+			const showSaveDialogSpy = vi.spyOn(fileDialogService, 'showSaveDialog').mockResolvedValue(undefined);
+
+			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
+			(plotsService as any).rememberSavePlotDirectory(URI.file('/tmp/positron-plots/reused/plot.svg'));
+			// eslint-disable-next-line local/code-no-any-casts -- testing private helper behavior directly
+			(plotsService as any).showSavePlotDialog('data:image/svg+xml,%3Csvg%20xmlns%3D%22http://www.w3.org/2000/svg%22%3E%3C/svg%3E', 'plot');
+
+			await Promise.resolve();
+
+			expect(defaultFilePathSpy).not.toHaveBeenCalled();
+			expect(showSaveDialogSpy).toHaveBeenCalledWith(expect.objectContaining({
+				defaultUri: URI.file('/tmp/positron-plots/reused/plot'),
+			}));
 		});
 	});
 


### PR DESCRIPTION
Fixes #2841

Remember the last directory used to save a plot during the current Positron session, so subsequent plot exports reuse that directory instead of falling back to the working directory.

This keeps the scope intentionally narrow and aligned with the issue discussion:
- the remembered directory lives only in the plots service for the current session
- it is reused by both the dynamic plot save modal and the static plot save dialog
- it is not persisted across restarts or workspaces

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:plots

- `npm run test:positron -- src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts`
- Save a plot to a non-default directory, then reopen the save flow for another plot and verify that Positron suggests the previously used directory for the current session.
