### PR TITLE
Resolve Posit AI Pass sign-in and gateway config from providers.json

### DIFF
--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -334,7 +334,12 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 	registerProvidersJsonMigration(context);
 
-	return { getLogs: () => log.formatEntriesForDiagnostics() };
+	return {
+		getLogs: () => log.formatEntriesForDiagnostics(),
+		// Lets `next-edit-suggestions` read a resolved connection value without
+		// duplicating the catalog here.
+		getResolvedProviderBaseUrl: (catalogId: string) => getCachedProvider(catalogId)?.connection.baseUrl,
+	};
 }
 
 async function registerAnthropicProvider(

--- a/extensions/authentication/src/positOAuthProvider.ts
+++ b/extensions/authentication/src/positOAuthProvider.ts
@@ -5,10 +5,17 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
+import { POSIT_AI_DEFAULTS } from 'ai-config';
 import { POSIT_AUTH_PROVIDER_ID, CREDENTIAL_REFRESH_INTERVAL_MS } from './constants';
 import { AuthProvider } from './authProvider';
+import { getCachedProvider } from './providerCatalog';
 import { log } from './log';
 
+/**
+ * Positron's registered OAuth client, distinct from ai-config's `POSIT_AI_DEFAULTS`:
+ * `clientId` is `rstudio-ide` there (RStudio's client), not Positron's.
+ */
+const PRODUCTION_DEFAULTS = { authHost: 'https://login.posit.cloud', scope: 'prism', clientId: 'positron' };
 
 /**
  * Posit AI Pass authentication provider using OAuth 2.0 Device Authorization
@@ -279,15 +286,26 @@ export class PositOAuthProvider extends AuthProvider {
 		return { success: true, accessToken: access_token };
 	}
 
+	/**
+	 * Resolves OAuth parameters from the `positai.positaiLogin` catalog entry
+	 * (providers.json + enforced/env). A field equal to ai-config's built-in
+	 * default means nothing overrode it, so {@link PRODUCTION_DEFAULTS} is used
+	 * instead -- that default's `clientId` is RStudio's, not Positron's.
+	 *
+	 * `host` is bare (providers.json's convention) and gets a scheme added here.
+	 */
 	private getOAuthParameters(): { authHost: string; scope: string; clientId: string } {
-		const config = vscode.workspace.getConfiguration('authentication.positai');
-		const authHost = config.inspect<string>('authHost')?.globalValue
-			?? 'https://login.posit.cloud';
-		const scope = config.inspect<string>('scope')?.globalValue
-			?? 'prism';
-		const clientId = config.inspect<string>('clientId')?.globalValue
-			?? 'positron';
+		const login = getCachedProvider('positai')?.connection.positaiLogin;
+		const builtinDefaults = POSIT_AI_DEFAULTS.positaiLogin;
 
-		return { authHost, scope, clientId };
+		const host = login?.host !== builtinDefaults.host ? login?.host : undefined;
+		const clientId = login?.clientId !== builtinDefaults.clientId ? login?.clientId : undefined;
+		const scope = login?.scope !== builtinDefaults.scope ? login?.scope : undefined;
+
+		return {
+			authHost: host ? `https://${host}` : PRODUCTION_DEFAULTS.authHost,
+			scope: scope ?? PRODUCTION_DEFAULTS.scope,
+			clientId: clientId ?? PRODUCTION_DEFAULTS.clientId,
+		};
 	}
 }

