### PR TITLE
Let extensions control runtime session working directories

### DIFF
--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1614,6 +1614,14 @@ declare module 'positron' {
 		): Thenable<void> | void;
 
 		/**
+		 * Set the current working directory of the session. Changes the
+		 * directory of the live process without restarting it.
+		 *
+		 * @param dir An absolute path on the machine where the runtime runs
+		 */
+		setWorkingDirectory(dir: string): Thenable<void>;
+
+		/**
 		 * Shut down the runtime; returns a Thenable that resolves when the
 		 * runtime shutdown sequence has been successfully started (not
 		 * necessarily when it has completed).
@@ -1694,11 +1702,6 @@ declare module 'positron' {
 
 		/** Reply to a prompt issued by the runtime */
 		replyToPrompt(id: string, reply: string): void;
-
-		/**
-		 * Set the current working directory of the session.
-		 */
-		setWorkingDirectory(dir: string): Thenable<void>;
 
 		/**
 		 * Start the session; returns a Thenable that resolves with information about the runtime.
@@ -3216,12 +3219,24 @@ declare module 'positron' {
 		 * @param sessionName A human-readable name for the new session.
 		 * @param notebookUri If the session is associated with a notebook,
 		 *   the notebook URI.
+		 * @param workingDirectory An absolute path on the machine where the
+		 *   runtime runs. When omitted, notebooks use the notebook working
+		 *   directory setting and consoles use the runtime's default.
 		 *
 		 * Returns a Thenable that resolves with the newly created session.
 		 */
 		export function startLanguageRuntime(runtimeId: string,
 			sessionName: string,
-			notebookUri?: vscode.Uri): Thenable<LanguageRuntimeSession>;
+			notebookUri?: vscode.Uri,
+			workingDirectory?: string): Thenable<LanguageRuntimeSession>;
+
+		/**
+		 * Get the current working directory of a session.
+		 *
+		 * @param sessionId The session ID, or undefined for the foreground session
+		 * @returns The working directory, or undefined if not available
+		 */
+		export function getSessionWorkingDirectory(sessionId?: string): Thenable<string | undefined>;
 
 		/**
 		 * Interrupt a running session.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1614,13 +1614,10 @@ declare module 'positron' {
 		): Thenable<void> | void;
 
 		/**
-		 * Set the current working directory of the session. Changes the
-		 * directory of the live process without restarting it or resetting
-		 * its environment. The returned Thenable signals acceptance of the
-		 * request, not completion of the directory change. Use
-		 * {@link runtime.getSessionWorkingDirectory} to observe the reported directory.
+		 * Changes directory without resetting session state. Resolves on request
+		 * acceptance, not completion; check {@link runtime.getSessionWorkingDirectory}.
 		 *
-		 * @param dir An absolute path on the machine where the runtime runs
+		 * @param dir Absolute path on the runtime's machine.
 		 */
 		setWorkingDirectory(dir: string): Thenable<void>;
 
