### PR TITLE
assistant: add empty inputSchema for getPlot tool (Closes #15735)

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/tools/positronAssistantTools.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/tools/positronAssistantTools.ts
@@ -54,6 +54,10 @@ const getPlotToolData: IToolData = {
 	displayName: localize('positron.assistant.tool.getPlot.displayName', "View Active Plot"),
 	userDescription: localize('positron.assistant.tool.getPlot.userDescription', "View the current active plot."),
 	modelDescription: 'View the current active plot if one exists. Don\'t invoke this tool if there are no plots in the session.',
+	inputSchema: {
+		type: 'object',
+		properties: {},
+	},
 };
 
 export class GetPlotTool implements IToolImpl {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: e2e feature tags are auto-added based on your changed
  files, so tests run automatically when you open this pull request. Add tags
  here yourself to run more.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
