### PR TITLE
e2e(memory): attribute the agent SDK runtime to agent_host, not extension_child

### DIFF
--- a/test/e2e/utils/memory/label.ts
+++ b/test/e2e/utils/memory/label.ts
@@ -152,7 +152,21 @@ const CMD_RULES: [RegExp, ProcessRole][] = [
 	// `language-server` nor ends in `ServerMain`, so the name rules miss it and it
 	// would otherwise fall through to the extension fallback below.
 	[/language-server|\/lsp\//, 'language_server'],
+	// The agent SDK runtime the agent host downloads and forks
+	// (agentSdkDownloader.ts `_cacheDir`). Its cost belongs with the host that
+	// spawned it, not with extensions.
+	[/\/agent-host\/sdk-cache\//, 'agent_host'],
 ];
+
+/**
+ * Roles whose children are the role's own cost when nothing more specific
+ * claims them. The agent host forks the agent SDK runtime through the same
+ * electron binary under a generic `electron-nodejs (index.js)` name, so neither
+ * the name nor argv says whose it is; the parent does. Without this it was
+ * 161 MB of `extension_child`, and when the host stopped spawning
+ * (2026.10.0-25) the chart showed extensions shrinking for no reason.
+ */
+const ADOPTING_PARENT_ROLES: ReadonlySet<ProcessRole> = new Set(['agent_host']);
 
 /**
  * Names Positron reports that identify a wrapper rather than a process.
@@ -189,8 +203,13 @@ function firstMatch(rules: [RegExp, ProcessRole][], subject: string): ProcessRol
  * An unclassifiable process becomes `unlabeled` rather than being folded into a
  * neighbouring role. That is deliberate. A new unnamed process should show up
  * as a visible gap in the chart, not silently inflate another bucket.
+ *
+ * `parentRole` is the already-resolved role of the process's parent, when the
+ * caller has one. It is consulted only after the name and argv rules, and only
+ * for the few parents listed in ADOPTING_PARENT_ROLES, so it can never
+ * re-bucket a process something more specific identified.
  */
-export function resolveRole(input: { positronName?: string; cmd: string; isRoot: boolean }): { role: ProcessRole; labeled: boolean } {
+export function resolveRole(input: { positronName?: string; cmd: string; isRoot: boolean; parentRole?: ProcessRole }): { role: ProcessRole; labeled: boolean } {
 	const labeled = !!input.positronName;
 
 	if (input.isRoot) {
@@ -205,6 +224,10 @@ export function resolveRole(input: { positronName?: string; cmd: string; isRoot:
 	const byCmd = firstMatch(CMD_RULES, input.cmd);
 	if (byCmd) {
 		return { role: byCmd, labeled };
+	}
+
+	if (input.parentRole !== undefined && ADOPTING_PARENT_ROLES.has(input.parentRole)) {
+		return { role: input.parentRole, labeled };
 	}
 
 	const byGenericName = input.positronName ? firstMatch(GENERIC_NAME_RULES, input.positronName) : undefined;

--- a/test/e2e/utils/memory/label.vitest.ts
+++ b/test/e2e/utils/memory/label.vitest.ts
@@ -260,6 +260,51 @@ describe('names that CI proved wrong', () => {
 	});
 });
 
+describe('the agent host and its SDK runtime', () => {
+	// Build 2026.10.0-9 spawned the agent host eagerly, and it forked the agent
+	// SDK runtime as `electron-nodejs (index.js)`: 161 MB that neither the name
+	// nor the argv attributes to anyone, so it landed in extension_child and read
+	// as extension memory on the dashboard. When the 1.134.0 merge stopped the
+	// agent host from spawning, "extension_child" dropped 161 MB overnight and
+	// nobody could tell why from the chart.
+	const SDK_RUNTIME = '/opt/positron/positron /home/u/.config/Positron/agent-host/sdk-cache/claude/1.2.3/linux-x64/index.js';
+
+	test('a generic child of the agent host is the agent host\'s cost, not an extension\'s', () => {
+		const { role } = resolveRole({
+			positronName: 'electron-nodejs (index.js)',
+			cmd: '/opt/positron/positron /somewhere/else/index.js',
+			isRoot: false,
+			parentRole: 'agent_host'
+		});
+		expect(role).toBe('agent_host');
+	});
+
+	test('the SDK cache path identifies the runtime even with no parent role or name', () => {
+		const { role } = resolveRole({ cmd: SDK_RUNTIME, isRoot: false });
+		expect(role).toBe('agent_host');
+	});
+
+	test('the parent role cannot steal a child argv already identified', () => {
+		const { role } = resolveRole({
+			positronName: 'electron-nodejs (lsp.js)',
+			cmd: QUARTO_LSP,
+			isRoot: false,
+			parentRole: 'agent_host'
+		});
+		expect(role).toBe('language_server');
+	});
+
+	test('only the agent host adopts its children; other parents do not', () => {
+		const { role } = resolveRole({
+			positronName: 'electron-nodejs (helper.js)',
+			cmd: '/build/node /build/some/helper.js',
+			isRoot: false,
+			parentRole: 'extension_host'
+		});
+		expect(role).toBe('extension_child');
+	});
+});
+
 describe('namedShareGateApplies', () => {
 	test('applies on desktop, where --status can name processes', () => {
 		expect(namedShareGateApplies('desktop')).toBe(true);

--- a/test/e2e/utils/memory/snapshot.ts
+++ b/test/e2e/utils/memory/snapshot.ts
@@ -12,7 +12,7 @@ import { MemoryLane } from './lanes.js';
 import { readProcessNames } from './positron-status.js';
 import { readProcessTree } from './process-tree.js';
 import { MemoryScenario } from './scenarios.js';
-import { ActivatedExtension, LabeledProcess, MemorySnapshot, RawProcess } from './types.js';
+import { ActivatedExtension, LabeledProcess, MemorySnapshot, ProcessRole, RawProcess } from './types.js';
 
 function median(values: number[]): number {
 	const sorted = [...values].sort((a, b) => a - b);
@@ -56,16 +56,30 @@ export function joinProcesses(
 		}
 	}
 
+	// Roles resolve top-down so a child can be attributed to its parent (the agent
+	// SDK runtime under agent-host). `raw` comes from buildTree, which is
+	// breadth-first from the root, but resolving in depth order here keeps that
+	// from being a silent dependency on caller ordering.
+	const roleByPid = new Map<number, { role: ProcessRole; labeled: boolean }>();
+	const nameOf = (pid: number): string | undefined => {
+		const reported = names.get(pid);
+		return reported === undefined ? undefined : normalizeProcessName(reported);
+	};
+	for (const proc of [...raw].sort((a, b) => depthOf(a.pid, byPid, rootPid) - depthOf(b.pid, byPid, rootPid))) {
+		roleByPid.set(proc.pid, resolveRole({
+			positronName: nameOf(proc.pid),
+			cmd: proc.cmd,
+			isRoot: proc.pid === rootPid,
+			parentRole: roleByPid.get(proc.ppid)?.role
+		}));
+	}
+
 	return raw.map(proc => {
 		// Normalized once, here, so the name the role rules see is the same one the
 		// report and the payload carry.
 		const reported = names.get(proc.pid);
-		const positronName = reported === undefined ? undefined : normalizeProcessName(reported);
-		const { role, labeled } = resolveRole({
-			positronName,
-			cmd: proc.cmd,
-			isRoot: proc.pid === rootPid
-		});
+		const positronName = nameOf(proc.pid);
+		const { role, labeled } = roleByPid.get(proc.pid)!;
 		// Preferred whenever Positron did not actually identify the process. That
 		// covers two cases: no name at all or a raw command line (Positron could
 		// not name it), and a generic wrapper name like `electron-nodejs (lsp.js)`,

--- a/test/e2e/utils/memory/snapshot.vitest.ts
+++ b/test/e2e/utils/memory/snapshot.vitest.ts
@@ -40,6 +40,23 @@ describe('joinProcesses', () => {
 		expect(kernel.processRole).toBe('kernel_supervisor');
 	});
 
+	test('resolves a child against its parent\'s role, so the agent SDK runtime is agent_host', () => {
+		// The real shape from build 2026.10.0-9: the agent host is a utility
+		// process under main, and it forks the SDK runtime through the same
+		// electron binary, so argv alone says nothing about who owns it.
+		const tree = [
+			proc(100, 1, '/opt/positron/positron', 90),
+			proc(104, 100, '/opt/positron/positron --type=utility --utility-sub-type=node.mojom.NodeService', 86),
+			proc(105, 104, '/opt/positron/positron /home/u/.config/Positron/x/index.js', 161),
+		];
+		const treeNames = new Map([[100, 'positron'], [104, 'agent-host'], [105, 'electron-nodejs (index.js)']]);
+		const joined = joinProcesses(tree, treeNames, 100, [tree]);
+		expect(joined.find(p => p.pid === 104)?.processRole).toBe('agent_host');
+		expect(joined.find(p => p.pid === 105)?.processRole).toBe('agent_host');
+		// Display name is untouched: the role changes, what the report calls it does not.
+		expect(joined.find(p => p.pid === 105)?.processName).toBe('electron-nodejs (index.js)');
+	});
+
 	test('takes the median across samples and keeps min and max', () => {
 		const samples = [
 			[proc(100, 1, '/opt/positron/positron', 80)],


### PR DESCRIPTION
### Summary
When the agent host spawns its helper process (the agent SDK runtime), that helper's memory is now counted under `agent_host` instead of `extension_child`.

The helper shows up as `electron-nodejs (index.js)`, and nothing in its name or command line says it belongs to the agent host, so the labeler put it in the catch-all bucket for things extensions spawn. When build 2026.10.0-25 stopped spawning the agent host, the memory chart showed extensions dropping 161 MB even though no extension changed.

- A generic child of `agent_host` is now counted as `agent_host`
- Also matches the SDK's install path (`agent-host/sdk-cache/`) for lanes where process names aren't available
- Process names, totals, and the set of roles are unchanged; no API or dashboard change

### QA Notes
Unit tests only (`npx vitest run test/e2e/utils/memory/`). Nothing visible changes today: current builds don't start the agent host. It takes effect the next time one does, when the ~247 MB will reappear as one `agent_host` step instead of splitting across two bands.