@@ -3222,20 +3219,15 @@ declare module 'positron' {
 		 * @param sessionName A human-readable name for the new session.
 		 * @param notebookUri If the session is associated with a notebook,
 		 *   the notebook URI.
-		 * @param workingDirectory An absolute path on the machine where the
-		 *   runtime runs. An explicit value overrides the notebook working
-		 *   directory setting. When omitted, notebooks use that setting and
-		 *   consoles use the runtime's default. The path is passed to the
-		 *   runtime without expansion or an existence check.
+		 * @param workingDirectory Absolute path on the runtime's machine, without
+		 *   expansion or an existence check. Overrides the notebook working directory
+		 *   setting; omitted values use that setting or the console runtime's default.
 		 *
-		 * Concurrent requests for the same runtime, session mode, and notebook
-		 * may join a session that is already starting. In that case, this
-		 * request's working directory is ignored. Console starts deferred until
-		 * workspace trust is granted also use the existing auto-start defaults.
-		 * Call `setWorkingDirectory`
-		 * on the returned session and verify its reported directory if needed.
+		 * Concurrent starts for the same runtime, mode, and notebook share the first
+		 * request's directory. Console starts deferred for workspace trust use
+		 * auto-start defaults.
 		 *
-		 * Returns a Thenable that resolves with the started session.
+		 * @returns The started session.
 		 */
 		export function startLanguageRuntime(runtimeId: string,
 			sessionName: string,
@@ -3243,10 +3235,8 @@ declare module 'positron' {
 			workingDirectory?: string): Thenable<LanguageRuntimeSession>;
 
 		/**
-		 * Get the current working directory of a session.
-		 *
-		 * @param sessionId The session ID, or undefined for the foreground session
-		 * @returns The working directory, or undefined if not available
+		 * @param sessionId Omit for the foreground session.
+		 * @returns The runtime-reported directory, or undefined if unavailable.
 		 */
 		export function getSessionWorkingDirectory(sessionId?: string): Thenable<string | undefined>;
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1615,7 +1615,10 @@ declare module 'positron' {
 
 		/**
 		 * Set the current working directory of the session. Changes the
-		 * directory of the live process without restarting it.
+		 * directory of the live process without restarting it or resetting
+		 * its environment. The returned Thenable signals acceptance of the
+		 * request, not completion of the directory change. Use
+		 * {@link runtime.getSessionWorkingDirectory} to observe the reported directory.
 		 *
 		 * @param dir An absolute path on the machine where the runtime runs
 		 */
@@ -3220,10 +3223,19 @@ declare module 'positron' {
 		 * @param notebookUri If the session is associated with a notebook,
 		 *   the notebook URI.
 		 * @param workingDirectory An absolute path on the machine where the
-		 *   runtime runs. When omitted, notebooks use the notebook working
-		 *   directory setting and consoles use the runtime's default.
+		 *   runtime runs. An explicit value overrides the notebook working
+		 *   directory setting. When omitted, notebooks use that setting and
+		 *   consoles use the runtime's default. The path is passed to the
+		 *   runtime without expansion or an existence check.
 		 *
-		 * Returns a Thenable that resolves with the newly created session.
+		 * Concurrent requests for the same runtime, session mode, and notebook
+		 * may join a session that is already starting. In that case, this
+		 * request's working directory is ignored. Console starts deferred until
+		 * workspace trust is granted also use the existing auto-start defaults.
+		 * Call `setWorkingDirectory`
+		 * on the returned session and verify its reported directory if needed.
+		 *
+		 * Returns a Thenable that resolves with the started session.
 		 */
 		export function startLanguageRuntime(runtimeId: string,
 			sessionName: string,

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1986,16 +1986,18 @@ export class MainThreadLanguageRuntime
 	}
 
 	$getSessionWorkingDirectory(sessionId?: string): Promise<string | undefined> {
-		let session;
-		if (sessionId) {
-			session = this.findSession(sessionId);
-		} else {
-			session = this._runtimeSessionService.foregroundSession;
+		const session = sessionId ?
+			this._runtimeSessionService.getSession(sessionId) :
+			this._runtimeSessionService.foregroundSession;
+		return Promise.resolve(session?.dynState.currentWorkingDirectory || undefined);
+	}
+
+	$setSessionWorkingDirectory(sessionId: string, directory: string): Promise<void> {
+		const session = this._runtimeSessionService.getSession(sessionId);
+		if (!session) {
+			return Promise.reject(new Error(`No such session: ${sessionId}`));
 		}
-		if (session) {
-			return Promise.resolve(session.dynState.currentWorkingDirectory || undefined);
-		}
-		return Promise.resolve(undefined);
+		return Promise.resolve(session.setWorkingDirectory(directory));
 	}
 
 	$callMethod(sessionId: string, method: string, args: unknown[]): Thenable<unknown> {
@@ -2026,7 +2028,8 @@ export class MainThreadLanguageRuntime
 		runtimeId: string,
 		sessionName: string,
 		sessionMode: LanguageRuntimeSessionMode,
-		notebookUri: URI | undefined): Promise<string> {
+		notebookUri: URI | undefined,
+		workingDirectory?: string): Promise<string> {
 		// Revive the URI from the serialized form
 		const uri = URI.revive(notebookUri);
 
@@ -2038,7 +2041,8 @@ export class MainThreadLanguageRuntime
 			uri,
 			'Extension-requested runtime selection via Positron API',
 			RuntimeStartMode.Starting,
-			true);
+			true,
+			{ workingDirectory });
 
 		return sessionId;
 	}

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -151,7 +151,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			},
 			startLanguageRuntime(runtimeId: string,
 				sessionName: string,
-				notebookUri?: vscode.Uri): Thenable<positron.LanguageRuntimeSession> {
+				notebookUri?: vscode.Uri,
+				workingDirectory?: string): Thenable<positron.LanguageRuntimeSession> {
 
 				// If a notebook document is provided, we are in notebook mode.
 				const sessionMode = notebookUri ?
@@ -162,7 +163,11 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				return extHostLanguageRuntime.startLanguageRuntime(runtimeId,
 					sessionName,
 					sessionMode,
-					notebookUri);
+					notebookUri,
+					workingDirectory);
+			},
+			getSessionWorkingDirectory(sessionId?: string): Thenable<string | undefined> {
+				return extHostLanguageRuntime.getSessionWorkingDirectory(sessionId);
 			},
 			interruptSession(sessionId: string): Thenable<void> {
 				return extHostLanguageRuntime.interruptSession(sessionId);

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -88,7 +88,7 @@ export interface IRuntimePickerItem {
 export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$registerLanguageRuntime(metadata: ILanguageRuntimeMetadata): void;
 	$selectLanguageRuntime(runtimeId: string): Promise<void>;
-	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined): Promise<string>;
+	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined, workingDirectory?: string): Promise<string>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(runtimeId: string): void;
 	$executeCode(languageId: string, extensionId: string, sessionId: string | undefined, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior, executionId?: string, documentUri?: URI, executionMetadata?: Record<string, unknown>, attributionMetadata?: Record<string, unknown>): Promise<string>;
@@ -109,6 +109,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$executeInSession(sessionId: string, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior, executionMetadata?: Record<string, unknown>): Promise<void>;
 	$getSessionDynState(sessionId: string): Promise<LanguageRuntimeDynState>;
 	$getSessionWorkingDirectory(sessionId?: string): Promise<string | undefined>;
+	$setSessionWorkingDirectory(sessionId: string, directory: string): Promise<void>;
 	$getSessionVariables(sessionId: string, accessKeys?: Array<Array<string>>): Promise<Array<Array<Variable>>>;
 	$querySessionTables(sessionId: string, accessKeys: Array<Array<string>>, queryTypes: Array<string>): Promise<Array<QueryTableSummaryResult>>;
 	$getConsoleHistory(sessionId: string, numberOfEntries?: number): Promise<ISerializedConsoleHistoryEntry[]>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -327,6 +327,13 @@ export class ExtHostRuntimeSessionProxy
 	}
 
 	/**
+	 * Set the current working directory of the session
+	 */
+	setWorkingDirectory(dir: string): Thenable<void> {
+		return this._proxy.$setSessionWorkingDirectory(this.sessionId, dir);
+	}
+
+	/**
 	 * Shut down the runtime; returns a Thenable that resolves when the
 	 * runtime shutdown sequence has been successfully started (not
 	 * necessarily when it has completed).
@@ -1853,6 +1860,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	 * @param sessionName A human-readable name for the new session.
 	 * @param sessionMode The mode in which the session is to be run.
 	 * @param notebookUri The URI of the notebook document, if in notebook mode.
+	 * @param workingDirectory The directory the session should start in, if any.
 	 *
 	 * Returns a Thenable that resolves with the newly created session, or
 	 * rejects with an error.
@@ -1860,11 +1868,12 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	public async startLanguageRuntime(runtimeId: string,
 		sessionName: string,
 		sessionMode: LanguageRuntimeSessionMode,
-		notebookUri: URI | undefined): Promise<positron.LanguageRuntimeSession> {
+		notebookUri: URI | undefined,
+		workingDirectory?: string): Promise<positron.LanguageRuntimeSession> {
 
 		// Start the runtime and get the session ID
 		const sessionId =
-			await this._proxy.$startLanguageRuntime(runtimeId, sessionName, sessionMode, notebookUri);
+			await this._proxy.$startLanguageRuntime(runtimeId, sessionName, sessionMode, notebookUri, workingDirectory);
 
 		// The process of starting a session in Positron should have caused the
 		// runtime to be registered with the extension host, so we should be able

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -326,9 +326,6 @@ export class ExtHostRuntimeSessionProxy
 		return this._proxy.$executeInSession(this.sessionId, code, id, mode, errorBehavior, executionMetadata);
 	}
 
-	/**
-	 * Set the current working directory of the session
-	 */
 	setWorkingDirectory(dir: string): Thenable<void> {
 		return this._proxy.$setSessionWorkingDirectory(this.sessionId, dir);
 	}
