### PR TITLE
Quarto: consolidate cell reconciliation for inline outputs and cell toolbars

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbarController.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbarController.ts
@@ -15,6 +15,7 @@ import { IQuartoExecutionManager } from '../common/quartoExecutionTypes.js';
 import { QuartoCodeCell, IQuartoDocumentModel, QuartoCellChangeEvent } from '../common/quartoTypes.js';
 import { QuartoCellToolbar } from './quartoCellToolbar.js';
 import { QuartoOutputContribution } from './quartoOutputManager.js';
+import { ICellAssociation, reconcileCellAssociations } from '../common/quartoCellReconciliation.js';
 import { computeDeleteCellEdit, computeInsertCellEdit, computeJoinCellsEdit } from './quartoCellOperations.js';
 import { POSITRON_QUARTO_INLINE_OUTPUT_SHOW_CELL_TOOLBAR_KEY, QUARTO_INLINE_OUTPUT_ENABLED, QUARTO_INLINE_OUTPUT_SHOW_CELL_TOOLBAR_KEY, affectsQuartoConfig, isQuartoDocument, usingQuartoCellToolbar } from '../common/positronQuartoConfig.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
@@ -40,6 +41,7 @@ export class QuartoCellToolbarController extends Disposable implements IEditorCo
 	private _quartoModel: IQuartoDocumentModel | undefined;
 	private _currentCellId: string | undefined;
 	private _mouseCellId: string | undefined;
+	private _previousCells: readonly QuartoCodeCell[] = [];
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -95,6 +97,7 @@ export class QuartoCellToolbarController extends Disposable implements IEditorCo
 		this._quartoModel = undefined;
 		this._currentCellId = undefined;
 		this._mouseCellId = undefined;
