### PR TITLE
Activate web workbench localization via nlsCoreBaseUrl

### DIFF
--- a/build/gulpfile.positron.nls.ts
+++ b/build/gulpfile.positron.nls.ts
@@ -30,8 +30,10 @@ const NLS_BUNDLE_FILE_HEADER = `/*----------------------------------------------
  * The output layout matches the tail of the URL template the server hands the
  * browser (`${nlsCoreBaseUrl}${commit}/${version}/${locale}/nls.messages.js`,
  * see src/vs/server/node/webClientServer.ts), so publishing is a recursive
- * copy of `out-build-nls/` to `<base>/<commit>/<version>/`. Until
- * `nlsCoreBaseUrl` is set in product.json, nothing consumes these files.
+ * copy of `out-build-nls/` to `<base>/<commit>/<version>/`, where `<base>` is
+ * the `nlsCoreBaseUrl` set in product.json. A locale whose bundle is missing
+ * from that base falls back to the English bundle the workbench always loads
+ * first, so an unpublished build degrades rather than breaks.
  *
  * See build/lib/positronNlsBundles.ts for why this merges English defaults
  * instead of reusing processCoreBundleFormat.

--- a/product.json
+++ b/product.json
@@ -318,6 +318,7 @@
 			"publisherDisplayName": "Posit Software, PBC"
 		}
 	],
+	"nlsCoreBaseUrl": "https://cdn.posit.co/positron/nls/",
 	"extensionsGallery": {
 		"serviceUrl": "https://p3m.dev/openvsx/latest/vscode/gallery",
 		"itemUrl": "https://p3m.dev/openvsx/latest/vscode/item",


### PR DESCRIPTION
Sets `nlsCoreBaseUrl` in `product.json`, which activates localization for the **web (reh-web) workbench**. This is the last of the three steps tracked in posit-dev/positron-builds#1174:

| Step | Where | Status |
|---|---|---|
| Generate per-locale bundles | #15826 | merged |
| Publish them to the CDN | posit-dev/positron-builds#1229 | merged |
| **Activate** (this PR) | `product.json` | here |

## Why the trailing slash matters

`webClientServer.ts` concatenates the path onto this value with no separator:

```ts
WORKBENCH_NLS_URL = `${WORKBENCH_NLS_BASE_URL}${commit}/${version}/${locale}/nls.messages.js`;
```

Dropping the slash would silently produce `.../nls<commit>/...` and 404 every locale.

## Failure mode is degrade, not break

`workbench.html` loads the English bundle unconditionally *before* the localized one:

```html
<!-- always ensure built in english NLS messages -->
<script type="module" src="{{WORKBENCH_NLS_FALLBACK_URL}}"></script>
<!-- attempt to load NLS messages in case non-english -->
<script type="module" src="{{WORKBENCH_NLS_URL}}"></script>
```

So a commit whose bundles were never published, or a locale we don't ship, falls back to English rather than failing. Note this is specifically about a **404**. The crash mode called out in the tracking issue is a *corrupt or index-mismatched* bundle returning 200 - which is the argument for keeping published paths immutable, as the publish step already does (commit-keyed prefix, `immutable` cache-control).

`en*` never requests the CDN at all; the server short-circuits before building the URL.

## No CSP change needed

`webClientServer.ts` already splices the base URL into `script-src`, and a trailing-slash URL is a valid CSP path-prefix source.

## Verification

Built `vscode-reh-web-darwin-arm64` from this branch and loaded it in Chromium with `locale: 'ja'`.

<!--EVIDENCE-->

### Reviewer gotcha

Spot-checking the CDN with a plain `curl -I` shows **no** `access-control-allow-origin` header. That is expected - the response carries `vary: Origin`, so the header only appears when the request has an `Origin`. It matters because the bundle is loaded as `<script type="module">`, and module scripts always fetch in CORS mode:

```console
$ curl -sI -H "Origin: https://example.com" \
    "https://cdn.posit.co/positron/nls/<commit>/1.134.0/ja/nls.messages.js" | grep -i 'access-control\|HTTP'
HTTP/2 200
access-control-allow-origin: *
```

## Scope

Upstream VS Code chrome is translated; Positron's own surfaces (Console, Variables, Plots, Data Explorer, Assistant) stay English, since `vscode-loc` has no translations for Positron keys. That is the agreed outcome, not a regression - the generation task deliberately merges English defaults in for those keys, because a bundle with holes would throw `!!! NLS MISSING !!!` and take down the workbench.

Locales published: `zh-tw`, `zh-cn`, `ja`, `ko`, `de`, `fr`, `es`, `ru`, `it`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