@@ -1860,7 +1857,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	 * @param sessionName A human-readable name for the new session.
 	 * @param sessionMode The mode in which the session is to be run.
 	 * @param notebookUri The URI of the notebook document, if in notebook mode.
-	 * @param workingDirectory The directory the session should start in, if any.
+	 * @param workingDirectory Startup directory.
 	 *
 	 * Returns a Thenable that resolves with the newly created session, or
 	 * rejects with an error.

--- a/src/vs/workbench/api/test/browser/positron/mainThreadLanguageRuntime.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadLanguageRuntime.vitest.ts
@@ -7,7 +7,7 @@
 
 import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -22,7 +22,7 @@ import { IQuartoExecutionManager } from '../../../../contrib/positronQuarto/comm
 import { IRuntimeNotebookKernelService } from '../../../../contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IWorkbenchEnvironmentService } from '../../../../services/environment/common/environmentService.js';
-import { ILanguageRuntimeMetadata, ILanguageRuntimeService, RuntimeCodeExecutionMode, RuntimeErrorBehavior } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeErrorBehavior } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IPathService } from '../../../../services/path/common/pathService.js';
 import { IPositronConnectionsService } from '../../../../services/positronConnections/common/interfaces/positronConnectionsService.js';
 import { IPositronConsoleService } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
