### PR TITLE
Variable Pane: fix ellipsis in function name

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
@@ -63,12 +63,11 @@
 	flex-shrink: 0;
 	overflow: hidden;
 	align-items: center;
-	white-space: nowrap;
-	text-overflow: ellipsis;
 }
 
 .variable-item .name-column .name-column-indenter {
 	display: flex;
+	min-width: 0;
 }
 
 .variable-item .name-column .gutter {
@@ -89,8 +88,10 @@
 }
 
 .variable-item .name-value {
-	display: flex;
-	align-items: center;
+	overflow: hidden;
+	line-height: 26px;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .variable-item .details-column {

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
@@ -67,6 +67,7 @@
 
 .variable-item .name-column .name-column-indenter {
 	display: flex;
+	align-items: center;
 	min-width: 0;
 }
 
@@ -89,7 +90,6 @@
 
 .variable-item .name-value {
 	overflow: hidden;
-	line-height: 26px;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### Bug Fixes

- Close https://github.com/posit-dev/positron/issues/15771

While trying to learn a little more about Positron's architecture, & front-end development, I attempted to fix an issue that was recently reported after one of feedback on the Variable Pane. **Diagnosis was performed with Claude**, and as CSS isn't the language I'm best at, I'm not 100% sure if this is the best possible fix. However, I made sure that every line in the PR made sense.

**Bug explanation:** text-overflow applies only to the text. However, the text is not a direct child of .name-column

### Validation Steps

<!--
  Positron team members: e2e feature tags are auto-added based on your changed
  files, so tests run automatically when you open this pull request. Add tags
  here yourself to run more.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
