### PR TITLE
fix: search interpreter paths in the interpreter picker

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -432,6 +432,8 @@ export const selectLanguageRuntimeSession = async (
 	const result = await quickInputService.pick(quickPickItems, {
 		title: options?.title || localize('positron.languageRuntime.selectSession.quickPickTitle', 'Select Interpreter Session'),
 		canPickMany: false,
+		// Each row's detail is its interpreter path; make it searchable.
+		matchOnDetail: true,
 		activeItem: sessionItems.find(item => item.picked)
 	});
 
@@ -734,6 +736,8 @@ export const selectNewLanguageRuntime = async (
 	const quickPick = disposables.add(quickInputService.createQuickPick<IQuickPickItem>({ useSeparators: true }));
 	quickPick.title = options?.title || localize('positron.languageRuntime.startSession', 'Start New Interpreter Session');
 	quickPick.canSelectMany = false;
+	// Each row's detail is its interpreter path; make it searchable.
+	quickPick.matchOnDetail = true;
 
 	// Reflect discovery state in the picker: a busy spinner while runtimes are
 	// still being discovered, and an explanatory placeholder for an empty list.

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -6,7 +6,7 @@
 /// <reference types="vitest/globals" />
 
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
-import { IQuickInputService, IQuickPickItem, QuickInputHideReason, QuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { IPickOptions, IQuickInputService, IQuickPickItem, QuickInputHideReason, QuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimePickerContribution, IRuntimePickerItem, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeState, RuntimeStartupPhase } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IRuntimeStartupService } from '../../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
@@ -342,6 +342,24 @@ describe('selectNewLanguageRuntime', () => {
 				(item): item is IQuickPickItem => item.type !== 'separator'
 			);
 			expect(runtimeItems.every(item => item.neverShowWhenFiltered !== true)).toBe(true);
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('searches interpreter paths as well as names', async () => {
+			await registerRuntime(makeRuntime({
+				runtimeId: 'py-opt',
+				runtimeName: 'Python 3.12',
+				runtimePath: '/opt/python/bin/python3',
+			}));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			const item = pick.items.find(
+				(item): item is IQuickPickItem => item.type !== 'separator' && item.id === 'py-opt'
+			);
+			expect(item?.detail).toBe('/opt/python/bin/python3');
+			expect(pick.matchOnDetail).toBe(true);
 			pick.cancel(QuickInputHideReason.Gesture);
 			await promise;
 		});
@@ -694,8 +712,10 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 	const changeNotebookSessionLabel = 'Change Notebook Session...';
 
 	let pickItems: QuickPickItem[] = [];
-	const pickFn = vi.fn(async (items: QuickPickItem[]): Promise<QuickPickItem | undefined> => {
+	let pickOptions: IPickOptions<QuickPickItem> | undefined;
+	const pickFn = vi.fn(async (items: QuickPickItem[], options?: IPickOptions<QuickPickItem>): Promise<QuickPickItem | undefined> => {
 		pickItems = items;
+		pickOptions = options;
 		return undefined; // user cancels by default; specific tests override
 	});
 	const executeCommand = vi.fn(async () => undefined);
@@ -756,6 +776,7 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 	beforeEach(() => {
 		foregroundSession = undefined;
 		pickItems = [];
+		pickOptions = undefined;
 		// Default to the Positron Notebook Editor for tests
 		activeEditor = makeEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, URI.file('/path/to/notebook.ipynb'));
 	});
@@ -768,6 +789,11 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 	function hasChangeNotebookItem(): boolean {
 		return pickItems.some(item => item.label === changeNotebookSessionLabel);
 	}
+
+	it('searches session paths as well as names', async () => {
+		await openInterpreterPicker();
+		expect(pickOptions?.matchOnDetail).toBe(true);
+	});
 
 	it('shows the item when foreground is an .ipynb notebook session', async () => {
 		foregroundSession = makeNotebookSession(URI.file('/path/to/notebook.ipynb'));


### PR DESCRIPTION
Fixes #7899

### Summary
The interpreter pickers only matched each row's label (the interpreter name), so typing a path fragment found nothing. Each row already carried its path as the quick-pick `detail`, so this folds that field into the existing filter.

- Enables `matchOnDetail` on both "Start New Interpreter Session" and "Select Interpreter Session"
- Same matcher as before; only the set of fields it looks at changed
- Two vitest cases, one per picker

Known gap, not fixed here: rows show a tildified path (`~/...`) for interpreters under `$HOME`, so searching an expanded `/Users/...` path still finds nothing. Home-relative fragments like `venvs/proj` do match.

#### Before

https://github.com/user-attachments/assets/68849f0c-89d4-4b10-8d7c-8079d4f25d0d


#### After

https://github.com/user-attachments/assets/56481909-4136-48e3-9239-c5a4a4c58f08


### Release Notes

#### New Features
- Interpreter picker search now matches interpreter paths as well as names (#7899)

#### Bug Fixes
- N/A

### Validation Steps

@:interpreter @:sessions

1. Open the interpreter picker (Start New Interpreter Session).
2. Type a path fragment that is not part of any interpreter name -- e.g. `opt` for an interpreter at `/opt/homebrew/bin/python3.11`.
3. Verify the interpreter at that path is listed. On `main` the list is empty.