@@ -33,7 +33,7 @@ import { IPositronIPyWidgetsService } from '../../../../services/positronIPyWidg
 import { IPositronPlotsService } from '../../../../services/positronPlots/common/positronPlots.js';
 import { IPositronVariablesService } from '../../../../services/positronVariables/common/interfaces/positronVariablesService.js';
 import { IPositronWebviewPreloadService } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
-import { IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IRuntimeStartupService } from '../../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { IExtHostContext } from '../../../../services/extensions/common/extHostCustomers.js';
 import { ExtHostLanguageRuntimeShape, RuntimeSessionCapabilities } from '../../../common/positron/extHost.positron.protocol.js';
@@ -175,6 +175,48 @@ describe('ExtHostLanguageRuntimeSessionAdapter - missing-package capabilities', 
 	});
 });
 
+/** Builds a MainThreadLanguageRuntime over stubbed services, overriding only what a test cares about. */
+function createMainThread(disposables: Pick<DisposableStore, 'add'>, overrides: {
+	proxy?: Partial<ExtHostLanguageRuntimeShape>;
+	runtimeSessionService?: Partial<IRuntimeSessionService>;
+	onDidExecuteConsoleCode?: Event<ILanguageRuntimeCodeExecutedEvent>;
+	onDidExecuteNotebookCode?: Event<ILanguageRuntimeCodeExecutedEvent>;
+	onDidExecuteQuartoCode?: Event<ILanguageRuntimeCodeExecutedEvent>;
+} = {}): MainThreadLanguageRuntime {
+	const proxy = stubInterface<ExtHostLanguageRuntimeShape>(overrides.proxy ?? {});
+	const extHostContext = stubInterface<IExtHostContext>({
+		getProxy: (() => proxy) as unknown as IExtHostContext['getProxy'],
+	});
+
+	const mainThread = new MainThreadLanguageRuntime(
+		extHostContext,
+		stubInterface<ILanguageRuntimeService>({ onDidRegisterRuntime: Event.None }),
+		stubInterface<IRuntimeSessionService>({ registerSessionManager: () => Disposable.None, ...overrides.runtimeSessionService }),
+		stubInterface<IRuntimeStartupService>({ registerRuntimeManager: () => Disposable.None }),
+		stubInterface<IRuntimeNotebookKernelService>({ initialize: vi.fn(), onDidExecuteCode: overrides.onDidExecuteNotebookCode ?? Event.None }),
+		stubInterface<IPositronConsoleService>({ initialize: vi.fn(), onDidExecuteCode: overrides.onDidExecuteConsoleCode ?? Event.None }),
+		stubInterface<IPositronDataExplorerService>({ initialize: vi.fn() }),
+		stubInterface<IPositronVariablesService>({ initialize: vi.fn() }),
+		stubInterface<IPositronHelpService>({ initialize: vi.fn() }),
+		stubInterface<IPositronPlotsService>({ initialize: vi.fn() }),
+		stubInterface<IPositronIPyWidgetsService>({ initialize: vi.fn() }),
+		stubInterface<IPositronWebviewPreloadService>({ initialize: vi.fn() }),
+		stubInterface<IPositronConnectionsService>({ initialize: vi.fn() }),
+		stubInterface<INotificationService>({}),
+		stubInterface<IQuartoExecutionManager>({ onDidExecuteCode: overrides.onDidExecuteQuartoCode ?? Event.None }),
+		stubInterface<IPathService>({}),
+		new NullLogService(),
+		stubInterface<ICommandService>({}),
+		stubInterface<INotebookService>({}),
+		stubInterface<IEditorService>({}),
+		stubInterface<IOpenerService>({}),
+		stubInterface<IWorkbenchEnvironmentService>({}),
+		stubInterface<IExecutionHistoryService>({}),
+		stubInterface<IConfigurationService>({}),
+	);
+	return disposables.add(mainThread);
+}
+
 describe('MainThreadLanguageRuntime - code execution event forwarding', () => {
 	const disposables = ensureNoLeakedDisposables();
 
@@ -192,49 +234,17 @@ describe('MainThreadLanguageRuntime - code execution event forwarding', () => {
 		};
 	}
 
-	function createMainThread() {
+	it('forwards code execution events from the console, notebook, and Quarto sources to the extension host', () => {
 		const consoleEmitter = disposables.add(new Emitter<ILanguageRuntimeCodeExecutedEvent>());
 		const notebookEmitter = disposables.add(new Emitter<ILanguageRuntimeCodeExecutedEvent>());
 		const quartoEmitter = disposables.add(new Emitter<ILanguageRuntimeCodeExecutedEvent>());
-
 		const $notifyCodeExecuted = vi.fn();
-		const proxy = stubInterface<ExtHostLanguageRuntimeShape>({ $notifyCodeExecuted });
-		const extHostContext = stubInterface<IExtHostContext>({
-			getProxy: (() => proxy) as unknown as IExtHostContext['getProxy'],
+		createMainThread(disposables, {
+			proxy: { $notifyCodeExecuted },
+			onDidExecuteConsoleCode: consoleEmitter.event,
+			onDidExecuteNotebookCode: notebookEmitter.event,
+			onDidExecuteQuartoCode: quartoEmitter.event,
 		});
-
-		const mainThread = new MainThreadLanguageRuntime(
-			extHostContext,
-			stubInterface<ILanguageRuntimeService>({ onDidRegisterRuntime: Event.None }),
-			stubInterface<IRuntimeSessionService>({ registerSessionManager: () => Disposable.None }),
-			stubInterface<IRuntimeStartupService>({ registerRuntimeManager: () => Disposable.None }),
-			stubInterface<IRuntimeNotebookKernelService>({ initialize: vi.fn(), onDidExecuteCode: notebookEmitter.event }),
-			stubInterface<IPositronConsoleService>({ initialize: vi.fn(), onDidExecuteCode: consoleEmitter.event }),
-			stubInterface<IPositronDataExplorerService>({ initialize: vi.fn() }),
-			stubInterface<IPositronVariablesService>({ initialize: vi.fn() }),
-			stubInterface<IPositronHelpService>({ initialize: vi.fn() }),
-			stubInterface<IPositronPlotsService>({ initialize: vi.fn() }),
-			stubInterface<IPositronIPyWidgetsService>({ initialize: vi.fn() }),
-			stubInterface<IPositronWebviewPreloadService>({ initialize: vi.fn() }),
-			stubInterface<IPositronConnectionsService>({ initialize: vi.fn() }),
-			stubInterface<INotificationService>({}),
-			stubInterface<IQuartoExecutionManager>({ onDidExecuteCode: quartoEmitter.event }),
-			stubInterface<IPathService>({}),
-			new NullLogService(),
-			stubInterface<ICommandService>({}),
-			stubInterface<INotebookService>({}),
-			stubInterface<IEditorService>({}),
-			stubInterface<IOpenerService>({}),
-			stubInterface<IWorkbenchEnvironmentService>({}),
-			stubInterface<IExecutionHistoryService>({}),
-			stubInterface<IConfigurationService>({}),
-		);
-		disposables.add(mainThread);
-		return { consoleEmitter, notebookEmitter, quartoEmitter, $notifyCodeExecuted };
-	}
-
-	it('forwards code execution events from the console, notebook, and Quarto sources to the extension host', () => {
-		const { consoleEmitter, notebookEmitter, quartoEmitter, $notifyCodeExecuted } = createMainThread();
 
 		const consoleEvent = codeExecutedEvent({ executionId: 'console' });
 		const notebookEvent = codeExecutedEvent({ executionId: 'notebook' });
@@ -249,5 +259,61 @@ describe('MainThreadLanguageRuntime - code execution event forwarding', () => {
 			notebookEvent,
 			quartoEvent,
 		]);
+	});
+});
+
+describe('MainThreadLanguageRuntime - session working directory', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function sessionWithWorkingDirectory(currentWorkingDirectory: string): ILanguageRuntimeSession {
+		return stubInterface<ILanguageRuntimeSession>({
+			dynState: { busy: false, sessionName: 'test', inputPrompt: '>', continuationPrompt: '+', currentWorkingDirectory },
+		});
+	}
+
+	it('$startLanguageRuntime passes the requested working directory to the session service', async () => {
+		const startNewRuntimeSession = vi.fn().mockResolvedValue('session-1');
+		const mainThread = createMainThread(disposables, { runtimeSessionService: { startNewRuntimeSession } });
+
+		const sessionId = await mainThread.$startLanguageRuntime(
+			'r-1', 'R', LanguageRuntimeSessionMode.Console, undefined, '/work/dir');
+
+		const [runtimeId, , sessionMode, notebookUri, , , , options] = startNewRuntimeSession.mock.calls[0];
+		expect({ sessionId, runtimeId, sessionMode, notebookUri, options }).toEqual({
+			sessionId: 'session-1',
+			runtimeId: 'r-1',
+			sessionMode: LanguageRuntimeSessionMode.Console,
+			notebookUri: undefined,
+			options: { workingDirectory: '/work/dir' },
+		});
+	});
+
+	it('$getSessionWorkingDirectory reads the named session, falling back to the foreground session', async () => {
+		const mainThread = createMainThread(disposables, {
+			runtimeSessionService: {
+				getSession: (sessionId: string) => sessionId === 'session-1' ? sessionWithWorkingDirectory('/named') : undefined,
+				foregroundSession: sessionWithWorkingDirectory('/foreground'),
+			},
+		});
+
+		expect(await Promise.all([
+			mainThread.$getSessionWorkingDirectory('session-1'),
+			mainThread.$getSessionWorkingDirectory(undefined),
+			mainThread.$getSessionWorkingDirectory('missing'),
+		])).toEqual(['/named', '/foreground', undefined]);
+	});
+
+	it('$setSessionWorkingDirectory forwards to the named session and rejects an unknown one', async () => {
+		const setWorkingDirectory = vi.fn().mockResolvedValue(undefined);
+		const session = stubInterface<ILanguageRuntimeSession>({ setWorkingDirectory });
+		const mainThread = createMainThread(disposables, {
+			runtimeSessionService: { getSession: (sessionId: string) => sessionId === 'session-1' ? session : undefined },
+		});
+
+		await mainThread.$setSessionWorkingDirectory('session-1', '/work/dir');
+		expect(setWorkingDirectory).toHaveBeenCalledWith('/work/dir');
+
+		await expect(mainThread.$setSessionWorkingDirectory('missing', '/work/dir'))
+			.rejects.toThrow('No such session: missing');
 	});
 });

--- a/src/vs/workbench/api/test/browser/positron/mainThreadLanguageRuntime.vitest.ts
+++ b/src/vs/workbench/api/test/browser/positron/mainThreadLanguageRuntime.vitest.ts
@@ -175,7 +175,6 @@ describe('ExtHostLanguageRuntimeSessionAdapter - missing-package capabilities', 
 	});
 });
 
