### PR TITLE
Open Positron modals in a visible window

### DIFF
--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -175,18 +175,20 @@ export class PositronModalReactRenderer extends Disposable {
 		// Call the base class's constructor.
 		super();
 
-		// If the container is not provided, use the active container.
+		// If the container is not provided, resolve one.
 		if (_options.container === undefined) {
-			_options.container = PositronReactServices.services.workbenchLayoutService.activeContainer;
+			_options.container = PositronModalReactRenderer.resolveContainer();
 		}
 
-		// Get the active element.
+		// Get the active element. It is read from the window the modal opens in, so that focus
+		// returns there on dispose rather than to whichever window the active document resolves
+		// to, which can be a hidden IDE window while Canvas mode presents an auxiliary window.
 		let activeElement: Element | null = null;
 		if (_options.parent !== undefined) {
 			activeElement = DOM.getWindow(_options.parent).document.activeElement;
 		}
 		if (activeElement === null) {
-			activeElement = DOM.getActiveWindow().document.activeElement;
+			activeElement = DOM.getDocument(_options.container).activeElement;
 		}
 
 		// If the active element is an HTML element, set it as the last focused element.
@@ -417,6 +419,27 @@ export class PositronModalReactRenderer extends Disposable {
 	//#region Private Methods
 
 	/**
+	 * Resolves the container for a renderer that was given none. This is the active container,
+	 * unless its window is hidden and another workbench window is visible. Canvas mode hides the
+	 * IDE window, and the active document can still resolve to it (nothing has focus, or its focus
+	 * state is stale), which would open the modal where the user cannot see or dismiss it. Among
+	 * visible windows, one that has focus wins.
+	 * @returns The container to render into.
+	 */
+	private static resolveContainer(): HTMLElement {
+		const layoutService = PositronReactServices.services.workbenchLayoutService;
+		const activeContainer = layoutService.activeContainer;
+		if (DOM.getDocument(activeContainer).visibilityState !== 'hidden') {
+			return activeContainer;
+		}
+
+		const visibleWindows = Array.from(DOM.getWindows(), ({ window }) => window)
+			.filter(window => window.document.visibilityState !== 'hidden');
+		const targetWindow = visibleWindows.find(window => window.document.hasFocus()) ?? visibleWindows[0];
+		return targetWindow !== undefined ? layoutService.getContainer(targetWindow) : activeContainer;
+	}
+
+	/**
 	 * Binds event listeners.
 	 */
 	private static bindEventListeners() {
@@ -444,10 +467,11 @@ export class PositronModalReactRenderer extends Disposable {
 			const event = new StandardKeyboardEvent(e);
 
 			// Soft dispatch the keyboard event so we can determine whether it is bound to a
-			// command.
+			// command. The renderer's container is the target: it is in the window the listener
+			// is bound to, where the active container can be another window's.
 			const resolutionResult = PositronReactServices.services.keybindingService.softDispatch(
 				event,
-				PositronReactServices.services.workbenchLayoutService.activeContainer
+				renderer._options.container!
 			);
 
 			// If a keybinding to a command was found, stop it from being processed if it is not one

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -416,7 +416,7 @@ export class PositronModalReactRenderer extends Disposable {
 	//#region Private Methods
 
 	/**
-	 * The active container can belong to the hidden IDE window in Canvas mode.
+	 * The active container can belong to a hidden window when focus is absent or stale.
 	 */
 	private static resolveContainer(): HTMLElement {
 		const layoutService = PositronReactServices.services.workbenchLayoutService;

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -175,14 +175,11 @@ export class PositronModalReactRenderer extends Disposable {
 		// Call the base class's constructor.
 		super();
 
-		// If the container is not provided, resolve one.
 		if (_options.container === undefined) {
 			_options.container = PositronModalReactRenderer.resolveContainer();
 		}
 
-		// Get the active element. It is read from the window the modal opens in, so that focus
-		// returns there on dispose rather than to whichever window the active document resolves
-		// to, which can be a hidden IDE window while Canvas mode presents an auxiliary window.
+		// Restore focus in the modal's window; the active window may be hidden.
 		let activeElement: Element | null = null;
 		if (_options.parent !== undefined) {
 			activeElement = DOM.getWindow(_options.parent).document.activeElement;
@@ -419,12 +416,7 @@ export class PositronModalReactRenderer extends Disposable {
 	//#region Private Methods
 
 	/**
-	 * Resolves the container for a renderer that was given none. This is the active container,
-	 * unless its window is hidden and another workbench window is visible. Canvas mode hides the
-	 * IDE window, and the active document can still resolve to it (nothing has focus, or its focus
-	 * state is stale), which would open the modal where the user cannot see or dismiss it. Among
-	 * visible windows, one that has focus wins.
-	 * @returns The container to render into.
+	 * The active container can belong to the hidden IDE window in Canvas mode.
 	 */
 	private static resolveContainer(): HTMLElement {
 		const layoutService = PositronReactServices.services.workbenchLayoutService;
@@ -466,9 +458,7 @@ export class PositronModalReactRenderer extends Disposable {
 			// Convert the KeyboardEvent into a StandardKeyboardEvent.
 			const event = new StandardKeyboardEvent(e);
 
-			// Soft dispatch the keyboard event so we can determine whether it is bound to a
-			// command. The renderer's container is the target: it is in the window the listener
-			// is bound to, where the active container can be another window's.
+			// Resolve commands in the modal's window, which may differ from the active window.
 			const resolutionResult = PositronReactServices.services.keybindingService.softDispatch(
 				event,
 				renderer._options.container!

--- a/src/vs/base/test/browser/positronModalReactRenderer.vitest.ts
+++ b/src/vs/base/test/browser/positronModalReactRenderer.vitest.ts
@@ -5,12 +5,22 @@
 
 /// <reference types="vitest/globals" />
 
+import * as DOM from '../../browser/dom.js';
+import { CodeWindow, ensureCodeWindow, mainWindow } from '../../browser/window.js';
+import { PositronReactServices } from '../../browser/positronReactServices.js';
 import { PositronModalReactRenderer } from '../../browser/positronModalReactRenderer.js';
-import { ensureNoLeakedDisposables } from '../../../test/vitest/vitestUtils.js';
+import { createTestContainer } from '../../../test/vitest/positronTestContainer.js';
 
 describe('PositronModalReactRenderer', () => {
-	// Disposables.
-	const disposables = ensureNoLeakedDisposables();
+	// The test container, which tracks leaked disposables. Its React services back the renderers
+	// that resolve their own container and the keydown handling.
+	const ctx = createTestContainer().withReactServices().build();
+	const disposables = ctx.disposables;
+
+	beforeEach(() => {
+		// The renderer reads the services singleton; bridge it to the test container's.
+		PositronReactServices.services = ctx.reactServices;
+	});
 
 	/**
 	 * Creates a mock container element for testing.
@@ -503,6 +513,233 @@ describe('PositronModalReactRenderer', () => {
 			renderer.dispose();
 
 			expect(callbackCalled).toBe(false);
+		});
+	});
+
+	/**
+	 * Auxiliary window test suite. An auxiliary window is an iframe here: its document has its own
+	 * window, as a workbench auxiliary window does.
+	 */
+	describe('auxiliary windows', () => {
+		// Window ids for auxiliary windows; the main window is 1.
+		let nextWindowId = 1000;
+
+		/**
+		 * Opens an auxiliary window and registers it with the DOM utilities, as the auxiliary window
+		 * service does.
+		 * @returns The auxiliary window and a container inside it.
+		 */
+		function createAuxiliaryWindow(): { auxWindow: CodeWindow; container: HTMLElement } {
+			const iframe = document.createElement('iframe');
+			iframe.src = 'about:blank';
+			document.body.appendChild(iframe);
+			disposables.add({ dispose: () => iframe.remove() });
+
+			const auxWindow = iframe.contentWindow!;
+			ensureCodeWindow(auxWindow, nextWindowId++);
+			disposables.add(DOM.registerWindow(auxWindow));
+
+			const container = auxWindow.document.createElement('div');
+			auxWindow.document.body.appendChild(container);
+			return { auxWindow, container };
+		}
+
+		/**
+		 * Sets a document's visibility state.
+		 * @param doc The document.
+		 * @param visibilityState The visibility state to report.
+		 */
+		function setVisibilityState(doc: Document, visibilityState: DocumentVisibilityState): void {
+			Object.defineProperty(doc, 'visibilityState', { value: visibilityState, configurable: true });
+			disposables.add({ dispose: () => { delete (doc as { visibilityState?: unknown }).visibilityState; } });
+		}
+
+		/**
+		 * Sets whether a document reports having focus.
+		 * @param doc The document.
+		 * @param hasFocus Whether the document has focus.
+		 */
+		function setHasFocus(doc: Document, hasFocus: boolean): void {
+			Object.defineProperty(doc, 'hasFocus', { value: () => hasFocus, configurable: true });
+			disposables.add({ dispose: () => { delete (doc as { hasFocus?: unknown }).hasFocus; } });
+		}
+
+		/**
+		 * Dispatches a keydown and a mousedown to a window.
+		 * @param targetWindow The window.
+		 */
+		function dispatchInput(targetWindow: CodeWindow): void {
+			targetWindow.dispatchEvent(new targetWindow.KeyboardEvent('keydown', { key: 'Escape' }));
+			targetWindow.dispatchEvent(new targetWindow.MouseEvent('mousedown'));
+		}
+
+		describe('event listeners', () => {
+			it('binds keydown and mousedown to the container\'s window, not the main window', () => {
+				const { auxWindow, container } = createAuxiliaryWindow();
+				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+				const onKeyDown = vi.fn();
+				const onMouseDown = vi.fn();
+				disposables.add(renderer.onKeyDown(onKeyDown));
+				disposables.add(renderer.onMouseDown(onMouseDown));
+				renderer.render(createMockReactElement());
+
+				dispatchInput(mainWindow);
+				expect(onKeyDown).not.toHaveBeenCalled();
+				expect(onMouseDown).not.toHaveBeenCalled();
+
+				dispatchInput(auxWindow);
+				expect(onKeyDown).toHaveBeenCalledTimes(1);
+				expect(onMouseDown).toHaveBeenCalledTimes(1);
+
+				renderer.dispose();
+			});
+
+			it('removes the listeners it added from the container\'s window on dispose', () => {
+				const { auxWindow, container } = createAuxiliaryWindow();
+				const addEventListener = vi.spyOn(auxWindow, 'addEventListener');
+				const removeEventListener = vi.spyOn(auxWindow, 'removeEventListener');
+				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+				renderer.render(createMockReactElement());
+
+				const added = addEventListener.mock.calls.filter(([type]) => ['keydown', 'mousedown', 'resize'].includes(type));
+				expect(added.map(([type]) => type).sort()).toEqual(['keydown', 'mousedown', 'resize']);
+
+				renderer.dispose();
+
+				for (const [type, listener, options] of added) {
+					expect(removeEventListener).toHaveBeenCalledWith(type, listener, options);
+				}
+			});
+
+			it('follows the top renderer across windows', () => {
+				const { auxWindow, container: auxContainer } = createAuxiliaryWindow();
+				const mainRenderer = disposables.add(new PositronModalReactRenderer({ container: createMockContainer() }));
+				const auxRenderer = disposables.add(new PositronModalReactRenderer({ container: auxContainer }));
+				const onMainKeyDown = vi.fn();
+				const onAuxKeyDown = vi.fn();
+				disposables.add(mainRenderer.onKeyDown(onMainKeyDown));
+				disposables.add(auxRenderer.onKeyDown(onAuxKeyDown));
+
+				// With the auxiliary window's renderer on top, only its window is listened to.
+				mainRenderer.render(createMockReactElement());
+				auxRenderer.render(createMockReactElement());
+				dispatchInput(mainWindow);
+				dispatchInput(auxWindow);
+				expect(onMainKeyDown).not.toHaveBeenCalled();
+				expect(onAuxKeyDown).toHaveBeenCalledTimes(1);
+
+				// Once it is disposed, the main window's renderer is on top and its window is listened
+				// to; the auxiliary window no longer is.
+				auxRenderer.dispose();
+				dispatchInput(auxWindow);
+				dispatchInput(mainWindow);
+				expect(onAuxKeyDown).toHaveBeenCalledTimes(1);
+				expect(onMainKeyDown).toHaveBeenCalledTimes(1);
+
+				mainRenderer.dispose();
+			});
+		});
+
+		describe('default container', () => {
+			/**
+			 * Points the layout service at containers per window. The active container is the
+			 * main window's.
+			 * @param containers The container of each window.
+			 */
+			function stubContainers(containers: Map<Window, HTMLElement>): void {
+				const layoutService = PositronReactServices.services.workbenchLayoutService;
+
+				// The test layout service holds activeContainer as a mutable field; the interface
+				// it implements declares it readonly.
+				(layoutService as { activeContainer: HTMLElement }).activeContainer = containers.get(mainWindow)!;
+				vi.spyOn(layoutService, 'getContainer').mockImplementation(
+					(targetWindow: Window) => containers.get(targetWindow)!
+				);
+			}
+
+			it('uses the active container while its window is visible', () => {
+				const mainContainer = createMockContainer();
+				const { auxWindow, container: auxContainer } = createAuxiliaryWindow();
+				stubContainers(new Map([[mainWindow, mainContainer], [auxWindow, auxContainer]]));
+
+				const renderer = disposables.add(new PositronModalReactRenderer());
+				renderer.render(createMockReactElement());
+
+				expect(mainContainer.children.length).toBe(1);
+				expect(auxContainer.children.length).toBe(0);
+
+				renderer.dispose();
+			});
+
+			it('opens in a visible window when the active container\'s window is hidden', () => {
+				const mainContainer = createMockContainer();
+				const { auxWindow, container: auxContainer } = createAuxiliaryWindow();
+				stubContainers(new Map([[mainWindow, mainContainer], [auxWindow, auxContainer]]));
+				setVisibilityState(document, 'hidden');
+
+				const renderer = disposables.add(new PositronModalReactRenderer());
+				renderer.render(createMockReactElement());
+
+				expect(mainContainer.children.length).toBe(0);
+				expect(auxContainer.children.length).toBe(1);
+
+				renderer.dispose();
+			});
+
+			it('prefers the visible window that has focus', () => {
+				const mainContainer = createMockContainer();
+				const first = createAuxiliaryWindow();
+				const second = createAuxiliaryWindow();
+				stubContainers(new Map([
+					[mainWindow, mainContainer],
+					[first.auxWindow, first.container],
+					[second.auxWindow, second.container]
+				]));
+				setVisibilityState(document, 'hidden');
+				setHasFocus(first.auxWindow.document, false);
+				setHasFocus(second.auxWindow.document, true);
+
+				const renderer = disposables.add(new PositronModalReactRenderer());
+				renderer.render(createMockReactElement());
+
+				expect(first.container.children.length).toBe(0);
+				expect(second.container.children.length).toBe(1);
+
+				renderer.dispose();
+			});
+
+			it('keeps the active container when no window is visible', () => {
+				const mainContainer = createMockContainer();
+				const { auxWindow, container: auxContainer } = createAuxiliaryWindow();
+				stubContainers(new Map([[mainWindow, mainContainer], [auxWindow, auxContainer]]));
+				setVisibilityState(document, 'hidden');
+				setVisibilityState(auxWindow.document, 'hidden');
+
+				const renderer = disposables.add(new PositronModalReactRenderer());
+				renderer.render(createMockReactElement());
+
+				expect(mainContainer.children.length).toBe(1);
+				expect(auxContainer.children.length).toBe(0);
+
+				renderer.dispose();
+			});
+		});
+
+		describe('focus restore', () => {
+			it('returns focus to the element focused in the modal\'s window', () => {
+				const { auxWindow, container } = createAuxiliaryWindow();
+				const button = auxWindow.document.createElement('button');
+				auxWindow.document.body.appendChild(button);
+				button.focus();
+				expect(auxWindow.document.activeElement).toBe(button);
+
+				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+				renderer.render(createMockReactElement());
+				expect(auxWindow.document.activeElement).not.toBe(button);
+
+				renderer.dispose();
+				expect(auxWindow.document.activeElement).toBe(button);
+			});
 		});
 	});
 });

--- a/src/vs/base/test/browser/positronModalReactRenderer.vitest.ts
+++ b/src/vs/base/test/browser/positronModalReactRenderer.vitest.ts
@@ -12,13 +12,11 @@ import { PositronModalReactRenderer } from '../../browser/positronModalReactRend
 import { createTestContainer } from '../../../test/vitest/positronTestContainer.js';
 
 describe('PositronModalReactRenderer', () => {
-	// The test container, which tracks leaked disposables. Its React services back the renderers
-	// that resolve their own container and the keydown handling.
 	const ctx = createTestContainer().withReactServices().build();
 	const disposables = ctx.disposables;
 
 	beforeEach(() => {
-		// The renderer reads the services singleton; bridge it to the test container's.
+		// The renderer reads the singleton directly.
 		PositronReactServices.services = ctx.reactServices;
 	});
 
@@ -516,19 +514,10 @@ describe('PositronModalReactRenderer', () => {
 		});
 	});
 
-	/**
-	 * Auxiliary window test suite. An auxiliary window is an iframe here: its document has its own
-	 * window, as a workbench auxiliary window does.
-	 */
 	describe('auxiliary windows', () => {
-		// Window ids for auxiliary windows; the main window is 1.
 		let nextWindowId = 1000;
 
-		/**
-		 * Opens an auxiliary window and registers it with the DOM utilities, as the auxiliary window
-		 * service does.
-		 * @returns The auxiliary window and a container inside it.
-		 */
+		/** An iframe provides a separate document and window. */
 		function createAuxiliaryWindow(): { auxWindow: CodeWindow; container: HTMLElement } {
 			const iframe = document.createElement('iframe');
 			iframe.src = 'about:blank';
@@ -544,36 +533,25 @@ describe('PositronModalReactRenderer', () => {
 			return { auxWindow, container };
 		}
 
-		/**
-		 * Sets a document's visibility state.
-		 * @param doc The document.
-		 * @param visibilityState The visibility state to report.
-		 */
-		function setVisibilityState(doc: Document, visibilityState: DocumentVisibilityState): void {
-			Object.defineProperty(doc, 'visibilityState', { value: visibilityState, configurable: true });
-			disposables.add({ dispose: () => { delete (doc as { visibilityState?: unknown }).visibilityState; } });
-		}
-
-		/**
-		 * Sets whether a document reports having focus.
-		 * @param doc The document.
-		 * @param hasFocus Whether the document has focus.
-		 */
-		function setHasFocus(doc: Document, hasFocus: boolean): void {
-			Object.defineProperty(doc, 'hasFocus', { value: () => hasFocus, configurable: true });
-			disposables.add({ dispose: () => { delete (doc as { hasFocus?: unknown }).hasFocus; } });
-		}
-
-		/**
-		 * Dispatches a keydown and a mousedown to a window.
-		 * @param targetWindow The window.
-		 */
 		function dispatchInput(targetWindow: CodeWindow): void {
 			targetWindow.dispatchEvent(new targetWindow.KeyboardEvent('keydown', { key: 'Escape' }));
 			targetWindow.dispatchEvent(new targetWindow.MouseEvent('mousedown'));
 		}
 
 		describe('event listeners', () => {
+			it('resolves keybindings against the modal container when another window is active', () => {
+				const { auxWindow, container } = createAuxiliaryWindow();
+				const softDispatch = vi.spyOn(ctx.reactServices.keybindingService, 'softDispatch');
+				expect(ctx.reactServices.workbenchLayoutService.activeContainer.ownerDocument).toBe(document);
+				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+				renderer.render(createMockReactElement());
+
+				dispatchInput(auxWindow);
+
+				expect(softDispatch).toHaveBeenCalledExactlyOnceWith(expect.anything(), container);
+				renderer.dispose();
+			});
+
 			it('binds keydown and mousedown to the container\'s window, not the main window', () => {
 				const { auxWindow, container } = createAuxiliaryWindow();
 				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
@@ -620,7 +598,6 @@ describe('PositronModalReactRenderer', () => {
 				disposables.add(mainRenderer.onKeyDown(onMainKeyDown));
 				disposables.add(auxRenderer.onKeyDown(onAuxKeyDown));
 
-				// With the auxiliary window's renderer on top, only its window is listened to.
 				mainRenderer.render(createMockReactElement());
 				auxRenderer.render(createMockReactElement());
 				dispatchInput(mainWindow);
@@ -628,8 +605,6 @@ describe('PositronModalReactRenderer', () => {
 				expect(onMainKeyDown).not.toHaveBeenCalled();
 				expect(onAuxKeyDown).toHaveBeenCalledTimes(1);
 
-				// Once it is disposed, the main window's renderer is on top and its window is listened
-				// to; the auxiliary window no longer is.
 				auxRenderer.dispose();
 				dispatchInput(auxWindow);
 				dispatchInput(mainWindow);
@@ -641,16 +616,10 @@ describe('PositronModalReactRenderer', () => {
 		});
 
 		describe('default container', () => {
-			/**
-			 * Points the layout service at containers per window. The active container is the
-			 * main window's.
-			 * @param containers The container of each window.
-			 */
 			function stubContainers(containers: Map<Window, HTMLElement>): void {
 				const layoutService = PositronReactServices.services.workbenchLayoutService;
 
-				// The test layout service holds activeContainer as a mutable field; the interface
-				// it implements declares it readonly.
+				// The test service's field is writable, despite the readonly interface.
 				(layoutService as { activeContainer: HTMLElement }).activeContainer = containers.get(mainWindow)!;
 				vi.spyOn(layoutService, 'getContainer').mockImplementation(
 					(targetWindow: Window) => containers.get(targetWindow)!
@@ -675,7 +644,8 @@ describe('PositronModalReactRenderer', () => {
 				const mainContainer = createMockContainer();
 				const { auxWindow, container: auxContainer } = createAuxiliaryWindow();
 				stubContainers(new Map([[mainWindow, mainContainer], [auxWindow, auxContainer]]));
-				setVisibilityState(document, 'hidden');
+				vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+				vi.spyOn(auxWindow.document, 'hasFocus').mockReturnValue(false);
 
 				const renderer = disposables.add(new PositronModalReactRenderer());
 				renderer.render(createMockReactElement());
@@ -695,9 +665,9 @@ describe('PositronModalReactRenderer', () => {
 					[first.auxWindow, first.container],
 					[second.auxWindow, second.container]
 				]));
-				setVisibilityState(document, 'hidden');
-				setHasFocus(first.auxWindow.document, false);
-				setHasFocus(second.auxWindow.document, true);
+				vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+				vi.spyOn(first.auxWindow.document, 'hasFocus').mockReturnValue(false);
+				vi.spyOn(second.auxWindow.document, 'hasFocus').mockReturnValue(true);
 
 				const renderer = disposables.add(new PositronModalReactRenderer());
 				renderer.render(createMockReactElement());
@@ -712,8 +682,8 @@ describe('PositronModalReactRenderer', () => {
 				const mainContainer = createMockContainer();
 				const { auxWindow, container: auxContainer } = createAuxiliaryWindow();
 				stubContainers(new Map([[mainWindow, mainContainer], [auxWindow, auxContainer]]));
-				setVisibilityState(document, 'hidden');
-				setVisibilityState(auxWindow.document, 'hidden');
+				vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+				vi.spyOn(auxWindow.document, 'visibilityState', 'get').mockReturnValue('hidden');
 
 				const renderer = disposables.add(new PositronModalReactRenderer());
 				renderer.render(createMockReactElement());
@@ -722,6 +692,17 @@ describe('PositronModalReactRenderer', () => {
 				expect(auxContainer.children.length).toBe(0);
 
 				renderer.dispose();
+			});
+
+			it('honors an explicit container even when its window is hidden', () => {
+				const mainContainer = createMockContainer();
+				const { auxWindow, container: auxContainer } = createAuxiliaryWindow();
+				stubContainers(new Map([[mainWindow, mainContainer], [auxWindow, auxContainer]]));
+				vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+
+				const renderer = disposables.add(new PositronModalReactRenderer({ container: mainContainer }));
+
+				expect(renderer.container).toBe(mainContainer);
 			});
 		});
 


### PR DESCRIPTION
When the main IDE window is hidden, such as when using a standalone window, a modal can still select the hidden window as its container. Choose a visible window in that case, preferring one with focus. Restore focus and resolve keyboard commands in the modal's window.

Explicit containers keep their existing behavior. If every window is hidden, retain the active container. 

Fixes #15994

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Positron dialogs use a visible window when the main IDE window is hidden.

### Validation Steps

- 64 tests pass across the modal renderer, dynamic dialog, and dialog keyboard suites. Coverage includes window selection, explicit containers, focus restoration, keyboard context, and listener cleanup.
- Real-window smoke test: Configure LLM Providers renders with the IDE hidden, Escape removes the overlay, and focus returns to the previous control. The ordinary IDE-window path passes too. The no-focus fallback was exercised by temporarily making both real documents report no focus.
- Canvas Settings -> Configure AI providers also passes through the actual webview and extension command. Escape and the close button remove the dialog, restore webview focus, and leave the menu usable with the IDE still hidden. The fresh profile has no configured models, so the model-picker entry point was not exercised.
- Client compilation and hygiene checks pass. Broader local checks still report four missing E2E dependencies and 383 test-type diagnostics, none in the changed files.

To verify manually, open Configure LLM Providers with Canvas visible and the IDE hidden, dismiss with Escape, and confirm Canvas remains interactive. Repeat in the ordinary IDE window. Run without the renderer debugger attached; the separately investigated React scheduler freeze is outside this change.
