### PR TITLE
e2e: raise the post-reload workbench budget past the measured CDP stall

### DIFF
--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -12,8 +12,22 @@ import { STARTUP_MESSAGING_SELECTOR, STARTUP_MESSAGING_TIMEOUT } from './utils/s
  */
 const RELOAD_PROBE_TIMEOUT = 2000;
 
-/** Overall budget for the post-reload workbench gate. */
-const RELOAD_READY_TIMEOUT = 30000;
+/**
+ * Overall budget for the post-reload workbench gate.
+ *
+ * Sized against a measured stall rather than a guess. On Windows CI the CDP session for
+ * the swapped-in renderer can go mute in both directions across a reload: console pushes,
+ * screencast frames and probe replies all queue in the channel and flush at one instant,
+ * while the renderer keeps logging to disk and the runner keeps reading Electron's stdout.
+ * Matching the trace's receipt timestamps against `renderer.log` for 150 records put the
+ * in-transit delay at a 24.0s median and 26.2s worst case; the probes then passed 33.8s
+ * and 30.9s into the gate, i.e. both attempts missed a 30s budget by under four seconds.
+ *
+ * 60s is a little over double the observed stall. The budget is only spent when the
+ * channel is actually stalled -- a healthy reload settles on the first probe -- so this
+ * costs nothing on the happy path, and the 120s per-test timeout still bounds it.
+ */
+const RELOAD_READY_TIMEOUT = 60000;
 
 /**
  * Wall-clock margin on top of a probe's own timeout, so a probe that is merely


### PR DESCRIPTION
Raises `RELOAD_READY_TIMEOUT` from 30s to 60s. One constant, test infrastructure only.

Mitigation for #16002, which holds the investigation into why the post-reload CDP session
stalls in the first place.

### Why 30s was not enough

On Windows the CDP session for the reloaded renderer goes mute for ~25s while the app boots
normally, then flushes everything at once. The probes were not failing -- they were parked,
and they passed on the drain, just past the budget:

| attempt | worst probe (2s timeout) | probes settled at | budget |
|---|---|---|---|
| 0 | 19.4s | 33.80s | 30s |
| 1 | 17.0s | 30.86s | 30s |

Both attempts of the same test missed by under four seconds. Matching the trace's receipt
timestamps against `renderer.log` for 150 records put the in-transit delay at a **24.0s
median and 26.2s worst case**, while a boot-marker comparison against the reload that passed
82 seconds earlier on the same machine showed the app was ready on schedule. Full evidence in
#16002.

### Why 60s

A little over double the observed stall. The budget is only spent when the channel is
actually stalled -- a healthy reload settles on the first probe -- so this costs nothing on
the happy path, and the 120s per-test timeout still bounds the worst case.

This makes the test tolerate a channel that is known to go mute rather than pretending it
will not. It is not a cure, and #16002 tracks the cure.

### This does not revert #15942

That fix works and is confirmed live in this build: zero TRACE records reached the console
echo in both attempts, and window volume fell 791 -> 190. It shortens the drain once the
wedge clears; it cannot prevent a wedge that is not caused by what is in the pipe.

### Scope

`reloadWindow` is called by 18 specs; ten carried this fingerprint across 93 fail/flaky
events in the 14-day window quoted in #15942, all Windows-only. Five reload tests are
currently `test.skip` for it -- re-enable candidates if #16002 lands a fix, left skipped here
to keep this to one constant.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Test-infrastructure only; no product code changes. Coverage is the reload-heavy specs,
particularly the Quarto inline-output persistence tests on Windows where this fails most.
Worth a repeat run on the Windows shard rather than a single pass, since the failure is
intermittent (~1 in 4-6 Windows attempts).

@:quarto @:sessions @:positron-notebooks @:layouts @:vscode-settings @:interpreter @:variables @:lsp @:assistant @:win @:web