--- a/extensions/authentication/src/test/positOAuthProvider.test.ts
+++ b/extensions/authentication/src/test/positOAuthProvider.test.ts
@@ -4,8 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { PositOAuthProvider } from '../positOAuthProvider';
+import { initProviderCatalog } from '../providerCatalog';
 
 function storeValidTokens(secrets: Map<string, string>, overrides?: {
 	accessToken?: string;
@@ -124,6 +128,71 @@ suite('PositOAuthProvider', () => {
 		test('true when a refresh token is stored', async () => {
 			storeValidTokens(secrets);
 			assert.strictEqual(await provider.isConfigured(), true);
+		});
+	});
+
+	suite('OAuth parameters from providers.json', () => {
+		let dir: string;
+		let configPath: string;
+		let catalogContext: vscode.ExtensionContext;
+
+		setup(() => {
+			dir = fs.mkdtempSync(path.join(os.tmpdir(), 'posit-oauth-'));
+			configPath = path.join(dir, 'providers.json');
+			catalogContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+		});
+
+		teardown(() => {
+			for (const d of catalogContext.subscriptions) {
+				d.dispose();
+			}
+			fs.rmSync(dir, { recursive: true, force: true });
+		});
+
+		async function refreshAndCaptureRequest(): Promise<{ url: string; body: string }> {
+			storeValidTokens(secrets, { expiresAt: Date.now() - 1000 });
+
+			let requestedUrl = '';
+			let requestedBody = '';
+			globalThis.fetch = async (url, init) => {
+				requestedUrl = String(url);
+				requestedBody = String(init?.body ?? '');
+				return new Response(JSON.stringify({
+					access_token: 'new-token',
+					refresh_token: 'new-refresh',
+					expires_in: 3600,
+				}), { status: 200 });
+			};
+
+			await provider.getAccessToken();
+			return { url: requestedUrl, body: requestedBody };
+		}
+
+		test('uses the custom host, clientId, and scope configured in providers.json', async () => {
+			fs.writeFileSync(configPath, JSON.stringify({
+				version: 1,
+				providers: {
+					positai: { positaiLogin: { host: 'login.example.com', clientId: 'my-client', scope: 'custom-scope' } },
+				},
+			}));
+			await initProviderCatalog(catalogContext, { configPath });
+
+			const { url, body } = await refreshAndCaptureRequest();
+
+			assert.strictEqual(url, 'https://login.example.com/oauth/token');
+			assert.ok(body.includes('client_id=my-client'), body);
+			assert.ok(body.includes('scope=custom-scope'), body);
+		});
+
+		test('falls back to Positron production defaults when providers.json has no positai config', async () => {
+			fs.writeFileSync(configPath, JSON.stringify({ version: 1, providers: {} }));
+			await initProviderCatalog(catalogContext, { configPath });
+
+			const { url, body } = await refreshAndCaptureRequest();
+
+			assert.strictEqual(url, 'https://login.posit.cloud/oauth/token');
+			assert.ok(body.includes('client_id=positron'), body);
+			assert.ok(body.includes('scope=prism'), body);
 		});
 	});
 

--- a/extensions/next-edit-suggestions/src/config.ts
+++ b/extensions/next-edit-suggestions/src/config.ts
@@ -21,11 +21,11 @@ function matchesGlobPattern(fileName: string, pattern: string): boolean {
 	return baseName === pattern;
 }
 
+/** Reads the resolved `positai` base URL via `authentication`'s provider catalog. */
 export function getGatewayBaseUrl(): string {
-	return vscode.workspace
-		.getConfiguration('authentication.positai')
-		.inspect<string>('baseUrl')?.globalValue
-		?? DEFAULT_BASE_URL;
+	const exports = vscode.extensions.getExtension('positron.authentication')?.exports as
+		{ getResolvedProviderBaseUrl?(catalogId: string): string | undefined } | undefined;
+	return exports?.getResolvedProviderBaseUrl?.('positai') ?? DEFAULT_BASE_URL;
 }
 
 export function getSelectedCompletionModelId(): string {


### PR DESCRIPTION
Fixes #15881

Posit AI Pass sign-in and the Next Edit Suggestions gateway URL both read a legacy, undeclared `authentication.positai.*` setting (global scope only) with a hardcoded production fallback, so a `positaiLogin`/`baseUrl` override in `~/.posit/ai/providers.json` was silently ignored.

`positOAuthProvider.ts` now resolves `host`/`clientId`/`scope` from the `positai` provider catalog (providers.json + enforced/env, same precedence every other provider gets), falling back to Positron's own production defaults only when the catalog resolves to ai-config's built-in default -- ai-config's default `clientId` ("rstudio-ide") is RStudio's registered OAuth client, not Positron's, so that field can't just be read straight through. `next-edit-suggestions`'s `getGatewayBaseUrl()` now reads the same catalog via a new `getResolvedProviderBaseUrl` export on the `authentication` extension, instead of the orphaned legacy setting.

Not included: the legacy-settings migration gap the issue also flagged (`authentication.positai.*` was never wired into the providers.json migration map). Those settings are undeclared -- no `package.json` contribution ever existed for them, in this extension or the removed `positron-assistant` -- so there's no real population of users with them set to migrate. Fixing it would also mean extending `ai-lib`'s `LEGACY_CONNECTION_ROWS` schema (currently flat `baseUrl`/`customHeaders` only) to handle `positaiLogin`'s nested shape, in a module already marked for deletion once the legacy channels go away.

This fixes things in Positron, but I think this handling should get centralized (outside of positron) as we do the auth refactor.

### Release Notes

#### Bug Fixes

- Fix Posit AI Pass sign-in and code completions ignoring custom Posit AI login/gateway configuration set in `providers.json` (#15881)

### Validation Steps

@:assistant

1. In `~/.posit/ai/providers.json`, customize the positai config block. See the `Posit AI Staging config` 1password entry for config.
2. Sign out of Posit AI Pass if signed in, then sign back in via the provider configuration dialog.
3. Confirm the device-authorization request targets the configured host (check the url in the browser), not `login.posit.cloud`.
4. Set a custom `positai.baseUrl` in the same file and confirm Next Edit Suggestions' gateway requests target it (no override falls back to `https://gateway.posit.ai`) -- if you have log level TRACE, then check the Next Edit Suggestions output channel: search for `[trace] === LLM REQUEST ===`, there should be a log immediately after with `baseURL=<the baseurl you configured>`


Unit test coverage: `extensions/authentication/src/test/positOAuthProvider.test.ts` (`OAuth parameters from providers.json` suite) exercises both the custom-config and unconfigured-fallback paths.
