### PR TITLE
Make extension-contributed action bar checkboxes accessible

### DIFF
--- a/.github/workflows/test-tag-paths-map.json
+++ b/.github/workflows/test-tag-paths-map.json
@@ -132,6 +132,7 @@
   "src/vs/editor/contrib/positronHelp/": ["@:help"],
   "src/vs/editor/contrib/positronInputBoundaries/": ["@:console"],
   "src/vs/editor/contrib/positronStatementRange/": [],
+  "src/vs/platform/actions/": [],
   "src/vs/platform/extensionManagement/": [],
   "src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts": ["@:extensions"],
   "src/vs/platform/extensionManagement/node/positronBootstrapExtensionsInitializer.ts": ["@:extensions"],

--- a/extensions/theme-defaults/themes/2026-light.json
+++ b/extensions/theme-defaults/themes/2026-light.json
@@ -5,7 +5,7 @@
 	"type": "light",
 	"colors": {
 		"foreground": "#202020",
-		"disabledForeground": "#BBBBBB",
+		"disabledForeground": "#CCCCCC",
 		"errorForeground": "#ad0707",
 		"descriptionForeground": "#606060",
 		"icon.foreground": "#606060",

--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -37,6 +37,7 @@ export interface KeyboardModifiers {
 export interface ButtonProps {
 	readonly id?: string;
 	readonly ariaControls?: string;
+	readonly ariaChecked?: boolean;
 	/**
 	 * Marks the button unavailable while leaving it in the tab order.
 	 *
@@ -194,6 +195,7 @@ export const Button = (props: PropsWithChildren<ButtonProps>) => {
 	return (
 		<button
 			ref={buttonRef}
+			aria-checked={props.ariaChecked}
 			aria-controls={props.ariaControls}
 			aria-disabled={props.disabled || props.ariaDisabled ? 'true' : undefined}
 			aria-expanded={props.ariaExpanded}

--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -101,6 +101,25 @@ export const isPositronActionBarCheckboxOptions = (positronActionBarOptions?: Po
 
 export const isPositronActionBarToggleOptions = (positronActionBarOptions?: PositronActionBarOptions): positronActionBarOptions is PositronActionBarToggleOptions =>
 	positronActionBarOptions !== undefined && positronActionBarOptions.controlType === 'toggle';
+
+/**
+ * Gets the context key expression that carries the state of a Positron action bar control. A
+ * checkbox calls it `checked` and a toggle calls it `toggled`; both mean the same thing to the
+ * menu, which is why the menu service and MenuItemAction both read it through here.
+ * @param positronActionBarOptions The Positron action bar options.
+ * @returns The expression, or undefined if the control has no state of its own.
+ */
+export const positronActionBarStateExpression = (positronActionBarOptions?: PositronActionBarOptions): ContextKeyExpression | undefined => {
+	if (isPositronActionBarCheckboxOptions(positronActionBarOptions)) {
+		return positronActionBarOptions.checked;
+	}
+
+	if (isPositronActionBarToggleOptions(positronActionBarOptions)) {
+		return positronActionBarOptions.toggled;
+	}
+
+	return undefined;
+};
 // --- End Positron ---
 
 export interface ICommandAction {

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -18,7 +18,7 @@ import { IKeybindingRule, KeybindingsRegistry } from '../../keybinding/common/ke
 // --- Start Positron ---
 import { CommandCenter } from '../../commandCenter/common/commandCenter.js';
 // eslint-disable-next-line no-duplicate-imports
-import { PositronActionBarOptions } from '../../action/common/action.js';
+import { PositronActionBarOptions, positronActionBarStateExpression } from '../../action/common/action.js';
 // --- End Positron ---
 
 
@@ -668,6 +668,17 @@ export class MenuItemAction implements IAction {
 				this.label = typeof toggled.title === 'string' ? toggled.title : toggled.title.value;
 			}
 		}
+
+		// --- Start Positron ---
+		// A Positron action bar checkbox or toggle keeps its state in its own expression instead of
+		// in `toggled`, so evaluate that here as well. The menu service tracks the keys it names
+		// alongside the toggled ones, so the menu raises a change event and the action bar rebuilds
+		// with a fresh value.
+		const positronStateExpression = positronActionBarStateExpression(item.positronActionBarOptions);
+		if (positronStateExpression) {
+			this.checked = contextKeyService.contextMatchesRules(positronStateExpression);
+		}
+		// --- End Positron ---
 
 		if (!icon) {
 			icon = ThemeIcon.isThemeIcon(item.icon) ? item.icon : undefined;

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -15,6 +15,10 @@ import { IStorageService, StorageScope, StorageTarget } from '../../storage/comm
 import { removeFastWithoutKeepingOrder } from '../../../base/common/arrays.js';
 import { localize } from '../../../nls.js';
 import { IKeybindingService } from '../../keybinding/common/keybinding.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { positronActionBarStateExpression } from '../../action/common/action.js';
+// --- End Positron ---
 
 export class MenuService extends Disposable implements IMenuService {
 
@@ -241,6 +245,16 @@ class MenuInfoSnapshot {
 				const toggledExpression: ContextKeyExpression = (item.command.toggled as { condition: ContextKeyExpression }).condition || item.command.toggled;
 				MenuInfoSnapshot._fillInKbExprKeys(toggledExpression, this._toggledContextKeys);
 			}
+
+			// --- Start Positron ---
+			// A Positron action bar checkbox or toggle keeps its state in its own expression, so
+			// keep its keys too. Without this the menu never raises an event when the control's
+			// state changes and the control goes on drawing a stale value.
+			MenuInfoSnapshot._fillInKbExprKeys(
+				positronActionBarStateExpression(item.command.positronActionBarOptions),
+				this._toggledContextKeys
+			);
+			// --- End Positron ---
 
 		} else if (this._collectContextKeysForSubmenus) {
 			// recursively collect context keys from submenus so that this

--- a/src/vs/platform/actions/test/browser/menuService.vitest.ts
+++ b/src/vs/platform/actions/test/browser/menuService.vitest.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../base/common/event.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { MenuId, MenuItemAction, MenuRegistry } from '../../common/actions.js';
+import { MenuService } from '../../common/menuService.js';
+import { NullCommandService } from '../../../commands/test/common/nullCommandService.js';
+import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
+import { ContextKeyService } from '../../../contextkey/browser/contextKeyService.js';
+import { ContextKeyExpr, RawContextKey } from '../../../contextkey/common/contextkey.js';
+import { MockKeybindingService } from '../../../keybinding/test/common/mockKeybindingService.js';
+import { InMemoryStorageService } from '../../../storage/common/storage.js';
+import { ensureNoLeakedDisposables } from '../../../../test/vitest/vitestUtils.js';
+
+// A Positron action bar checkbox or toggle keeps its state in its own context key expression,
+// which the menu has to treat the same way it treats `toggled`: evaluate it onto the action, and
+// raise a change event when a key it names changes. A real ContextKeyService is essential here --
+// MockContextKeyService's onDidChangeContext is Event.None, so nothing would ever fire.
+describe('MenuService, Positron action bar control state', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	const setup = (positronActionBarOptions: MenuItemAction['positronActionBarOptions']) => {
+		const contextKeyService = disposables.add(new ContextKeyService(new TestConfigurationService()));
+		const menuService = disposables.add(new MenuService(
+			NullCommandService,
+			new MockKeybindingService(),
+			disposables.add(new InMemoryStorageService())
+		));
+
+		const menuId = new MenuId(`test/${generateUuid()}`);
+		disposables.add(MenuRegistry.appendMenuItem(menuId, {
+			command: {
+				id: 'test.renderOnSave',
+				title: 'Render on Save',
+				positronActionBarOptions
+			}
+		}));
+
+		const menu = disposables.add(menuService.createMenu(menuId, contextKeyService, { eventDebounceDelay: 0 }));
+		return {
+			contextKeyService,
+			menu,
+			// The action is rebuilt on every call, which is what the action bar does when the menu
+			// tells it something changed.
+			action: () => menu.getActions()[0][1][0] as MenuItemAction
+		};
+	};
+
+	it('updates checkbox state and emits a toggle change when its checked expression changes', async () => {
+		const { contextKeyService, menu, action } = setup({
+			controlType: 'checkbox',
+			checked: ContextKeyExpr.has('test.renderOnSave')
+		});
+		const renderOnSave = new RawContextKey<boolean>('test.renderOnSave', false).bindTo(contextKeyService);
+
+		expect(action().checked).toBe(false);
+
+		const changed = Event.toPromise(menu.onDidChange);
+		renderOnSave.set(true);
+
+		expect((await changed).isToggleChange).toBe(true);
+		expect(action().checked).toBe(true);
+	});
+
+	it('updates toggle state and emits a toggle change when its toggled expression changes', async () => {
+		const { contextKeyService, menu, action } = setup({
+			controlType: 'toggle',
+			toggled: ContextKeyExpr.equals('test.editMode', 'visual'),
+			leftTitle: 'Source',
+			rightTitle: 'Visual'
+		});
+		const editMode = new RawContextKey<string>('test.editMode', 'source').bindTo(contextKeyService);
+
+		expect(action().checked).toBe(false);
+
+		const changed = Event.toPromise(menu.onDidChange);
+		editMode.set('visual');
+
+		expect((await changed).isToggleChange).toBe(true);
+		expect(action().checked).toBe(true);
+	});
+
+	it('leaves checked undefined for a control with no state of its own', () => {
+		const { action } = setup({ controlType: 'button', displayTitle: true });
+
+		expect(action().checked).toBeUndefined();
+	});
+});

--- a/src/vs/platform/positronActionBar/browser/components/actionBarActionCheckbox.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarActionCheckbox.tsx
@@ -47,16 +47,13 @@ export const ActionBarActionCheckbox = (props: ActionBarActionCheckboxProps) => 
 	// Participate in roving tabindex.
 	useRegisterWithActionBar([buttonRef]);
 
-	// Get the menu item action.
+	// Get the menu item action and the Positron action bar checkbox options. The options and their
+	// checked expression must both be defined; otherwise the checkbox has no state to show and
+	// nothing is rendered.
 	const menuItemAction = toMenuItemAction(props.action);
-	if (!menuItemAction) {
-		return null;
-	}
+	const positronActionBarCheckboxOptions = toPositronActionBarCheckboxOptions(menuItemAction?.positronActionBarOptions);
 
-	// Get the Positron action bar checkbox options. This must be defined and the checked context ket expression must be defined.
-	// If this is not the case, render nothing. This prevents the checkbox from being rendered when its initial state isn't know.
-	const positronActionBarCheckboxOptions = toPositronActionBarCheckboxOptions(menuItemAction.positronActionBarOptions);
-	if (!positronActionBarCheckboxOptions || !positronActionBarCheckboxOptions.checked) {
+	if (!menuItemAction || !positronActionBarCheckboxOptions?.checked) {
 		return null;
 	}
 
@@ -65,8 +62,9 @@ export const ActionBarActionCheckbox = (props: ActionBarActionCheckboxProps) => 
 		<ActionBarCheckbox
 			ref={buttonRef}
 			ariaLabel={props.action.label ?? props.action.tooltip}
-			checked={services.contextKeyService.contextMatchesRules(positronActionBarCheckboxOptions.checked)}
-			label={menuItemAction?.label ?? props.action.label}
+			checked={menuItemAction.checked ?? false}
+			disabled={!props.action.enabled}
+			label={menuItemAction.label ?? props.action.label}
 			tooltip={actionTooltip(
 				services.contextKeyService,
 				services.keybindingService,

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.css
@@ -34,12 +34,13 @@
 	align-items: center;
 }
 
-/*
- * Dim the visible checkbox face when the native button is disabled. Applying opacity to the face
- * keeps the button itself responsible for disabled semantics and pointer behavior.
- */
+/* Use the action bar's theme-aware disabled color for the complete visible checkbox face. */
 .action-bar-checkbox .checkbox-button.disabled .checkbox-face {
-	opacity: 0.5;
+	color: var(--vscode-positronActionBar-disabledForeground);
+}
+
+.action-bar-checkbox .checkbox-button.disabled .checkbox-indicator {
+	border-color: var(--vscode-positronActionBar-disabledForeground);
 }
 
 .action-bar-checkbox .checkbox-indicator {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.css
@@ -1,42 +1,61 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 .action-bar-checkbox {
-	gap: 6px;
 	display: flex;
 	margin: 0 4px;
 	font-size: 12px;
 	align-items: center;
 }
 
+/* The label sits inside the button so that clicking it toggles the checkbox. */
 .action-bar-checkbox .checkbox-button {
-	width: 16px;
-	height: 16px;
-	border: none;
+	padding: 0;
 	display: flex;
 	cursor: pointer;
-	border-radius: 3px;
-	justify-content: center;
+	align-items: center;
 	background-color: transparent;
 	color: var(--vscode-positronActionBar-foreground);
-	border: 1px solid var(--vscode-positronActionBar-checkboxBorder);
 }
 
-.action-bar-checkbox .checkbox-button:focus {
-	outline: none !important;
+.action-bar-checkbox .checkbox-button.disabled {
+	cursor: default;
 }
 
 .action-bar-checkbox .checkbox-button:focus-visible {
 	outline-offset: 2px;
-	outline: 1px solid var(--vscode-focusBorder);
 }
 
-.action-bar-checkbox .checkbox-button .check-indicator {
+.action-bar-checkbox .checkbox-face {
+	gap: 6px;
+	display: flex;
+	align-items: center;
+}
+
+/*
+ * Dim the visible checkbox face when the native button is disabled. Applying opacity to the face
+ * keeps the button itself responsible for disabled semantics and pointer behavior.
+ */
+.action-bar-checkbox .checkbox-button.disabled .checkbox-face {
+	opacity: 0.5;
+}
+
+.action-bar-checkbox .checkbox-indicator {
+	width: 16px;
+	height: 16px;
+	display: flex;
+	flex: 0 0 auto;
+	border-radius: 3px;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid var(--vscode-positronActionBar-checkboxBorder);
+}
+
+.action-bar-checkbox .checkbox-indicator .codicon {
 	font-weight: bold;
 	font-size: 12px !important;
-	color: var(--vscode-positronActionBar-foreground);
 }
 
 .action-bar-checkbox .checkbox-label {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarCheckbox.tsx
@@ -7,65 +7,67 @@
 import './actionBarCheckbox.css';
 
 // React.
-import { forwardRef, PropsWithChildren, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React from 'react';
 
 // Other dependencies.
-import { generateUuid } from '../../../../base/common/uuid.js';
-import { useRegisterWithActionBar } from '../useRegisterWithActionBar.js';
+import { Button } from '../../../../base/browser/ui/positronComponents/button/button.js';
+import { usePositronActionBarContext } from '../positronActionBarContext.js';
 
 /**
  * ActionBarCheckboxProps interface.
  */
 export interface ActionBarCheckboxProps {
 	readonly ariaLabel?: string;
-	readonly checked?: boolean;
+	readonly checked: boolean;
+	/** Marks the checkbox unavailable using native button disabled semantics. */
+	readonly disabled?: boolean;
 	readonly label?: string;
 	readonly tooltip?: string | (() => string | undefined);
 	readonly onChanged: (checked: boolean) => void;
+	ref?: React.Ref<HTMLButtonElement>;
 }
 
 /**
  * ActionBarCheckbox component.
+ *
+ * This is a `role='checkbox'` button rather than an `<input type='checkbox'>`, which is also what
+ * core's own checkbox is (see Toggle in `base/browser/ui/toggle/toggle.ts`). It follows the native
+ * button disabled behavior used by Positron's other action-bar controls. Button also supplies the
+ * action bar's hover manager for tooltips. Activating on Enter as well as Space follows from
+ * Button, and matches what core's Toggle accepts.
+ *
+ * Wrapping core's Toggle instead would mean owning an imperative DOM widget's lifecycle from
+ * React, and it brings its own codicon and title handling to fight with the action bar's.
+ *
  * @param props An ActionBarCheckboxProps that contains the component properties.
- * @param ref A ref to the HTMLButtonElement.
  * @returns The rendered component.
  */
-export const ActionBarCheckbox = forwardRef<
-	HTMLButtonElement,
-	PropsWithChildren<ActionBarCheckboxProps>
->((props, ref) => {
-	// Reference hooks.
-	const buttonRef = useRef<HTMLButtonElement>(undefined!);
+export const ActionBarCheckbox = (props: ActionBarCheckboxProps) => {
+	// Context hooks.
+	const context = usePositronActionBarContext();
 
-	// Imperative handle to ref.
-	useImperativeHandle(ref, () => buttonRef.current);
-
-	// State hooks.
-	const [id] = useState(generateUuid());
-	const [checked, setChecked] = useState(props.checked ?? false);
-
-	// Effect hook to update the checked state when the prop changes.
-	useEffect(() => {
-		setChecked(props.checked ?? false);
-	}, [props.checked]);
-
-	// Participate in roving tabindex.
-	useRegisterWithActionBar([buttonRef]);
-
-	// Click handler.
-	const clickHandler = () => {
-		buttonRef.current.setAttribute('aria-checked', !checked ? 'true' : 'false');
-		setChecked(!checked);
-		props.onChanged(!checked);
-	};
-
-	// Render.
+	// Render. The face is hidden from assistive technology and the control is named by ariaLabel,
+	// because VoiceOver reads a button with inner text as a group rather than as a single control.
 	return (
 		<div className='action-bar-checkbox'>
-			<button ref={buttonRef} aria-checked={checked} className='checkbox-button' id={id} role='checkbox' tabIndex={0} onClick={clickHandler}>
-				{checked && <div className='check-indicator codicon codicon-check' />}
-			</button>
-			<label className='checkbox-label' htmlFor={id}>{props.label}</label>
+			<Button
+				ref={props.ref}
+				ariaChecked={props.checked}
+				ariaLabel={props.ariaLabel ?? props.label}
+				className='checkbox-button'
+				disabled={props.disabled}
+				hoverManager={context.hoverManager}
+				role='checkbox'
+				tooltip={props.tooltip}
+				onPressed={() => props.onChanged(!props.checked)}
+			>
+				<div aria-hidden='true' className='checkbox-face'>
+					<div className='checkbox-indicator'>
+						{props.checked && <div className='codicon codicon-check' />}
+					</div>
+					{props.label && <div className='checkbox-label'>{props.label}</div>}
+				</div>
+			</Button>
 		</div>
 	);
-});
+};

--- a/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/useRegisterWithActionBar.tsx
@@ -12,20 +12,21 @@ import { usePositronActionBarContext } from './positronActionBarContext.js';
  * in the Action Bar is focusable (i.e. tabindex=0) and the rest have tabindex=-1.
  * The arrow keys are used to move between the components in the Action Bar.
  */
-export const useRegisterWithActionBar = (refs: MutableRefObject<HTMLElement>[]) => {
+export const useRegisterWithActionBar = (refs: MutableRefObject<HTMLElement | undefined>[]) => {
 	const { focusableComponents } = usePositronActionBarContext();
 
 	useEffect(() => {
-		refs.forEach(ref => {
+		const elements = refs.map(ref => ref.current).filter(element => element !== undefined);
+		elements.forEach(element => {
 			if (focusableComponents.size === 0) {
-				ref.current.tabIndex = 0; // initially the first component is focusable
+				element.tabIndex = 0; // initially the first component is focusable
 			} else {
-				ref.current.tabIndex = -1;
+				element.tabIndex = -1;
 			}
-			focusableComponents.add(ref.current);
+			focusableComponents.add(element);
 		});
 		return () => {
-			refs.forEach(ref => focusableComponents.delete(ref.current));
+			elements.forEach(element => focusableComponents.delete(element));
 		};
 	}, [focusableComponents, refs]);
 };

--- a/src/vs/platform/positronActionBar/test/browser/actionBarActionCheckbox.vitest.tsx
+++ b/src/vs/platform/positronActionBar/test/browser/actionBarActionCheckbox.vitest.tsx
@@ -104,4 +104,14 @@ describe('ActionBarActionCheckbox', () => {
 		await user.click(checkbox);
 		expect(executeCommand).not.toHaveBeenCalled();
 	});
+
+	it('renders nothing when the action has no checked condition', () => {
+		renderCheckbox(createAction({
+			positronActionBarOptions: {
+				controlType: 'checkbox'
+			}
+		}));
+
+		expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+	});
 });

--- a/src/vs/platform/positronActionBar/test/browser/actionBarActionCheckbox.vitest.tsx
+++ b/src/vs/platform/positronActionBar/test/browser/actionBarActionCheckbox.vitest.tsx
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { ActionBarActionCheckbox } from '../../browser/components/actionBarActionCheckbox.js';
+import { MenuId, MenuItemAction, MenuRegistry } from '../../../actions/common/actions.js';
+import { PositronActionBarOptions } from '../../../action/common/action.js';
+import { MenuService } from '../../../actions/common/menuService.js';
+import { NullCommandService } from '../../../commands/test/common/nullCommandService.js';
+import { TestConfigurationService } from '../../../configuration/test/common/testConfigurationService.js';
+import { ContextKeyService } from '../../../contextkey/browser/contextKeyService.js';
+import { ContextKeyExpr, RawContextKey } from '../../../contextkey/common/contextkey.js';
+import { MockKeybindingService } from '../../../keybinding/test/common/mockKeybindingService.js';
+import { InMemoryStorageService } from '../../../storage/common/storage.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { setupRTLRenderer } from '../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../test/vitest/positronTestContainer.js';
+
+// The wrapper reads a real MenuItemAction and decides whether, and with what state, to render the
+// low-level ActionBarCheckbox (already covered by actionBarCheckbox.vitest.tsx). A real
+// ContextKeyService is used to build that action, the same way menuService.vitest.ts does, because
+// `checked` is evaluated once at construction from the live context.
+describe('ActionBarActionCheckbox', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	let disposables: DisposableStore;
+	beforeEach(() => {
+		disposables = new DisposableStore();
+	});
+	afterEach(() => {
+		disposables.dispose();
+	});
+
+	const createAction = (overrides?: {
+		checked?: boolean;
+		enabled?: boolean;
+		positronActionBarOptions?: PositronActionBarOptions;
+	}): MenuItemAction => {
+		const contextKeyService = disposables.add(new ContextKeyService(new TestConfigurationService()));
+		new RawContextKey<boolean>('test.renderOnSave', overrides?.checked ?? false).bindTo(contextKeyService);
+		new RawContextKey<boolean>('test.renderOnSaveEnabled', overrides?.enabled ?? true).bindTo(contextKeyService);
+
+		const menuService = disposables.add(new MenuService(
+			NullCommandService,
+			new MockKeybindingService(),
+			disposables.add(new InMemoryStorageService())
+		));
+
+		const menuId = new MenuId(`test/${generateUuid()}`);
+		disposables.add(MenuRegistry.appendMenuItem(menuId, {
+			command: {
+				id: 'test.renderOnSave',
+				title: 'Render on Save',
+				precondition: ContextKeyExpr.has('test.renderOnSaveEnabled'),
+				positronActionBarOptions: overrides?.positronActionBarOptions ?? {
+					controlType: 'checkbox',
+					checked: ContextKeyExpr.has('test.renderOnSave')
+				}
+			}
+		}));
+
+		const menu = disposables.add(menuService.createMenu(menuId, contextKeyService, { eventDebounceDelay: 0 }));
+		return menu.getActions()[0][1][0] as MenuItemAction;
+	};
+
+	const renderCheckbox = (action = createAction()) => {
+		rtl.render(<ActionBarActionCheckbox action={action} />);
+		return action;
+	};
+
+	it('uses the action label as its accessible name and reports the action checked state', () => {
+		renderCheckbox(createAction({ checked: true }));
+
+		const checkbox = screen.getByRole('checkbox');
+		expect(checkbox).toHaveAccessibleName('Render on Save');
+		expect(checkbox).toBeChecked();
+	});
+
+	it('runs the action through the command service when activated', async () => {
+		const user = userEvent.setup();
+		const executeCommand = vi.spyOn(NullCommandService, 'executeCommand');
+		const action = renderCheckbox(createAction());
+
+		await user.click(screen.getByRole('checkbox'));
+
+		expect(executeCommand).toHaveBeenCalledWith(action.id);
+	});
+
+	it('disables the checkbox when its action is disabled', async () => {
+		const user = userEvent.setup();
+		const executeCommand = vi.spyOn(NullCommandService, 'executeCommand');
+		renderCheckbox(createAction({ enabled: false }));
+		const checkbox = screen.getByRole('checkbox');
+
+		expect(checkbox).toBeDisabled();
+
+		await user.click(checkbox);
+		expect(executeCommand).not.toHaveBeenCalled();
+	});
+});

--- a/src/vs/platform/positronActionBar/test/browser/actionBarCheckbox.vitest.tsx
+++ b/src/vs/platform/positronActionBar/test/browser/actionBarCheckbox.vitest.tsx
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { ActionBarCheckbox } from '../../browser/components/actionBarCheckbox.js';
+import { setupRTLRenderer } from '../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../test/vitest/positronTestContainer.js';
+
+// The checkbox reads the action bar's hover manager out of context, so it needs the provider tree
+// that setupRTLRenderer puts around it. The assertions go through the accessibility tree rather
+// than the DOM, because the point of the component is what a screen reader is told about it.
+describe('ActionBarCheckbox', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	const renderCheckbox = (overrides?: Partial<React.ComponentProps<typeof ActionBarCheckbox>>) => {
+		const onChanged = vi.fn();
+		rtl.render(
+			<ActionBarCheckbox
+				checked={false}
+				label='Word Wrap'
+				onChanged={onChanged}
+				{...overrides}
+			/>
+		);
+		return { onChanged, checkbox: screen.getByRole('checkbox') };
+	};
+
+	it('uses its visible label as its accessible name and reports its checked state', () => {
+		const { checkbox } = renderCheckbox({ checked: true });
+
+		expect(checkbox).toHaveAccessibleName('Word Wrap');
+		expect(checkbox).toBeChecked();
+	});
+
+	it('prefers an explicit ariaLabel over the visible label', () => {
+		const { checkbox } = renderCheckbox({ ariaLabel: 'Wrap long lines' });
+
+		expect(checkbox).toHaveAccessibleName('Wrap long lines');
+		expect(checkbox).not.toBeChecked();
+	});
+
+	it('requests the inverse value without changing its controlled checked state', async () => {
+		const user = userEvent.setup();
+		const { onChanged, checkbox } = renderCheckbox({ checked: true });
+
+		await user.click(checkbox);
+
+		// The parent owns the value, so the checkbox asks for the opposite of what it was given
+		// and stays where it is until the parent says otherwise.
+		expect(onChanged).toHaveBeenCalledWith(false);
+		expect(checkbox).toBeChecked();
+	});
+
+	it('activates on Space and Enter', async () => {
+		const user = userEvent.setup();
+		const { onChanged, checkbox } = renderCheckbox();
+
+		checkbox.focus();
+		await user.keyboard('[Space]');
+		await user.keyboard('[Enter]');
+
+		// Two activations, not four: neither key may also fire the click the browser synthesizes
+		// for a native <button>.
+		expect(onChanged).toHaveBeenCalledTimes(2);
+		expect(onChanged).toHaveBeenNthCalledWith(1, true);
+		expect(onChanged).toHaveBeenNthCalledWith(2, true);
+	});
+
+	it('uses native disabled semantics and ignores clicks', async () => {
+		const user = userEvent.setup();
+		const { onChanged, checkbox } = renderCheckbox({ disabled: true });
+
+		expect(checkbox).toBeDisabled();
+		checkbox.focus();
+		expect(checkbox).not.toHaveFocus();
+
+		await user.click(checkbox);
+		expect(onChanged).not.toHaveBeenCalled();
+	});
+});

--- a/src/vs/workbench/contrib/positronControlGallery/browser/galleries/galleries.ts
+++ b/src/vs/workbench/contrib/positronControlGallery/browser/galleries/galleries.ts
@@ -5,5 +5,6 @@
 
 // Side-effect imports. Each module registers a ControlGalleryEntry into the registry at
 // load time. Adding a new control's harness is a single-line addition here.
+import './positronActionBarControlsGallery.js';
 import './positronListGallery.js';
 import './positronTreeGallery.js';

--- a/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronActionBarControlsGallery.css
+++ b/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronActionBarControlsGallery.css
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.action-bar-controls-harness {
+	gap: 24px;
+	width: 100%;
+	display: flex;
+	padding: 16px 0;
+	flex-direction: column;
+}
+
+.action-bar-controls-harness-section {
+	display: flex;
+	flex-direction: column;
+}
+
+.action-bar-controls-harness-section-title {
+	font-weight: 600;
+	padding: 0 16px 4px;
+	color: var(--vscode-descriptionForeground);
+}
+
+.action-bar-controls-harness-toolbar {
+	gap: 16px;
+	display: flex;
+	flex-wrap: wrap;
+	padding: 8px 16px;
+	align-items: center;
+}
+
+.action-bar-controls-harness-knob {
+	gap: 6px;
+	font-size: 0.9em;
+	align-items: center;
+	display: inline-flex;
+}
+
+.action-bar-controls-harness-knob input {
+	width: 100px;
+	padding: 2px 6px;
+	border-radius: 2px;
+	color: var(--vscode-input-foreground);
+	background-color: var(--vscode-input-background);
+	border: 1px solid var(--vscode-input-border, transparent);
+}
+
+.action-bar-controls-harness-checkbox input {
+	width: auto;
+	padding: 0;
+	border: none;
+	background-color: transparent;
+}

--- a/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronActionBarControlsGallery.tsx
+++ b/src/vs/workbench/contrib/positronControlGallery/browser/galleries/positronActionBarControlsGallery.tsx
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './positronActionBarControlsGallery.css';
+
+// React.
+import { PropsWithChildren, useRef, useState } from 'react';
+
+// Other dependencies.
+import { controlGalleryRegistry } from '../controlGalleryRegistry.js';
+import { PositronActionBar } from '../../../../../platform/positronActionBar/browser/positronActionBar.js';
+import { useRegisterWithActionBar } from '../../../../../platform/positronActionBar/browser/useRegisterWithActionBar.js';
+import { PositronActionBarContextProvider } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
+import { ActionBarCheckbox } from '../../../../../platform/positronActionBar/browser/components/actionBarCheckbox.js';
+
+/**
+ * TextKnob component. A labelled text field.
+ */
+const TextKnob = (props: {
+	readonly label: string;
+	readonly value: string;
+	readonly onChange: (value: string) => void;
+}) => (
+	<label className='action-bar-controls-harness-knob'>
+		<span>{props.label}</span>
+		<input
+			type='text'
+			value={props.value}
+			onChange={e => props.onChange(e.target.value)}
+		/>
+	</label>
+);
+
+/**
+ * CheckKnob component. A labelled checkbox.
+ */
+const CheckKnob = (props: {
+	readonly label: string;
+	readonly value: boolean;
+	readonly onChange: (value: boolean) => void;
+}) => (
+	<label className='action-bar-controls-harness-knob action-bar-controls-harness-checkbox'>
+		<input
+			checked={props.value}
+			type='checkbox'
+			onChange={e => props.onChange(e.target.checked)}
+		/>
+		<span>{props.label}</span>
+	</label>
+);
+
+/**
+ * PreviewBar component. A real action bar wrapped around a single control, so the control gets
+ * the roving tabindex and the hover manager it would have in the workbench. Each control gets its
+ * own bar and its own context, so focus and tab order in one cannot affect the other.
+ */
+const PreviewBar = (props: PropsWithChildren) => (
+	<PositronActionBarContextProvider>
+		{/* eslint-disable-next-line no-restricted-syntax -- the harness shows one control at a fixed width; overflow behavior is PositronDynamicActionBar's concern, not what this fixture is for. */}
+		<PositronActionBar borderBottom borderTop paddingLeft={8} paddingRight={8}>
+			{props.children}
+		</PositronActionBar>
+	</PositronActionBarContextProvider>
+);
+
+/**
+ * Section component. One control: its knobs above, its preview bar below.
+ */
+const Section = (props: PropsWithChildren<{
+	readonly title: string;
+	readonly knobs: React.ReactNode;
+}>) => (
+	<div className='action-bar-controls-harness-section'>
+		<div className='action-bar-controls-harness-section-title'>{props.title}</div>
+		<div className='action-bar-controls-harness-toolbar'>{props.knobs}</div>
+		<div className='action-bar-controls-harness-preview'>{props.children}</div>
+	</div>
+);
+
+/**
+ * CheckboxSection component.
+ */
+const CheckboxSection = () => {
+	// State hooks.
+	const [checked, setChecked] = useState(false);
+	const [disabled, setDisabled] = useState(false);
+	const [label, setLabel] = useState('Check Me!');
+
+	// Reference hooks.
+	const checkboxRef = useRef<HTMLButtonElement>(undefined!);
+
+	// Render.
+	return (
+		<Section
+			knobs={
+				<>
+					<TextKnob label='Label' value={label} onChange={setLabel} />
+					<CheckKnob label='Checked' value={checked} onChange={setChecked} />
+					<CheckKnob label='Disabled' value={disabled} onChange={setDisabled} />
+				</>
+			}
+			title='Checkbox'
+		>
+			<PreviewBar>
+				<RegisteredCheckbox
+					ref={checkboxRef}
+					checked={checked}
+					disabled={disabled}
+					label={label}
+					onChanged={setChecked}
+				/>
+			</PreviewBar>
+		</Section>
+	);
+};
+
+/**
+ * RegisteredCheckbox component. Registers the checkbox with its bar, which in the workbench is
+ * ActionBarActionCheckbox's job.
+ */
+const RegisteredCheckbox = (props: {
+	readonly checked: boolean;
+	readonly disabled: boolean;
+	readonly label: string;
+	readonly onChanged: (checked: boolean) => void;
+	readonly ref: React.RefObject<HTMLButtonElement>;
+}) => {
+	// Participate in roving tabindex.
+	useRegisterWithActionBar([props.ref]);
+
+	// Render.
+	return (
+		<ActionBarCheckbox
+			ref={props.ref}
+			checked={props.checked}
+			disabled={props.disabled}
+			label={props.label}
+			tooltip={props.label}
+			onChanged={props.onChanged}
+		/>
+	);
+};
+
+/**
+ * PositronActionBarControlsHarness component. A configurable fixture for the action bar checkbox.
+ * Nothing in the workbench renders it in every state Quarto's Render on Save can reach, so this is
+ * the only place its markup, CSS and screen reader output can be checked side by side.
+ */
+const PositronActionBarControlsHarness = () => (
+	<div className='action-bar-controls-harness'>
+		<CheckboxSection />
+	</div>
+);
+
+controlGalleryRegistry.register({
+	id: 'positronActionBarControls',
+	label: 'Action Bar Controls',
+	description: 'The checkbox that extensions can put on the Editor Action Bar.',
+	render: () => <PositronActionBarControlsHarness />
+});

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -1044,6 +1044,7 @@ namespace schema {
 				},
 				{
 					type: 'object',
+					required: ['controlType', 'checked'],
 					properties: {
 						controlType: {
 							description: localize('vscode.extension.contributes.commandType.actionBarOptions.controlType', 'The type of the action bar control.'),
@@ -1057,6 +1058,7 @@ namespace schema {
 				},
 				{
 					type: 'object',
+					required: ['controlType', 'toggled', 'leftTitle', 'rightTitle'],
 					properties: {
 						controlType: {
 							description: localize('vscode.extension.contributes.commandType.actionBarOptions.controlType', 'The type of the action bar control.'),


### PR DESCRIPTION
Fixes #7289

### Summary

This PR improves the accessibility of checkboxes contributed by extensions to the Editor Action Bar.

The checkbox now:

- Exposes a consistent accessible name, role, checked state, and disabled state.
- Supports Space and Enter activation through the shared `Button` component.
- Includes its visible label in the clickable area while presenting the checkbox as a single control to assistive technology.
- Follows the extension's context-key state instead of maintaining an optimistic local copy.
- Updates when the extension changes its checked state externally.
- Uses native button disablement when its command is unavailable.

This also adds an Action Bar Controls entry to the Control Gallery for inspecting the checkbox's checked, disabled, and labelled states.

The Editor Action Bar's existing focus and arrow-navigation behavior is outside the scope of this PR.

### Screenshots


https://github.com/user-attachments/assets/540c0cf9-678c-44f3-a4b5-b2a9949b8d9d

<img width="1163" height="821" alt="Screenshot 2026-09-09 at 1 32 56 PM" src="https://github.com/user-attachments/assets/c75e1430-fa94-4979-b815-5aceb6ff1bc6" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Extension-contributed Editor Action Bar checkboxes now expose their label, checked state, disabled state, and keyboard interaction correctly to assistive technology. (#7289)

### Validation Steps

@:editor-action-bar @:quarto

#### Control Gallery

1. Run **Open Control Gallery**.
2. Select **Action Bar Controls**.
3. Verify changing the **Label** updates both the visible and accessible names.
4. Verify the **Checked** control updates the checkmark and `aria-checked` state.
5. Verify clicking either the box or visible label toggles the checkbox once.
6. Focus the enabled checkbox and verify Space and Enter each toggle it once.
7. Enable **Disabled** and verify the checkbox is dimmed, skipped by Tab, and cannot be activated.
8. Hover the checkbox and verify its tooltip uses the current label.

#### VoiceOver

1. On macOS, open the **Action Bar Controls** gallery and start VoiceOver with <kbd>Command</kbd>+<kbd>F5</kbd>.
2. Navigate to the checkbox with <kbd>Control</kbd>+<kbd>Option</kbd>+<kbd>Right Arrow</kbd>.
3. Verify VoiceOver announces the checkbox's current label, checkbox role, and checked or unchecked state as one control.
4. Activate the checkbox with <kbd>Control</kbd>+<kbd>Option</kbd>+<kbd>Space</kbd>.
5. Verify VoiceOver announces the updated checked state and does not announce the visible label or checkmark as separate nested elements.
6. Change the **Label** field and navigate back to the checkbox. Verify VoiceOver announces the new label.
7. Enable **Disabled** and navigate back to the checkbox using VoiceOver. Verify it is announced as disabled and cannot be activated.

#### Quarto

1. Open a `.qmd` file that displays the **Render on Save** checkbox.
2. Verify its initial checked state matches the Quarto setting.
3. Click the checkbox and verify its checkmark and accessible checked state update.
4. Open the Command Palette and run **Quarto: Render on Save**.
5. Verify the existing checkbox updates without reopening the editor.
6. Verify the checkbox's enabled state follows the command enablement supplied by Quarto.

### QA Notes

For extension-contributed controls, a command's `enablement` expression becomes its precondition. Positron uses that precondition to determine whether the action is enabled, and the checkbox now reflects that state using native disabled behavior.

The Quarto extension therefore needs to update the **Render on Save** command's `enablement` expression to include every editor where the checkbox should be interactive. Until then, the checkbox may appear disabled in some Quarto editors.

CC @juliasilge, who plans to make this change in the Quarto extension.