-/** Builds a MainThreadLanguageRuntime over stubbed services, overriding only what a test cares about. */
 function createMainThread(disposables: Pick<DisposableStore, 'add'>, overrides: {
 	proxy?: Partial<ExtHostLanguageRuntimeShape>;
 	runtimeSessionService?: Partial<IRuntimeSessionService>;

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -674,6 +674,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		const sessionMapKey = getSessionMapKey(sessionMode, runtimeId, notebookUri);
 		const startingRuntimePromise = this._startingSessionsBySessionMapKey.get(sessionMapKey);
 		if (startingRuntimePromise && !startingRuntimePromise.isSettled) {
+			if (options?.workingDirectory !== undefined) {
+				this._logService.warn(`Ignoring working directory '${options.workingDirectory}' ` +
+					`for runtime ${runtimeId}: a session is already starting.`);
+			}
 			return startingRuntimePromise.p;
 		}
 
@@ -1837,9 +1841,10 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 
 		const sessionId = this.generateNewSessionId(runtimeMetadata, sessionMode === LanguageRuntimeSessionMode.Notebook);
 
-		// Resolve the working directory configuration
-		let workingDirectory: string | undefined;
-		if (notebookUri) {
+		// Resolve the working directory; an explicit request wins over the
+		// notebook configuration
+		let workingDirectory: string | undefined = options?.workingDirectory;
+		if (workingDirectory === undefined && notebookUri) {
 			workingDirectory = await resolveNotebookWorkingDirectory(
 				notebookUri,
 				this._fileService,

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1841,8 +1841,6 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 
 		const sessionId = this.generateNewSessionId(runtimeMetadata, sessionMode === LanguageRuntimeSessionMode.Notebook);
 
-		// Resolve the working directory; an explicit request wins over the
-		// notebook configuration
 		let workingDirectory: string | undefined = options?.workingDirectory;
 		if (workingDirectory === undefined && notebookUri) {
 			workingDirectory = await resolveNotebookWorkingDirectory(

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -88,6 +88,9 @@ export interface IStartNewRuntimeSessionOptions {
 	 * transposed with `activate` at a call site.
 	 */
 	readonly userSelected?: boolean;
+
+	/** The directory the session should start in; overrides the notebook working directory. */
+	readonly workingDirectory?: string;
 }
 
 export interface IRuntimeSessionMetadata {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -89,7 +89,7 @@ export interface IStartNewRuntimeSessionOptions {
 	 */
 	readonly userSelected?: boolean;
 
-	/** The directory the session should start in; overrides the notebook working directory. */
+	/** Overrides the notebook working directory. */
 	readonly workingDirectory?: string;
 }
 

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
@@ -80,6 +80,7 @@ describe('Positron - RuntimeSessionService', () => {
 		runtime: ILanguageRuntimeMetadata,
 		sessionMode: LanguageRuntimeSessionMode,
 		notebookUri?: URI,
+		workingDirectory?: string,
 	) {
 		return startTestLanguageRuntimeSession(
 			ctx.instantiationService,
@@ -90,6 +91,7 @@ describe('Positron - RuntimeSessionService', () => {
 				startReason,
 				sessionMode,
 				notebookUri,
+				workingDirectory,
 			},
 		);
 	}
@@ -1225,6 +1227,23 @@ describe('Positron - RuntimeSessionService', () => {
 			const session = await startConsole(runtime);
 
 			expect(session.metadata.workingDirectory, 'Working directory should be undefined for console sessions').toBe(undefined);
+		});
+
+		it('an explicitly requested working directory is applied to console sessions', async () => {
+			const workingDir = '/requested/console/directory';
+
+			const session = await startSession(runtime, LanguageRuntimeSessionMode.Console, undefined, workingDir);
+
+			expect(session.metadata.workingDirectory, 'Working directory should be the requested one').toBe(workingDir);
+		});
+
+		it('an explicitly requested working directory takes precedence over the notebook configuration', async () => {
+			configService.setUserConfiguration(NotebookSetting.workingDirectory, '/configured/directory');
+			const workingDir = '/requested/notebook/directory';
+
+			const session = await startSession(runtime, LanguageRuntimeSessionMode.Notebook, notebookUri, workingDir);
+
+			expect(session.metadata.workingDirectory, 'Working directory should be the requested one').toBe(workingDir);
 		});
 
 		it('working directory is default when configuration is empty string', async () => {

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
@@ -11,6 +11,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { IOpener } from '../../../../../platform/opener/common/opener.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 import { IWorkspaceTrustManagementService } from '../../../../../platform/workspace/common/workspaceTrust.js';
 import { formatLanguageRuntimeMetadata, formatLanguageRuntimeSession, ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageStartupBehavior, RuntimeExitReason, RuntimeState } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent, RuntimeClientType, RuntimeStartMode } from '../../common/runtimeSessionService.js';
@@ -1235,6 +1236,20 @@ describe('Positron - RuntimeSessionService', () => {
 			const session = await startSession(runtime, LanguageRuntimeSessionMode.Console, undefined, workingDir);
 
 			expect(session.metadata.workingDirectory, 'Working directory should be the requested one').toBe(workingDir);
+		});
+
+		it('concurrent starts keep the first working directory and warn about the ignored request', async () => {
+			const warn = vi.spyOn(ctx.instantiationService.get(ILogService), 'warn');
+			const [first, second] = await Promise.all([
+				startSession(runtime, LanguageRuntimeSessionMode.Console, undefined, '/first/directory'),
+				startSession(runtime, LanguageRuntimeSessionMode.Console, undefined, '/second/directory')
+			]);
+
+			expect(second.sessionId).toBe(first.sessionId);
+			expect(second.metadata.workingDirectory).toBe('/first/directory');
+			expect(warn).toHaveBeenCalledWith(
+				`Ignoring working directory '/second/directory' for runtime ${runtime.runtimeId}: a session is already starting.`
+			);
 		});
 
 		it('an explicitly requested working directory takes precedence over the notebook configuration', async () => {

--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -112,6 +112,7 @@ export interface IStartTestLanguageRuntimeSessionOptions {
 	sessionMode?: LanguageRuntimeSessionMode;
 	notebookUri?: URI;
 	startReason?: string;
+	workingDirectory?: string;
 }
 
 export async function startTestLanguageRuntimeSession(
@@ -131,7 +132,8 @@ export async function startTestLanguageRuntimeSession(
 		options?.notebookUri,
 		options?.startReason ?? 'Test requested to start a runtime session',
 		RuntimeStartMode.Starting,
-		true
+		true,
+		{ workingDirectory: options?.workingDirectory },
 	);
 
 	// Get the session.


### PR DESCRIPTION
Fixes #15985

Extensions can now start a runtime session in a chosen directory and inspect or change the directory of a session obtained through the Positron API. This supports clients such as Canvas that work in a different folder from the IDE window.

- Add optional `workingDirectory` to `positron.runtime.startLanguageRuntime`; it overrides notebook directory configuration when supplied.
- Expose `positron.runtime.getSessionWorkingDirectory(sessionId?)` and move `setWorkingDirectory` onto `BaseLanguageRuntimeSession`, including forwarding for sessions owned by another extension host.
- Preserve existing defaults and runtime lifecycle behavior. Concurrent starts can share a session, ignoring the later directory request with a warning. `setWorkingDirectory` acknowledges the request before the change necessarily completes; callers can verify the runtime-reported directory. Public API docs describe these semantics.

Paths are absolute on the runtime's machine and are passed through without expansion or existence checks. Console startup deferred for workspace trust and restart of an uninitialized session retain their existing defaults; callers needing a particular directory should recheck it. This PR adds no workspace-switching UI or modal changes.

### Release Notes

#### New Features

- Extensions can specify a runtime session's startup directory and inspect or change its working directory through the Positron API.

#### Bug Fixes

- N/A

### Validation Steps

@:sessions @:console @:notebooks

- Targeted Vitest suites: `mainThreadLanguageRuntime.vitest.ts` and `runtimeSession.vitest.ts`, **186 passed, 5 skipped**. Coverage includes console startup directory, explicit notebook override, concurrent-start coalescing and warning, query behavior, setter forwarding, and unknown sessions.
- Public API smoke tests in a separate development instance with a temporary extension/profile, using real R and Python: explicit startup directory agrees with executed code; `getSession().setWorkingDirectory()` changes the directory and preserves variables; active/foreground session access and foreground directory query work; omitted console directory retains the workspace default; omitted notebook directory follows `notebook.workingDirectory`; unknown-session query returns `undefined`. Test-owned sessions were shut down.
- Client compilation: zero errors. Precommit checks pass for all changed files.
- Broader local checks remain non-green outside this diff: the test TypeScript project reports 383 diagnostics, none in changed files; the E2E watcher lacks `archiver`, `ncp`, `canvas`, and `resemblejs` dependencies.

To verify manually, create two scratch directories, start an R or Python console with the first as the fourth argument to `startLanguageRuntime`, and compare `getSessionWorkingDirectory(session.metadata.sessionId)` with executed `getwd()` / `os.getcwd()`. Set a variable, change to the second directory through a session returned by `getSession`, wait for the reported directory to update, and confirm the variable remains available. Also verify ordinary console startup and notebook directory configuration.