+		this._previousCells = [];
 
 		const model = this._editor.getModel();
 		if (!model) {
@@ -128,6 +131,10 @@ export class QuartoCellToolbarController extends Disposable implements IEditorCo
 		// Get the Quarto document model
 		this._quartoModel = this._documentModelService.getModel(model);
 		this._logService.debug(`[QuartoCellToolbarController] Got Quarto model, cells: ${this._quartoModel.cells.length}`);
+
+		// Record the cell list now, before anything below can start tracking
+		// a toolbar for an individual cell
+		this._previousCells = this._quartoModel.cells;
 
 		// Listen for execution state changes
 		this._disposables.add(this._executionManager.onDidChangeExecutionState((event) => {
@@ -370,55 +377,52 @@ export class QuartoCellToolbarController extends Disposable implements IEditorCo
 			return;
 		}
 
-		const cells = this._quartoModel.cells;
-		const totalCells = cells.length;
-
-		// Build a set of current cell IDs for quick lookup, and a map by
-		// content hash so we can match toolbars whose cell IDs changed
-		const currentCellIds = new Set<string>();
-		const cellsByHash = new Map<string, QuartoCodeCell>();
-		for (const cell of cells) {
-			currentCellIds.add(cell.id);
-			cellsByHash.set(cell.contentHash, cell);
-		}
+		const totalCells = this._quartoModel.cells.length;
 
 		// Collect re-mappings and orphans in a first pass, then apply them.
 		// We can't mutate the map while iterating it.
 		const remaps: { oldId: string; toolbar: QuartoCellToolbar; newCell: QuartoCodeCell }[] = [];
 		const orphans: string[] = [];
+		const toReconcile: ICellAssociation[] = [];
+		const toolbarByOldId = new Map<string, QuartoCellToolbar>();
 
+		// Every toolbar goes through reconciliation, including ones whose id
+		// still resolves.
 		for (const [id, toolbar] of this._toolbars) {
-			if (currentCellIds.has(id)) {
-				// ID still valid, just refresh position
-				const cell = this._quartoModel.getCellById(id)!;
-				toolbar.updateCell(cell, cell.index, totalCells);
-			} else {
-				// ID no longer in model, try to match by content hash
-				const matched = cellsByHash.get(toolbar.cell.contentHash);
-				if (matched && !this._toolbars.has(matched.id)) {
-					remaps.push({ oldId: id, toolbar, newCell: matched });
-				} else {
-					orphans.push(id);
-				}
-			}
+			toReconcile.push({ id, contentHash: toolbar.cell.contentHash });
+			toolbarByOldId.set(id, toolbar);
 		}
 
-		// Apply re-mappings
-		for (const { oldId, toolbar, newCell } of remaps) {
+		for (const result of reconcileCellAssociations(this._quartoModel, this._previousCells, toReconcile)) {
+			if (result.kind === 'orphaned') {
+				orphans.push(result.id);
+				continue;
+			}
+			remaps.push({ oldId: result.oldId, toolbar: toolbarByOldId.get(result.oldId)!, newCell: result.newCell });
+		}
+
+		// Capture the orphans' toolbars before any map mutation
+		const orphanToolbars = orphans.map(id => ({ id, toolbar: this._toolbars.get(id) }));
+
+		for (const { oldId } of remaps) {
 			this._toolbars.delete(oldId);
+		}
+		for (const { id } of orphanToolbars) {
+			this._toolbars.delete(id);
+		}
+
+		for (const { toolbar, newCell } of remaps) {
 			toolbar.updateCell(newCell, newCell.index, totalCells);
 			this._toolbars.set(newCell.id, toolbar);
 		}
-
-		// Dispose orphaned toolbars
-		for (const id of orphans) {
-			const toolbar = this._toolbars.get(id);
+		for (const { id, toolbar } of orphanToolbars) {
 			if (toolbar) {
 				this._logService.debug(`[QuartoCellToolbarController] Disposing orphaned toolbar ${id}`);
 				toolbar.dispose();
-				this._toolbars.delete(id);
 			}
 		}
+
+		this._previousCells = this._quartoModel.cells;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoDocumentModel.ts
@@ -37,6 +37,25 @@ function generateCellId(
 	return `${index}-${hashPrefix}-${labelPart}`;
 }
 
+/** The index and content-hash prefix embedded in a cell id. */
+export interface ParsedCellId {
+	readonly index: number | undefined;
+	readonly hashPrefix: string | undefined;
+}
+
+/**
+ * Reads a cell id back apart (partial inverse of `generateCellId`; the label
+ * isn't reconstructed, since no caller needs it back).
+ */
+export function parseCellId(id: string): ParsedCellId {
+	const parts = id.split('-');
+	const index = parseInt(parts[0], 10);
+	return {
+		index: Number.isNaN(index) ? undefined : index,
+		hashPrefix: parts.length >= 2 ? parts[1] : undefined,
+	};
+}
+
 
 /**
  * Represents the parsed state of a Quarto document.

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -27,6 +27,7 @@ import { getImageOutputName, openImageOutputInNewTab, saveImageOutput } from '..
 import { IPositronPreviewService } from '../../positronPreview/browser/positronPreviewSevice.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 import { QuartoCodeCell } from '../common/quartoTypes.js';
+import { parseCellId } from './quartoDocumentModel.js';
 import { IQuartoExecutionManager, ICellOutput, ICellOutputItem, CellExecutionState, IQuartoOutputCacheService, QuartoCellErrorContext } from '../common/quartoExecutionTypes.js';
 import { ICellAssociation, reconcileCellAssociations } from '../common/quartoCellReconciliation.js';
 import { QUARTO_INLINE_OUTPUT_ENABLED, POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY, affectsQuartoConfig, getQuartoConfigValue, isQuartoDocument, usingQuartoInlineOutputAutoScroll } from '../common/positronQuartoConfig.js';
@@ -873,11 +874,8 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			// If not found by ID, try to find by content hash
 			// (cell IDs include index which could differ if whitespace/parsing changed)
 			if (!cell) {
-				// Extract content hash from old cell ID (format: index-hashPrefix-label)
-				const parts = cellId.split('-');
-				if (parts.length >= 2) {
-					const hashPrefix = parts[1];
-					// Find cell with matching hash prefix
+				const { hashPrefix } = parseCellId(cellId);
+				if (hashPrefix) {
 					cell = quartoModel.cells.find(c => c.contentHash.startsWith(hashPrefix));
 				}
 			}
@@ -1433,8 +1431,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	 * Returns the zero-based cell index encoded at the start of the cell ID.
 	 */
 	private _getCellIndex(cellId: string): number {
-		const index = parseInt(cellId.split('-')[0], 10);
-		return Number.isNaN(index) ? 0 : index;
+		return parseCellId(cellId).index ?? 0;
 	}
 
 	/** Returns the cell's current code, when the cell still exists. */

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -26,7 +26,9 @@ import { getImageDataUrl } from '../../../services/positronPlots/common/imageDat
 import { getImageOutputName, openImageOutputInNewTab, saveImageOutput } from '../../positronNotebook/common/imageOutputUtils.js';
 import { IPositronPreviewService } from '../../positronPreview/browser/positronPreviewSevice.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
+import { QuartoCodeCell } from '../common/quartoTypes.js';
 import { IQuartoExecutionManager, ICellOutput, ICellOutputItem, CellExecutionState, IQuartoOutputCacheService, QuartoCellErrorContext } from '../common/quartoExecutionTypes.js';
+import { ICellAssociation, reconcileCellAssociations } from '../common/quartoCellReconciliation.js';
 import { QUARTO_INLINE_OUTPUT_ENABLED, POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, QUARTO_INLINE_OUTPUT_MAX_LINES_KEY, QUARTO_INLINE_OUTPUT_AUTO_SCROLL_KEY, affectsQuartoConfig, getQuartoConfigValue, isQuartoDocument, usingQuartoInlineOutputAutoScroll } from '../common/positronQuartoConfig.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
@@ -227,6 +229,8 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	private readonly _contentHashByCellId = new Map<string, string>();
 	// Track last-known execution info per cell so the status bar can survive tab switches
 	private readonly _executionInfoByCell = new Map<string, { state: CellExecutionState; startTime?: number; endTime?: number }>();
+	// The full cell list as of the last position update, tracked or not
+	private _previousCells: readonly QuartoCodeCell[] = [];
 	private _documentUri: URI | undefined;
 	private _featureEnabled: boolean;
 	private _outputHandlingInitialized = false;
@@ -373,6 +377,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			this._contentHashByCellId.clear();
 			this._executionInfoByCell.clear();
 			this._cellsAwaitingRecomputeOutput.clear();
+			this._previousCells = [];
 
 			// Clear previous output handling subscriptions to prevent duplicates
 			this._outputHandlingDisposables.clear();
@@ -422,6 +427,14 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		}
 		this._outputHandlingInitialized = true;
 		this._logService.debug('[QuartoOutputContribution] Initializing for', this._documentUri?.toString());
+
+		// Record the cell list now, before anything below can start tracking
+		// output for individual cells (loading the cache, then live
+		// execution).
+		const initialModel = this._editor.getModel();
+		if (initialModel) {
+			this._previousCells = this._documentModelService.getModel(initialModel).cells;
+		}
 
 		// Load cached outputs
 		this._loadCachedOutputs();
@@ -1725,45 +1738,60 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		// (can't modify maps while iterating)
 		const remappings: Array<{ oldId: string; newId: string; contentHash: string }> = [];
 		const deletions: string[] = [];
+		const toReconcile: ICellAssociation[] = [];
 
 		for (const [cellId, viewZone] of this._viewZones) {
+			const contentHash = this._contentHashByCellId.get(cellId);
+			if (contentHash) {
+				toReconcile.push({ id: cellId, contentHash });
+				continue;
+			}
 			const cell = quartoModel.getCellById(cellId);
 			if (cell) {
-				// Cell still exists with same ID - just update position
 				viewZone.updateAfterLineNumber(cell.endLine);
 			} else {
-				// Cell ID not found - check if the cell just moved (ID changed due to index shift)
-				const contentHash = this._contentHashByCellId.get(cellId);
-				if (contentHash) {
-					const oldIndex = parseInt(cellId, 10);
-					const movedCell = quartoModel.findCellByContentHash(contentHash, isNaN(oldIndex) ? undefined : oldIndex);
-					if (movedCell) {
-						// Cell moved! Remap to new ID and update position
-						this._logService.debug('[QuartoOutputContribution] Cell moved from', cellId, 'to', movedCell.id);
-						viewZone.updateAfterLineNumber(movedCell.endLine);
-						remappings.push({ oldId: cellId, newId: movedCell.id, contentHash });
-					} else {
-						// Cell content hash no longer exists - cell was truly deleted
-						deletions.push(cellId);
-					}
-				} else {
-					// No content hash tracked - cell was truly deleted
-					deletions.push(cellId);
-				}
+				deletions.push(cellId);
 			}
 		}
 
-		// Apply remappings
-		for (const { oldId, newId, contentHash } of remappings) {
-			const viewZone = this._viewZones.get(oldId);
-			const outputs = this._outputsByCell.get(oldId);
+		for (const result of reconcileCellAssociations(quartoModel, this._previousCells, toReconcile)) {
+			if (result.kind === 'orphaned') {
+				// Cell content hash no longer exists - cell was truly deleted
+				deletions.push(result.id);
+				continue;
+			}
+			// Cell moved (or stayed put); refresh its position either way
+			const viewZone = this._viewZones.get(result.oldId);
+			if (viewZone) {
+				if (result.oldId !== result.newCell.id) {
+					this._logService.debug('[QuartoOutputContribution] Cell moved from', result.oldId, 'to', result.newCell.id);
+				}
+				viewZone.updateAfterLineNumber(result.newCell.endLine);
+			}
+			remappings.push({ oldId: result.oldId, newId: result.newCell.id, contentHash: result.newCell.contentHash });
+		}
 
-			// Remove old entries
+		// Apply remappings and deletions together
+		const remapSnapshots = remappings.map(({ oldId, newId, contentHash }) => ({
+			newId,
+			contentHash,
+			viewZone: this._viewZones.get(oldId),
+			outputs: this._outputsByCell.get(oldId),
+		}));
+		const deletionSnapshots = deletions.map(cellId => this._viewZones.get(cellId));
+
+		for (const { oldId } of remappings) {
 			this._viewZones.delete(oldId);
 			this._outputsByCell.delete(oldId);
 			this._contentHashByCellId.delete(oldId);
+		}
+		for (const cellId of deletions) {
+			this._viewZones.delete(cellId);
+			this._outputsByCell.delete(cellId);
+			this._contentHashByCellId.delete(cellId);
+		}
 
-			// Add with new ID
+		for (const { newId, contentHash, viewZone, outputs } of remapSnapshots) {
 			if (viewZone) {
 				this._viewZones.set(newId, viewZone);
 			}
@@ -1772,17 +1800,12 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			}
 			this._contentHashByCellId.set(newId, contentHash);
 		}
-
-		// Apply deletions
-		for (const cellId of deletions) {
-			const viewZone = this._viewZones.get(cellId);
-			if (viewZone) {
-				viewZone.dispose();
-			}
-			this._viewZones.delete(cellId);
-			this._outputsByCell.delete(cellId);
-			this._contentHashByCellId.delete(cellId);
+		for (const viewZone of deletionSnapshots) {
+			viewZone?.dispose();
 		}
+
+		// Record this parse's cells for next time
+		this._previousCells = quartoModel.cells;
 	}
 
 	private _handleFeatureToggle(): void {

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoCellReconciliation.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoCellReconciliation.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { QuartoCodeCell } from './quartoTypes.js';
+
+/**
+ * A per-cell association (a view zone, a cell toolbar, ...) that needs to be
+ * re-anchored to a current cell after a reparse. `id` is the association's
+ * key, expected to equal a `QuartoCodeCell.id` while it is still valid.
+ */
+export interface ICellAssociation {
+	readonly id: string;
+	readonly contentHash: string;
+}
+
+/**
+ * Result of re-anchoring one association. `moved` covers both an actual
+ * relocation and the no-op case where `oldId` already equals `newCell.id`:
+ * either way the caller refreshes from `newCell` the same way.
+ */
+export type CellReconciliation =
+	| { readonly kind: 'moved'; readonly oldId: string; readonly newCell: QuartoCodeCell }
+	| { readonly kind: 'orphaned'; readonly id: string };
+
+/**
+ * The one piece of `IQuartoDocumentModel` this module needs. A structural
+ * subset rather than the full interface, so a caller with a real document
+ * model satisfies it without change, and a test can supply a plain array.
+ */
+export interface IQuartoCellSource {
+	readonly cells: readonly QuartoCodeCell[];
+}
+
+/**
+ * Re-anchors associations to their current cells by content hash, since a
+ * stale `id` resolving to *some* cell doesn't prove it resolves to the
+ * *same* one: ids embed their index (`{index}-{hashPrefix}-{label}`), so
+ * identical-content cells can swap which one an old id names across a shift.
+ *
+ * Within each content-hash group, current cells are ranked by index and
+ * associations by how many same-hash siblings preceded them in
+ * `previousCells` -- the full cell list from the last update, not just the
+ * tracked ones, since tracking is sparse (only cells with a view zone or
+ * toolbar get an association). Same-rank pairs match; an association past
+ * the end of its group's current cells is `orphaned`. An id missing from
+ * `previousCells` (no prior update yet) falls back to the index in its own
+ * id instead of a true rank.
+ *
+ * Known limitation: rank is fixed from `previousCells` and reused as-is, so
+ * if an earlier same-hash cell is itself added or removed (not just shifted)
+ * between updates, every later association in that group can be misranked.
+ * Fixing this needs a whole-document, anchor-aware alignment (using
+ * non-duplicate neighbors to localize where a change happened) rather than
+ * per-group ranking; accepted for now.
+ */
+export function reconcileCellAssociations(
+	model: IQuartoCellSource,
+	previousCells: readonly QuartoCodeCell[],
+	associations: readonly ICellAssociation[],
+): CellReconciliation[] {
+	const previousCellsById = new Map<string, QuartoCodeCell>();
+	for (const cell of previousCells) {
+		previousCellsById.set(cell.id, cell);
+	}
+
+	const cellsByHash = new Map<string, QuartoCodeCell[]>();
+	for (const cell of model.cells) {
+		const group = cellsByHash.get(cell.contentHash);
+		if (group) {
+			group.push(cell);
+		} else {
+			cellsByHash.set(cell.contentHash, [cell]);
+		}
+	}
+
+	interface GroupEntry {
+		readonly position: number;
+		readonly id: string;
+		/** True rank among all same-hash siblings in `previousCells`, tracked or not; `undefined` if `id` isn't in `previousCells` at all. */
+		readonly trueRank: number | undefined;
+		/** Ordering fallback for when `trueRank` is unavailable: the index embedded in `id`, meaningful only relative to other associations in the same group. */
+		readonly parsedIndex: number;
+	}
+
+	const results: CellReconciliation[] = new Array(associations.length);
+	const groups = new Map<string, GroupEntry[]>();
+	associations.forEach((association, position) => {
+		const previousCell = previousCellsById.get(association.id);
+		const entry: GroupEntry = {
+			position,
+			id: association.id,
+			trueRank: previousCell ? countPrecedingSiblings(previousCells, previousCell) : undefined,
+			parsedIndex: parsePreviousIndex(association.id) ?? 0,
+		};
+		const group = groups.get(association.contentHash);
+		if (group) {
+			group.push(entry);
+		} else {
+			groups.set(association.contentHash, [entry]);
+		}
+	});
+
+	for (const [hash, group] of groups) {
+		const candidates = cellsByHash.get(hash) ?? [];
+		const allRanked = group.every(entry => entry.trueRank !== undefined);
+		const ordered = allRanked
+			? [...group].sort((a, b) => a.trueRank! - b.trueRank!)
+			: [...group].sort((a, b) => a.parsedIndex - b.parsedIndex);
+		ordered.forEach((entry, sequentialIndex) => {
+			const candidateIndex = allRanked ? entry.trueRank! : sequentialIndex;
+			const newCell = candidates[candidateIndex];
+			results[entry.position] = newCell
+				? { kind: 'moved', oldId: entry.id, newCell }
+				: { kind: 'orphaned', id: entry.id };
+		});
+	}
+
+	return results;
+}
+
+/**
+ * How many cells sharing `previousCell`'s content hash preceded it in the
+ * full previous parse -- its true position among same-content siblings,
+ * regardless of which of them were tracked.
+ */
+function countPrecedingSiblings(previousCells: readonly QuartoCodeCell[], previousCell: QuartoCodeCell): number {
+	let rank = 0;
+	for (const cell of previousCells) {
+		if (cell.contentHash === previousCell.contentHash && cell.index < previousCell.index) {
+			rank++;
+		}
+	}
+	return rank;
+}
+
+/** The leading digits of a cell id are its index; `NaN` becomes "no preference". */
+function parsePreviousIndex(id: string): number | undefined {
+	const index = parseInt(id, 10);
+	return Number.isNaN(index) ? undefined : index;
+}

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoCellReconciliation.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoCellReconciliation.ts
@@ -7,9 +7,9 @@ import { ISequence, LcsDiff } from '../../../../base/common/diff/diff.js';
 import { QuartoCodeCell } from './quartoTypes.js';
 
 /**
- * A per-cell association (a view zone, a cell toolbar, ...) that needs to be
- * re-anchored to a current cell after a reparse. `id` is the association's
- * key, expected to equal a `QuartoCodeCell.id` while it is still valid.
+ * A per-cell association (a view zone, a cell toolbar, ...) to re-anchor
+ * to a current cell after a reparse. `id` equals a `QuartoCodeCell.id`
+ * while still valid.
  */
 export interface ICellAssociation {
 	readonly id: string;
@@ -17,9 +17,9 @@ export interface ICellAssociation {
 }
 
 /**
- * Result of re-anchoring one association. `moved` covers both an actual
- * relocation and the no-op case where `oldId` already equals `newCell.id`:
- * either way the caller refreshes from `newCell` the same way.
+ * Result of re-anchoring one association. `moved` also covers the no-op
+ * case `oldId === newCell.id`; the caller refreshes from `newCell` either
+ * way.
  */
 export type CellReconciliation =
 	| { readonly kind: 'moved'; readonly oldId: string; readonly newCell: QuartoCodeCell }
@@ -27,8 +27,7 @@ export type CellReconciliation =
 
 /**
  * The one piece of `IQuartoDocumentModel` this module needs. A structural
- * subset rather than the full interface, so a caller with a real document
- * model satisfies it without change, and a test can supply a plain array.
+ * subset, so a test can supply a plain array.
  */
 export interface IQuartoCellSource {
 	readonly cells: readonly QuartoCodeCell[];
@@ -48,26 +47,22 @@ class CellHashSequence implements ISequence {
 }
 
 /**
- * Re-anchors associations to their current cells by aligning the previous
- * and current cell sequences on content hash. A stale `id` resolving to
- * *some* cell doesn't prove it resolves to the *same* one: ids embed their
- * index (`{index}-{hashPrefix}-{label}`), so identical-content cells can
- * swap which one an old id names across a shift.
+ * Re-anchors associations to their current cells after a reparse. A stale
+ * `id` resolving to *some* cell doesn't prove it resolves to the *same*
+ * one: ids embed their index (`{index}-{hashPrefix}-{label}`), so
+ * identical-content cells can swap which one an old id names across a
+ * shift.
  *
- * The alignment is a whole-document LCS diff over the hash sequences, so an
- * unchanged cell keeps its association no matter what changed elsewhere in
- * the document -- including an edit or deletion of a same-content sibling,
- * which per-hash-group reasoning cannot tell apart from the cell itself
- * moving. Within a run of identical cells the diff cannot know which twin
- * was added or removed; when it deems a *tracked* cell deleted while an
- * untracked twin from the same run survives, the association inherits the
- * twin's aligned cell rather than being orphaned, since identical content
- * makes the surviving twin an equally good home for it. (When both twins
- * are tracked, one orphan is unavoidable -- a cell really did vanish.)
+ * Strategy: align the previous and current content-hash sequences with a
+ * whole-document LCS diff, then let each unmatched association claim an
+ * unclaimed current cell with the same hash. The diff reads a reorder as
+ * deletion plus insertion, and which of several identical cells it deems
+ * deleted is arbitrary, so prefer the outcome that keeps tracked state
+ * alive -- identical content makes any survivor an equally good home. An
+ * association with no unclaimed same-hash cell is genuinely orphaned.
  *
- * An association whose id is missing from `previousCells` entirely (no
- * prior parse recorded) falls back to matching by content hash, in
- * id-index order, against cells no aligned association claimed.
+ * Associations missing from `previousCells` (no prior parse recorded) fall
+ * back to the same hash matching, in id-index order.
  */
 export function reconcileCellAssociations(
 	model: IQuartoCellSource,
@@ -76,8 +71,7 @@ export function reconcileCellAssociations(
 ): CellReconciliation[] {
 	const currentCells = model.cells;
 
-	// Align the two cell sequences; unchanged blocks map an old array
-	// position to its new one.
+	// Whole-document alignment: maps old array positions to new ones.
 	const oldToNew = alignCellSequences(previousCells, currentCells);
 
 	const previousPositionById = new Map<string, number>();
@@ -88,9 +82,8 @@ export function reconcileCellAssociations(
 	const orphanedPositions: number[] = [];
 	const fallbackPositions: number[] = [];
 
-	// Aligned path: an association whose previous cell still has an aligned
-	// counterpart moves to it; one whose previous cell was deleted (or
-	// edited into different content) is tentatively orphaned.
+	// Aligned path: follow the alignment where possible; the rest are
+	// tentatively orphaned.
 	associations.forEach((association, position) => {
 		const oldPosition = previousPositionById.get(association.id);
 		if (oldPosition === undefined) {
@@ -106,41 +99,41 @@ export function reconcileCellAssociations(
 		results[position] = { kind: 'moved', oldId: association.id, newCell: currentCells[newPosition] };
 	});
 
-	// Rescue pass: a tentatively orphaned association whose previous cell
-	// sat in a run of identical cells inherits the aligned cell of an
-	// untracked twin from that run, if one exists. The diff's choice of
-	// which twin was deleted is arbitrary, so prefer the choice that keeps
-	// tracked state alive.
-	const trackedIds = new Set(associations.map(association => association.id));
-	for (const position of orphanedPositions) {
-		const association = associations[position];
-		const oldPosition = previousPositionById.get(association.id)!;
-		const rescued = findUntrackedTwinCell(previousCells, oldPosition, oldToNew, trackedIds, claimedNewPositions);
-		if (rescued !== undefined) {
-			claimedNewPositions.add(rescued);
-			results[position] = { kind: 'moved', oldId: association.id, newCell: currentCells[rescued] };
-		}
-	}
-
-	// Fallback path: associations with no entry in the previous cell list
-	// match by content hash, in id-index order, against unclaimed cells.
-	const fallbackCandidates = new Map<string, number[]>();
+	// Pairing pass: each unmatched association claims an unclaimed current
+	// cell with the same content hash, in previous-position order so
+	// duplicate-hash pairings are deterministic.
+	const unclaimedByHash = new Map<string, number[]>();
 	currentCells.forEach((cell, position) => {
 		if (claimedNewPositions.has(position)) {
 			return;
 		}
-		const candidates = fallbackCandidates.get(cell.contentHash);
+		const candidates = unclaimedByHash.get(cell.contentHash);
 		if (candidates) {
 			candidates.push(position);
 		} else {
-			fallbackCandidates.set(cell.contentHash, [position]);
+			unclaimedByHash.set(cell.contentHash, [position]);
 		}
 	});
+	const orphansByPreviousPosition = [...orphanedPositions].sort((a, b) =>
+		previousPositionById.get(associations[a].id)! - previousPositionById.get(associations[b].id)!);
+	for (const position of orphansByPreviousPosition) {
+		const association = associations[position];
+		const candidates = unclaimedByHash.get(association.contentHash);
+		const newPosition = candidates?.shift();
+		if (newPosition === undefined) {
+			continue;
+		}
+		claimedNewPositions.add(newPosition);
+		results[position] = { kind: 'moved', oldId: association.id, newCell: currentCells[newPosition] };
+	}
+
+	// Fallback path: associations with no previous-cell entry match what
+	// the pairing pass left unclaimed, in id-index order.
 	const orderedFallbacks = [...fallbackPositions].sort((a, b) =>
 		(parsePreviousIndex(associations[a].id) ?? 0) - (parsePreviousIndex(associations[b].id) ?? 0));
 	for (const position of orderedFallbacks) {
 		const association = associations[position];
-		const candidates = fallbackCandidates.get(association.contentHash);
+		const candidates = unclaimedByHash.get(association.contentHash);
 		const newPosition = candidates?.shift();
 		if (newPosition === undefined) {
 			continue;
@@ -154,9 +147,8 @@ export function reconcileCellAssociations(
 }
 
 /**
- * Maps each previous-cell array position to its current array position via
- * an LCS diff of the two content-hash sequences. Positions inside changed
- * regions have no entry.
+ * Maps previous-cell array positions to current ones via an LCS diff of
+ * the content-hash sequences. Positions in changed regions have no entry.
  */
 function alignCellSequences(
 	previousCells: readonly QuartoCodeCell[],
@@ -184,40 +176,6 @@ function alignCellSequences(
 		oldToNew.set(alignedOld, alignedNew++);
 	}
 	return oldToNew;
-}
-
-/**
- * The aligned current position of an untracked twin of the deleted cell at
- * `oldPosition`: another cell from the same maximal run of identical
- * content in `previousCells` that no association tracks and whose aligned
- * cell no result has claimed. `undefined` when no such twin exists.
- */
-function findUntrackedTwinCell(
-	previousCells: readonly QuartoCodeCell[],
-	oldPosition: number,
-	oldToNew: Map<number, number>,
-	trackedIds: ReadonlySet<string>,
-	claimedNewPositions: ReadonlySet<number>,
-): number | undefined {
-	const contentHash = previousCells[oldPosition].contentHash;
-	let runStart = oldPosition;
-	while (runStart > 0 && previousCells[runStart - 1].contentHash === contentHash) {
-		runStart--;
-	}
-	let runEnd = oldPosition;
-	while (runEnd < previousCells.length - 1 && previousCells[runEnd + 1].contentHash === contentHash) {
-		runEnd++;
-	}
-	for (let twin = runStart; twin <= runEnd; twin++) {
-		if (twin === oldPosition || trackedIds.has(previousCells[twin].id)) {
-			continue;
-		}
-		const newPosition = oldToNew.get(twin);
-		if (newPosition !== undefined && !claimedNewPositions.has(newPosition)) {
-			return newPosition;
-		}
-	}
-	return undefined;
 }
 
 /** The leading digits of a cell id are its index; `NaN` becomes "no preference". */

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoCellReconciliation.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoCellReconciliation.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ISequence, LcsDiff } from '../../../../base/common/diff/diff.js';
 import { QuartoCodeCell } from './quartoTypes.js';
 
 /**
@@ -33,106 +34,190 @@ export interface IQuartoCellSource {
 	readonly cells: readonly QuartoCodeCell[];
 }
 
+/** A cell sequence for `LcsDiff`, compared by content hash. */
+class CellHashSequence implements ISequence {
+	private readonly _hashes: string[];
+
+	constructor(cells: readonly QuartoCodeCell[]) {
+		this._hashes = cells.map(cell => cell.contentHash);
+	}
+
+	getElements(): string[] {
+		return this._hashes;
+	}
+}
+
 /**
- * Re-anchors associations to their current cells by content hash, since a
- * stale `id` resolving to *some* cell doesn't prove it resolves to the
- * *same* one: ids embed their index (`{index}-{hashPrefix}-{label}`), so
- * identical-content cells can swap which one an old id names across a shift.
+ * Re-anchors associations to their current cells by aligning the previous
+ * and current cell sequences on content hash. A stale `id` resolving to
+ * *some* cell doesn't prove it resolves to the *same* one: ids embed their
+ * index (`{index}-{hashPrefix}-{label}`), so identical-content cells can
+ * swap which one an old id names across a shift.
  *
- * Within each content-hash group, current cells are ranked by index and
- * associations by how many same-hash siblings preceded them in
- * `previousCells` -- the full cell list from the last update, not just the
- * tracked ones, since tracking is sparse (only cells with a view zone or
- * toolbar get an association). Same-rank pairs match; an association past
- * the end of its group's current cells is `orphaned`. An id missing from
- * `previousCells` (no prior update yet) falls back to the index in its own
- * id instead of a true rank.
+ * The alignment is a whole-document LCS diff over the hash sequences, so an
+ * unchanged cell keeps its association no matter what changed elsewhere in
+ * the document -- including an edit or deletion of a same-content sibling,
+ * which per-hash-group reasoning cannot tell apart from the cell itself
+ * moving. Within a run of identical cells the diff cannot know which twin
+ * was added or removed; when it deems a *tracked* cell deleted while an
+ * untracked twin from the same run survives, the association inherits the
+ * twin's aligned cell rather than being orphaned, since identical content
+ * makes the surviving twin an equally good home for it. (When both twins
+ * are tracked, one orphan is unavoidable -- a cell really did vanish.)
  *
- * Known limitation: rank is fixed from `previousCells` and reused as-is, so
- * if an earlier same-hash cell is itself added or removed (not just shifted)
- * between updates, every later association in that group can be misranked.
- * Fixing this needs a whole-document, anchor-aware alignment (using
- * non-duplicate neighbors to localize where a change happened) rather than
- * per-group ranking; accepted for now.
+ * An association whose id is missing from `previousCells` entirely (no
+ * prior parse recorded) falls back to matching by content hash, in
+ * id-index order, against cells no aligned association claimed.
  */
 export function reconcileCellAssociations(
 	model: IQuartoCellSource,
 	previousCells: readonly QuartoCodeCell[],
 	associations: readonly ICellAssociation[],
 ): CellReconciliation[] {
-	const previousCellsById = new Map<string, QuartoCodeCell>();
-	for (const cell of previousCells) {
-		previousCellsById.set(cell.id, cell);
-	}
+	const currentCells = model.cells;
 
-	const cellsByHash = new Map<string, QuartoCodeCell[]>();
-	for (const cell of model.cells) {
-		const group = cellsByHash.get(cell.contentHash);
-		if (group) {
-			group.push(cell);
-		} else {
-			cellsByHash.set(cell.contentHash, [cell]);
-		}
-	}
+	// Align the two cell sequences; unchanged blocks map an old array
+	// position to its new one.
+	const oldToNew = alignCellSequences(previousCells, currentCells);
 
-	interface GroupEntry {
-		readonly position: number;
-		readonly id: string;
-		/** True rank among all same-hash siblings in `previousCells`, tracked or not; `undefined` if `id` isn't in `previousCells` at all. */
-		readonly trueRank: number | undefined;
-		/** Ordering fallback for when `trueRank` is unavailable: the index embedded in `id`, meaningful only relative to other associations in the same group. */
-		readonly parsedIndex: number;
-	}
+	const previousPositionById = new Map<string, number>();
+	previousCells.forEach((cell, position) => previousPositionById.set(cell.id, position));
 
-	const results: CellReconciliation[] = new Array(associations.length);
-	const groups = new Map<string, GroupEntry[]>();
+	const results: (CellReconciliation | undefined)[] = new Array(associations.length);
+	const claimedNewPositions = new Set<number>();
+	const orphanedPositions: number[] = [];
+	const fallbackPositions: number[] = [];
+
+	// Aligned path: an association whose previous cell still has an aligned
+	// counterpart moves to it; one whose previous cell was deleted (or
+	// edited into different content) is tentatively orphaned.
 	associations.forEach((association, position) => {
-		const previousCell = previousCellsById.get(association.id);
-		const entry: GroupEntry = {
-			position,
-			id: association.id,
-			trueRank: previousCell ? countPrecedingSiblings(previousCells, previousCell) : undefined,
-			parsedIndex: parsePreviousIndex(association.id) ?? 0,
-		};
-		const group = groups.get(association.contentHash);
-		if (group) {
-			group.push(entry);
-		} else {
-			groups.set(association.contentHash, [entry]);
+		const oldPosition = previousPositionById.get(association.id);
+		if (oldPosition === undefined) {
+			fallbackPositions.push(position);
+			return;
 		}
+		const newPosition = oldToNew.get(oldPosition);
+		if (newPosition === undefined) {
+			orphanedPositions.push(position);
+			return;
+		}
+		claimedNewPositions.add(newPosition);
+		results[position] = { kind: 'moved', oldId: association.id, newCell: currentCells[newPosition] };
 	});
 
-	for (const [hash, group] of groups) {
-		const candidates = cellsByHash.get(hash) ?? [];
-		const allRanked = group.every(entry => entry.trueRank !== undefined);
-		const ordered = allRanked
-			? [...group].sort((a, b) => a.trueRank! - b.trueRank!)
-			: [...group].sort((a, b) => a.parsedIndex - b.parsedIndex);
-		ordered.forEach((entry, sequentialIndex) => {
-			const candidateIndex = allRanked ? entry.trueRank! : sequentialIndex;
-			const newCell = candidates[candidateIndex];
-			results[entry.position] = newCell
-				? { kind: 'moved', oldId: entry.id, newCell }
-				: { kind: 'orphaned', id: entry.id };
-		});
+	// Rescue pass: a tentatively orphaned association whose previous cell
+	// sat in a run of identical cells inherits the aligned cell of an
+	// untracked twin from that run, if one exists. The diff's choice of
+	// which twin was deleted is arbitrary, so prefer the choice that keeps
+	// tracked state alive.
+	const trackedIds = new Set(associations.map(association => association.id));
+	for (const position of orphanedPositions) {
+		const association = associations[position];
+		const oldPosition = previousPositionById.get(association.id)!;
+		const rescued = findUntrackedTwinCell(previousCells, oldPosition, oldToNew, trackedIds, claimedNewPositions);
+		if (rescued !== undefined) {
+			claimedNewPositions.add(rescued);
+			results[position] = { kind: 'moved', oldId: association.id, newCell: currentCells[rescued] };
+		}
 	}
 
-	return results;
+	// Fallback path: associations with no entry in the previous cell list
+	// match by content hash, in id-index order, against unclaimed cells.
+	const fallbackCandidates = new Map<string, number[]>();
+	currentCells.forEach((cell, position) => {
+		if (claimedNewPositions.has(position)) {
+			return;
+		}
+		const candidates = fallbackCandidates.get(cell.contentHash);
+		if (candidates) {
+			candidates.push(position);
+		} else {
+			fallbackCandidates.set(cell.contentHash, [position]);
+		}
+	});
+	const orderedFallbacks = [...fallbackPositions].sort((a, b) =>
+		(parsePreviousIndex(associations[a].id) ?? 0) - (parsePreviousIndex(associations[b].id) ?? 0));
+	for (const position of orderedFallbacks) {
+		const association = associations[position];
+		const candidates = fallbackCandidates.get(association.contentHash);
+		const newPosition = candidates?.shift();
+		if (newPosition === undefined) {
+			continue;
+		}
+		results[position] = { kind: 'moved', oldId: association.id, newCell: currentCells[newPosition] };
+	}
+
+	// Anything still unresolved is genuinely orphaned.
+	return associations.map((association, position) =>
+		results[position] ?? { kind: 'orphaned', id: association.id });
 }
 
 /**
- * How many cells sharing `previousCell`'s content hash preceded it in the
- * full previous parse -- its true position among same-content siblings,
- * regardless of which of them were tracked.
+ * Maps each previous-cell array position to its current array position via
+ * an LCS diff of the two content-hash sequences. Positions inside changed
+ * regions have no entry.
  */
-function countPrecedingSiblings(previousCells: readonly QuartoCodeCell[], previousCell: QuartoCodeCell): number {
-	let rank = 0;
-	for (const cell of previousCells) {
-		if (cell.contentHash === previousCell.contentHash && cell.index < previousCell.index) {
-			rank++;
+function alignCellSequences(
+	previousCells: readonly QuartoCodeCell[],
+	currentCells: readonly QuartoCodeCell[],
+): Map<number, number> {
+	const { changes } = new LcsDiff(
+		new CellHashSequence(previousCells),
+		new CellHashSequence(currentCells),
+	).ComputeDiff(false);
+
+	const oldToNew = new Map<number, number>();
+	let oldPosition = 0;
+	let newPosition = 0;
+	for (const change of changes) {
+		// The gap before this change is an unchanged block.
+		let alignedNew = newPosition;
+		for (let alignedOld = oldPosition; alignedOld < change.originalStart; alignedOld++) {
+			oldToNew.set(alignedOld, alignedNew++);
+		}
+		oldPosition = change.originalStart + change.originalLength;
+		newPosition = change.modifiedStart + change.modifiedLength;
+	}
+	let alignedNew = newPosition;
+	for (let alignedOld = oldPosition; alignedOld < previousCells.length; alignedOld++) {
+		oldToNew.set(alignedOld, alignedNew++);
+	}
+	return oldToNew;
+}
+
+/**
+ * The aligned current position of an untracked twin of the deleted cell at
+ * `oldPosition`: another cell from the same maximal run of identical
+ * content in `previousCells` that no association tracks and whose aligned
+ * cell no result has claimed. `undefined` when no such twin exists.
+ */
+function findUntrackedTwinCell(
+	previousCells: readonly QuartoCodeCell[],
+	oldPosition: number,
+	oldToNew: Map<number, number>,
+	trackedIds: ReadonlySet<string>,
+	claimedNewPositions: ReadonlySet<number>,
+): number | undefined {
+	const contentHash = previousCells[oldPosition].contentHash;
+	let runStart = oldPosition;
+	while (runStart > 0 && previousCells[runStart - 1].contentHash === contentHash) {
+		runStart--;
+	}
+	let runEnd = oldPosition;
+	while (runEnd < previousCells.length - 1 && previousCells[runEnd + 1].contentHash === contentHash) {
+		runEnd++;
+	}
+	for (let twin = runStart; twin <= runEnd; twin++) {
+		if (twin === oldPosition || trackedIds.has(previousCells[twin].id)) {
+			continue;
+		}
+		const newPosition = oldToNew.get(twin);
+		if (newPosition !== undefined && !claimedNewPositions.has(newPosition)) {
+			return newPosition;
 		}
 	}
-	return rank;
+	return undefined;
 }
 
 /** The leading digits of a cell id are its index; `NaN` becomes "no preference". */

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoTypes.ts
@@ -147,7 +147,7 @@ export interface QuartoCodeCell {
 	readonly options: string;
 
 	/**
-	 * SHA-256 hash of cell content (first 16 chars).
+	 * SHA-1 hash of cell content (first 16 chars).
 	 * Used for cache matching and cell identification across edits.
 	 */
 	readonly contentHash: string;

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoDocumentModel.vitest.ts
@@ -9,7 +9,7 @@ import { URI } from '../../../../../base/common/uri.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
-import { QuartoDocumentModel } from '../../browser/quartoDocumentModel.js';
+import { QuartoDocumentModel, parseCellId } from '../../browser/quartoDocumentModel.js';
 
 describe('QuartoDocumentModel', () => {
 	const ctx = createTestContainer().build();
@@ -695,4 +695,22 @@ x = 1
 		});
 	});
 
+});
+
+describe('parseCellId', () => {
+	it('extracts the index and hash prefix from a well-formed id', () => {
+		expect(parseCellId('2-a1b2c3d4-unlabeled')).toEqual({ index: 2, hashPrefix: 'a1b2c3d4' });
+	});
+
+	it('extracts the hash prefix even when the label itself contains hyphens', () => {
+		expect(parseCellId('0-a1b2c3d4-my-analysis')).toEqual({ index: 0, hashPrefix: 'a1b2c3d4' });
+	});
+
+	it('returns an undefined index when the id has no parseable leading number', () => {
+		expect(parseCellId('not-a-valid-id')).toEqual({ index: undefined, hashPrefix: 'a' });
+	});
+
+	it('returns an undefined hash prefix when the id has no second segment', () => {
+		expect(parseCellId('5')).toEqual({ index: 5, hashPrefix: undefined });
+	});
 });

--- a/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellReconciliation.vitest.ts
@@ -168,6 +168,105 @@ describe('reconcileCellAssociations', () => {
 		]);
 	});
 
+	it('keeps associations on reordered cells with unique content', () => {
+		// Reordering looks like deletion plus insertion to the diff: the
+		// moved cell's hash still exists, just at a new position, so its
+		// association must follow it rather than being orphaned.
+		const previousCells = [cell(0, 'a'), cell(1, 'b'), cell(2, 'c')];
+		const model = source(cell(0, 'b'), cell(1, 'c'), cell(2, 'a'));
+
+		const results = reconcileCellAssociations(model, previousCells, [
+			{ id: '0-a-unlabeled', contentHash: 'a' },
+			{ id: '1-b-unlabeled', contentHash: 'b' },
+			{ id: '2-c-unlabeled', contentHash: 'c' },
+		]);
+
+		expect(results).toEqual([
+			{ kind: 'moved', oldId: '0-a-unlabeled', newCell: cell(2, 'a') },
+			{ kind: 'moved', oldId: '1-b-unlabeled', newCell: cell(0, 'b') },
+			{ kind: 'moved', oldId: '2-c-unlabeled', newCell: cell(1, 'c') },
+		]);
+	});
+
+	it('keeps associations through a two-cell swap', () => {
+		const previousCells = [cell(0, 'a'), cell(1, 'b')];
+		const model = source(cell(0, 'b'), cell(1, 'a'));
+
+		const results = reconcileCellAssociations(model, previousCells, [
+			{ id: '0-a-unlabeled', contentHash: 'a' },
+			{ id: '1-b-unlabeled', contentHash: 'b' },
+		]);
+
+		expect(results).toEqual([
+			{ kind: 'moved', oldId: '0-a-unlabeled', newCell: cell(1, 'a') },
+			{ kind: 'moved', oldId: '1-b-unlabeled', newCell: cell(0, 'b') },
+		]);
+	});
+
+	it('orphans a deleted cell while tracking a moved one in the same parse', () => {
+		const previousCells = [cell(0, 'a'), cell(1, 'b'), cell(2, 'c')];
+		const model = source(cell(0, 'c'), cell(1, 'a'));
+
+		const results = reconcileCellAssociations(model, previousCells, [
+			{ id: '0-a-unlabeled', contentHash: 'a' },
+			{ id: '1-b-unlabeled', contentHash: 'b' },
+			{ id: '2-c-unlabeled', contentHash: 'c' },
+		]);
+
+		expect(results).toEqual([
+			{ kind: 'moved', oldId: '0-a-unlabeled', newCell: cell(1, 'a') },
+			{ kind: 'orphaned', id: '1-b-unlabeled' },
+			{ kind: 'moved', oldId: '2-c-unlabeled', newCell: cell(0, 'c') },
+		]);
+	});
+
+	it('keeps an association on a non-adjacent identical cell when its own cell is deleted', () => {
+		// The surviving duplicate is not contiguous with the tracked one in
+		// the previous cell list, and the diff aligns it with the untracked
+		// first duplicate -- but the tracked association should still
+		// inherit it rather than lose its output.
+		const previousCells = [cell(0, 'dup'), cell(1, 'middle'), cell(2, 'dup')];
+		const model = source(cell(0, 'dup'));
+
+		const [result] = reconcileCellAssociations(model, previousCells, [
+			{ id: '2-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: '2-dup-unlabeled', newCell: cell(0, 'dup') });
+	});
+
+	it('transfers an association to a distant identical survivor when the tracked cell is deleted', () => {
+		// Only the trailing duplicate was tracked; deleting it leaves the
+		// untracked leading duplicate. Identical content makes the survivor
+		// an equally good home for the association (the on-disk output
+		// cache is keyed by content hash for the same reason).
+		const previousCells = [cell(0, 'dup'), cell(1, 'middle'), cell(2, 'dup')];
+		const model = source(cell(0, 'dup'), cell(1, 'middle'));
+
+		const [result] = reconcileCellAssociations(model, previousCells, [
+			{ id: '2-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: '2-dup-unlabeled', newCell: cell(0, 'dup') });
+	});
+
+	it('still orphans a deleted duplicate when every identical survivor is itself tracked', () => {
+		// One orphan is unavoidable here: a cell really did vanish, and the
+		// survivor's own association already claims it.
+		const previousCells = [cell(0, 'dup'), cell(1, 'middle'), cell(2, 'dup')];
+		const model = source(cell(0, 'dup'), cell(1, 'middle'));
+
+		const results = reconcileCellAssociations(model, previousCells, [
+			{ id: '0-dup-unlabeled', contentHash: 'dup' },
+			{ id: '2-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(results).toEqual([
+			{ kind: 'moved', oldId: '0-dup-unlabeled', newCell: cell(0, 'dup') },
+			{ kind: 'orphaned', id: '2-dup-unlabeled' },
+		]);
+	});
+
 	it('falls back to the id-embedded index when the association is not in the previous cell list', () => {
 		// No previous-cell history yet (e.g. the very first reconciliation
 		// pass) -- falls back to the index parsed from the id, same as before

--- a/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellReconciliation.vitest.ts
@@ -117,6 +117,57 @@ describe('reconcileCellAssociations', () => {
 		expect(result).toEqual({ kind: 'moved', oldId: '1-dup-unlabeled', newCell: cell(2, 'dup') });
 	});
 
+	it('keeps a surviving duplicate\'s association when its twin is edited', () => {
+		// Two identical cells, only the second tracked. Editing the FIRST
+		// cell shrinks the hash group to one candidate; matching that ranks
+		// associations within the group would read the survivor's stale rank
+		// (1) as out of bounds and orphan it, dropping its output, even
+		// though the tracked cell itself never changed.
+		const previousCells = [cell(0, 'dup'), cell(1, 'dup')];
+		const model = source(cell(0, 'edited'), cell(1, 'dup'));
+
+		const [result] = reconcileCellAssociations(model, previousCells, [
+			{ id: '1-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: '1-dup-unlabeled', newCell: cell(1, 'dup') });
+	});
+
+	it('keeps a surviving duplicate\'s association when its twin is deleted', () => {
+		// Same scenario, but the first cell is deleted outright. The diff
+		// cannot tell which identical twin vanished, so it aligns the
+		// untracked first cell onto the survivor; the tracked association
+		// inherits that cell rather than being orphaned and losing its
+		// output.
+		const previousCells = [cell(0, 'dup'), cell(1, 'dup')];
+		const model = source(cell(0, 'dup'));
+
+		const [result] = reconcileCellAssociations(model, previousCells, [
+			{ id: '1-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: '1-dup-unlabeled', newCell: cell(0, 'dup') });
+	});
+
+	it('tracks cells across edits in disjoint regions of the same parse', () => {
+		// An edit near the top and a deletion near the bottom landing in one
+		// parse (a multi-cell paste, an undo of a multi-part edit). Matching
+		// in from both ends only would widen the whole middle into one
+		// changed region and orphan everything in it.
+		const previousCells = [cell(0, 'a'), cell(1, 'dup'), cell(2, 'dup'), cell(3, 'b')];
+		const model = source(cell(0, 'a2'), cell(1, 'dup'), cell(2, 'dup'));
+
+		const results = reconcileCellAssociations(model, previousCells, [
+			{ id: '1-dup-unlabeled', contentHash: 'dup' },
+			{ id: '2-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(results).toEqual([
+			{ kind: 'moved', oldId: '1-dup-unlabeled', newCell: cell(1, 'dup') },
+			{ kind: 'moved', oldId: '2-dup-unlabeled', newCell: cell(2, 'dup') },
+		]);
+	});
+
 	it('falls back to the id-embedded index when the association is not in the previous cell list', () => {
 		// No previous-cell history yet (e.g. the very first reconciliation
 		// pass) -- falls back to the index parsed from the id, same as before

--- a/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellReconciliation.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/common/quartoCellReconciliation.vitest.ts
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { QuartoCodeCell } from '../../common/quartoTypes.js';
+import { IQuartoCellSource, reconcileCellAssociations } from '../../common/quartoCellReconciliation.js';
+
+function cell(index: number, contentHash: string): QuartoCodeCell {
+	return {
+		id: `${index}-${contentHash.substring(0, 8)}-unlabeled`,
+		language: 'r',
+		startLine: 1,
+		endLine: 1,
+		codeStartLine: 2,
+		codeEndLine: 2,
+		options: '',
+		contentHash,
+		index,
+	};
+}
+
+function source(...cells: readonly QuartoCodeCell[]): IQuartoCellSource {
+	return { cells };
+}
+
+describe('reconcileCellAssociations', () => {
+	it('keeps an association on its own cell when nothing changed', () => {
+		const model = source(cell(0, 'hash'));
+
+		const [result] = reconcileCellAssociations(model, [cell(0, 'hash')], [
+			{ id: '0-hash-unlabeled', contentHash: 'hash' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: '0-hash-unlabeled', newCell: cell(0, 'hash') });
+	});
+
+	it('resolves a moved cell via content hash when no other cell shares it', () => {
+		const model = source(cell(3, 'hash'));
+
+		const [result] = reconcileCellAssociations(model, [cell(2, 'hash')], [
+			{ id: '2-hash-unlabeled', contentHash: 'hash' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: '2-hash-unlabeled', newCell: cell(3, 'hash') });
+	});
+
+	it('orphans an association whose content hash matches no current cell', () => {
+		const model = source(cell(0, 'other'));
+
+		const [result] = reconcileCellAssociations(model, [cell(0, 'hash')], [
+			{ id: '0-hash-unlabeled', contentHash: 'hash' },
+		]);
+
+		expect(result).toEqual({ kind: 'orphaned', id: '0-hash-unlabeled' });
+	});
+
+	it('pairs several stale associations sharing a content hash with current cells in index order', () => {
+		// Insert a distinct cell before two identical unlabeled cells. Both
+		// duplicates shift down by one, and the second duplicate's *old* id
+		// now happens to equal the *first* duplicate's *new* id. An
+		// id-equality check alone would wrongly treat the second association
+		// as still valid, bound to the first duplicate's cell, leaving the
+		// first association nothing to resolve to but a false "orphaned".
+		// Both were fully tracked before the edit, so the previous cell list
+		// already reflects their true relative order.
+		const previousCells = [cell(0, 'dup'), cell(1, 'dup')];
+		const model = source(cell(0, 'distinct'), cell(1, 'dup'), cell(2, 'dup'));
+
+		const results = reconcileCellAssociations(model, previousCells, [
+			{ id: '0-dup-unlabeled', contentHash: 'dup' },
+			{ id: '1-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(results).toEqual([
+			{ kind: 'moved', oldId: '0-dup-unlabeled', newCell: cell(1, 'dup') },
+			{ kind: 'moved', oldId: '1-dup-unlabeled', newCell: cell(2, 'dup') },
+		]);
+	});
+
+	it('orphans the excess association when fewer current cells share a hash than associations do', () => {
+		// Three duplicate-content associations, but one of the three cells was
+		// genuinely deleted: only two candidates remain for three claimants.
+		const previousCells = [cell(0, 'dup'), cell(1, 'dup'), cell(2, 'dup')];
+		const model = source(cell(0, 'dup'), cell(1, 'dup'));
+
+		const results = reconcileCellAssociations(model, previousCells, [
+			{ id: '0-dup-unlabeled', contentHash: 'dup' },
+			{ id: '1-dup-unlabeled', contentHash: 'dup' },
+			{ id: '2-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(results).toEqual([
+			{ kind: 'moved', oldId: '0-dup-unlabeled', newCell: cell(0, 'dup') },
+			{ kind: 'moved', oldId: '1-dup-unlabeled', newCell: cell(1, 'dup') },
+			{ kind: 'orphaned', id: '2-dup-unlabeled' },
+		]);
+	});
+
+	it('uses the previous cell list to rank a sparsely-tracked association among untracked siblings', () => {
+		// Only the SECOND of two identical cells has an association (e.g. only
+		// it ever produced output); the first was never tracked. Insert a
+		// distinct cell above both. Ranking the lone association among only
+		// the *tracked* siblings would treat it as rank 0 and wrongly resolve
+		// it to the first duplicate's new position. The previous cell list
+		// (which includes the untracked first duplicate) reveals its true
+		// rank is 1, resolving it to the second duplicate's new position.
+		const previousCells = [cell(0, 'dup'), cell(1, 'dup')]; // both existed; only index 1 was tracked
+		const model = source(cell(0, 'distinct'), cell(1, 'dup'), cell(2, 'dup'));
+
+		const [result] = reconcileCellAssociations(model, previousCells, [
+			{ id: '1-dup-unlabeled', contentHash: 'dup' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: '1-dup-unlabeled', newCell: cell(2, 'dup') });
+	});
+
+	it('falls back to the id-embedded index when the association is not in the previous cell list', () => {
+		// No previous-cell history yet (e.g. the very first reconciliation
+		// pass) -- falls back to the index parsed from the id, same as before
+		// previous-cell tracking existed.
+		const model = source(cell(0, 'hash'));
+
+		const [result] = reconcileCellAssociations(model, [], [
+			{ id: '2-hash-unlabeled', contentHash: 'hash' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: '2-hash-unlabeled', newCell: cell(0, 'hash') });
+	});
+
+	it('does not throw on an id with no parseable index, and still matches by hash alone', () => {
+		const model = source(cell(0, 'hash'));
+
+		const [result] = reconcileCellAssociations(model, [], [
+			{ id: 'not-a-valid-id', contentHash: 'hash' },
+		]);
+
+		expect(result).toEqual({ kind: 'moved', oldId: 'not-a-valid-id', newCell: cell(0, 'hash') });
+	});
+});


### PR DESCRIPTION
Fixes #15792

This PR consolidates Quarto cell-continuity matching (reconstructing which cell is which across a reparse, once cell IDs have changed) into one shared helper, `reconcileCellAssociations` (`common/quartoCellReconciliation.ts`), used by both the inline-output view zones (`quartoOutputManager.ts`) and the cell toolbars (`quartoCellToolbarController.ts`). This replaces two independent inline implementations and fixes a bug in the toolbar one, whose last-writer-wins hash map could remap a toolbar to the wrong cell or dispose it as a false orphan when two cells shared a content hash.

Also shares one cell-ID parser (`parseCellId()`, exported next to `generateCellId()`) in place of two ad hoc `split('-')` call sites, and fixes the `contentHash` doc comment (SHA-1 truncated to 16 chars, not SHA-256).

> [!NOTE]  
> The audit posted on #15792 corrected that issue's original premise: cell identity (IDs, content hashes) was **already centralized** in `quartoDocumentModel.ts`, so there was no cache-drift risk between the virtual notebook and the output cache to fix. Nothing in this PR consolidates anything between the new virtual notebook for Quarto and the `.ipynb` representation for inline output.

The real duplication that I found was just cell-continuity matching, which is what this PR consolidates. Not consolidated here, deliberately:

- The virtual notebook's prefix/suffix splice (text-model handle stability, a different cost model)
- The output cache's on-disk cross-session matching (a problem no in-memory consumer has)
- The two `.ipynb` representations themselves (in-memory vs. always-on persistence)

### How reconciliation works now (the part to review)

A stale cell ID resolving to *some* cell doesn't prove it resolves to the *same* cell, so the helper re-anchors associations in three passes:

1. **Align** the previous and current content-hash sequences with a whole-document LCS diff (`LcsDiff` from `vs/base/common/diff`). An unchanged cell keeps its association no matter what changed elsewhere, including edits or deletions of same-content siblings.
2. **Pair** whatever is left: an unmatched association claims any unclaimed current cell with the same content hash, in previous-position order. The diff reads a reorder as delete-plus-insert, and which of several identical cells it deems deleted is arbitrary, so prefer the outcome that keeps tracked state alive. Identical content makes any survivor an equally good home (the on-disk output cache is keyed by content hash for the same reason).
3. **Fallback** for associations with no previous-parse record at all: same hash matching, in id-index order.

An association is orphaned only when every same-content survivor is claimed by another association, i.e. a cell really did vanish. Within a run of byte-identical cells, which instance was added or removed is fundamentally unknowable; that residual ambiguity is accepted and documented in the function's doc comment.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix Quarto inline cell outputs and cell toolbars losing track of their cells (outputs disappearing or attaching to the wrong cell) when cells with identical content are edited, deleted, moved, or reordered (#15792)

### Validation Steps

@:quarto

Unit: `npx vitest --run src/vs/workbench/contrib/positronQuarto` (427 tests, including 17 reconciliation regression tests covering duplicate-content edits and deletions, adjacent and non-adjacent, reorders, swaps, mixed delete-plus-move parses, and multi-region edits in a single parse).

Manual:

1. Open a `.qmd` and create two cells with identical content.
2. Run the second cell so it shows inline output.
3. Edit or delete the *first* cell. The second cell's output should survive in place.
4. Move a cell with output to elsewhere in the document (cut/paste). The output and cell toolbar should follow it.
5. Insert a new cell above cells with output. Outputs should stay with their cells.