### PR TITLE
e2e(memory): send the VS Code version and build commit in the memory payload

### DIFF
--- a/test/e2e/infra/test-runner/positron-version.ts
+++ b/test/e2e/infra/test-runner/positron-version.ts
@@ -16,7 +16,23 @@ import { execSync } from 'child_process';
  * levels to the repo root; moving the file would silently change where that lands.
  */
 
-export type PositronVersion = { positronVersion: string; buildNumber: number };
+export type PositronVersion = {
+	positronVersion: string;
+	buildNumber: number;
+	/**
+	 * The VS Code release this build is based on (`1.134.0`), as the build stamped
+	 * it into product.json from package.json. Absent when the build did not stamp
+	 * it. It is what moves when an upstream merge lands, which the Positron version
+	 * does not show.
+	 */
+	vscodeVersion?: string;
+	/**
+	 * The posit-dev/positron commit the build was made from. Not the commit of
+	 * whatever checkout is running the tests: in the nightly memory workflow those
+	 * differ by days, and attributing a change to the wrong one is a dead end.
+	 */
+	commit?: string;
+};
 
 export function getPositronVersion(testCodePath = process.env.BUILD || ''): PositronVersion | null {
 	// Dev mode - use version script directly
@@ -95,7 +111,17 @@ function getVersionFromBuild(testCodePath: string): PositronVersion | null {
 			throw new Error('positronVersion not found in product.json.');
 		}
 
-		return { positronVersion, buildNumber };
+		// Omitted rather than '' so a consumer keying on "did it change" never sees
+		// a change from '' to a real version. The source-tree product.json has
+		// `"version": ""`; only the build pipeline fills it.
+		const version: PositronVersion = { positronVersion, buildNumber };
+		if (typeof productJson.version === 'string' && productJson.version) {
+			version.vscodeVersion = productJson.version;
+		}
+		if (typeof productJson.commit === 'string' && productJson.commit) {
+			version.commit = productJson.commit;
+		}
+		return version;
 	} catch (error) {
 		console.error('Error reading product.json:', error);
 		return null;

--- a/test/e2e/infra/test-runner/positron-version.vitest.ts
+++ b/test/e2e/infra/test-runner/positron-version.vitest.ts
@@ -48,4 +48,36 @@ describe('getPositronVersion from a build directory', () => {
 	test('yields null when the build has no product.json in either place', () => {
 		expect(getPositronVersion(mkdtempSync(join(tmpdir(), 'positron-version-')))).toBeNull();
 	});
+
+	// The build pipeline stamps the VS Code `version` (package.json) and the
+	// positron `commit` into product.json (gulpfile.vscode.ts / gulpfile.reh.ts).
+	// Together they place a build against the upstream merges, which the Positron
+	// version alone cannot: 2026.10.0-9 and 2026.10.0-25 differ by a VS Code
+	// release, and only the second has a `1.134.0`.
+	describe('the upstream version and build commit', () => {
+		const commit = '13e0efe1234567890abcdef1234567890abcdef12';
+
+		const buildWithProduct = (productJson: Record<string, unknown>): string => {
+			const root = mkdtempSync(join(tmpdir(), 'positron-version-'));
+			writeFileSync(join(root, 'product.json'), JSON.stringify(productJson));
+			return root;
+		};
+
+		test('reads them from product.json when the build stamped them', () => {
+			const root = buildWithProduct({
+				positronVersion: '2026.10.0', positronBuildNumber: 25, version: '1.134.0', commit
+			});
+			expect(getPositronVersion(root)).toEqual({
+				positronVersion: '2026.10.0', buildNumber: 25, vscodeVersion: '1.134.0', commit
+			});
+		});
+
+		test('leaves them out rather than reporting an empty string', () => {
+			// The source-tree product.json carries `"version": ""` and no commit; a
+			// build that somehow shipped it must not report a VS Code release of ''.
+			const root = buildWithProduct({ positronVersion: '2026.10.0', positronBuildNumber: 25, version: '' });
+			expect(getPositronVersion(root)).not.toHaveProperty('vscodeVersion');
+			expect(getPositronVersion(root)).not.toHaveProperty('commit');
+		});
+	});
 });

--- a/test/e2e/utils/memory/publish.ts
+++ b/test/e2e/utils/memory/publish.ts
@@ -73,9 +73,25 @@ export type MemoryPayload = {
 	timestamp: string;
 	run_id: string;
 	branch: string;
+	/**
+	 * The checkout the harness ran from (`GITHUB_SHA`), not the build it measured.
+	 * The nightly workflow tests whichever build `latest-prerelease` resolves to,
+	 * which can trail this by days; `build_commit` below is the one to attribute a
+	 * memory change to.
+	 */
 	commit_sha: string;
 	app_version: string;
 	build_number: string;
+	/**
+	 * The VS Code release the build is based on, e.g. `1.134.0`, read from the
+	 * build's product.json. It changes exactly when an upstream merge ships, which
+	 * `app_version` (`2026.10.0` across both sides of a merge) does not show.
+	 * Optional and omitted rather than 'unknown', for the same reason as
+	 * `ark_version`: a marker drawn where it changes must not fire on a placeholder.
+	 */
+	vscode_version?: string;
+	/** The positron commit the build was made from, from the same product.json. */
+	build_commit?: string;
 	platform_os: string;
 	platform_version: string;
 	container_image: string;
@@ -231,6 +247,8 @@ export function buildPayload(snapshots: MemorySnapshot[], meta: RunMeta): Memory
 		commit_sha: meta.commitSha,
 		app_version: positronVersion?.positronVersion ?? 'unknown',
 		build_number: String(positronVersion?.buildNumber ?? 'unknown'),
+		vscode_version: positronVersion?.vscodeVersion,
+		build_commit: positronVersion?.commit,
 		platform_os: platformOs,
 		platform_version: platformVersion,
 		container_image: meta.containerImage,

--- a/test/e2e/utils/memory/publish.vitest.ts
+++ b/test/e2e/utils/memory/publish.vitest.ts
@@ -11,13 +11,27 @@ vi.mock('undici', () => ({
 	request: vi.fn()
 }));
 
+// One mutable object rather than a fresh mock per test: publish.ts reads the
+// fields at call time, so a test can delete one to model a build that did not
+// stamp it. Hoisted because vi.mock factories run before this file's body.
+const { buildUnderTest } = vi.hoisted(() => {
+	const build: { positronVersion: string; buildNumber: number; vscodeVersion?: string; commit?: string } = {
+		positronVersion: '2026.10.0',
+		buildNumber: 25,
+		vscodeVersion: '1.134.0',
+		commit: '13e0efe1234567890abcdef1234567890abcdef12'
+	};
+	return { buildUnderTest: build };
+});
+
 vi.mock('../metrics/metric-base.js', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('../metrics/metric-base.js')>();
 	return {
 		...actual,
 		CONNECT_API_KEY: 'fake-key-for-testing',
 		LOCAL_API_URL: 'http://localhost:3000/metrics',
-		PROD_API_URL: 'https://api.example.com/metrics'
+		PROD_API_URL: 'https://api.example.com/metrics',
+		positronVersion: buildUnderTest
 	};
 });
 
@@ -144,6 +158,41 @@ describe('buildPayload', () => {
 		const payload = buildPayload([snapshot], meta);
 		expect(payload.ark_version).toBeUndefined();
 		expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty('ark_version');
+	});
+
+	// The Positron version cannot place a build against the upstream merges, and
+	// commit_sha is the harness checkout, not the build. These two come from the
+	// build's own product.json, so a step change in the chart can be read against
+	// "which VS Code, which commit" without a trip through the resolve-build log.
+	describe('the build under test', () => {
+		afterEach(() => {
+			buildUnderTest.vscodeVersion = '1.134.0';
+			buildUnderTest.commit = '13e0efe1234567890abcdef1234567890abcdef12';
+		});
+
+		test('sends the VS Code version and the build commit at the payload root', () => {
+			const payload = buildPayload([snapshot], meta);
+			expect(payload.app_version).toBe('2026.10.0');
+			expect(payload.build_number).toBe('25');
+			expect(payload.vscode_version).toBe('1.134.0');
+			expect(payload.build_commit).toBe('13e0efe1234567890abcdef1234567890abcdef12');
+		});
+
+		test('keeps the build commit distinct from the harness commit', () => {
+			const payload = buildPayload([snapshot], meta);
+			expect(payload.commit_sha).toBe('abc123');
+			expect(payload.build_commit).not.toBe(payload.commit_sha);
+		});
+
+		// Same rule as ark_version: absent, never 'unknown', so a dashboard marker
+		// on "the value changed" cannot fire on a placeholder.
+		test('omits both entirely when the build did not stamp them', () => {
+			delete buildUnderTest.vscodeVersion;
+			delete buildUnderTest.commit;
+			const wire = JSON.parse(JSON.stringify(buildPayload([snapshot], meta)));
+			expect(wire).not.toHaveProperty('vscode_version');
+			expect(wire).not.toHaveProperty('build_commit');
+		});
 	});
 
 	test('still pins payload_version at 1 with both fields present', () => {


### PR DESCRIPTION
### Summary
The nightly memory payload now says which VS Code release a build is based on and which positron commit it was built from, so a step change on the memory charts can be lined up with an upstream merge without digging through workflow logs.

- Reads `version` and `commit` from the build's `product.json`, where the build already stamps them
- Sends them as optional `vscode_version` and `build_commit` at the payload root
- Omitted (not `'unknown'`) when the build did not stamp them, same rule as `ark_version`
- `commit_sha` is unchanged and documented as the harness checkout, not the build
- `payload_version` stays 1; no report or dashboard changes

### QA Notes
No visible effect until the dashboard reads the new fields (follow-up in e2e-test-insights). Either repo can ship first. Covered by `positron-version.vitest.ts` and `publish.vitest.ts`.