### PR TITLE
Fix welcome page scrolling after content changes

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1215,6 +1215,7 @@ export class GettingStartedPage extends EditorPane {
 				this.registerDispatchListeners();
 				this.categoriesPageScrollbar?.scanDomNode();
 			},
+			onDidChangeContentSize: () => this.categoriesPageScrollbar?.scanDomNode(),
 		});
 
 		return reactHost;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePage/positronWelcomePage.tsx
@@ -10,6 +10,7 @@ import './positronWelcomePage.css';
 import { useEffect } from 'react';
 
 // Other dependencies.
+import { DisposableResizeObserver, getWindow } from '../../../../../base/browser/dom.js';
 import { PositronReactRenderer } from '../../../../../base/browser/positronReactRenderer.js';
 import { DomSlot } from './components/domSlot.js';
 import { EnvironmentHealthSection } from './components/environmentHealthSection.js';
@@ -60,6 +61,12 @@ export interface PositronWelcomePageProps {
 	 * has mounted them.
 	 */
 	readonly onDidMount: () => void;
+
+	/**
+	 * Called whenever the rendered page changes size. The editor pane uses this
+	 * to update the dimensions cached by its scrollbar.
+	 */
+	readonly onDidChangeContentSize: () => void;
 }
 
 /**
@@ -100,10 +107,19 @@ export const PositronWelcomePage = (props: PositronWelcomePageProps) => {
  */
 export const createPositronWelcomePage = (
 	container: HTMLElement,
-	props: PositronWelcomePageProps
+	props: PositronWelcomePageProps,
+	resizeObserverCtor: typeof ResizeObserver = getWindow(container).ResizeObserver
 ): PositronReactRenderer => {
 	container.classList.add('positron-welcome-page');
 	const renderer = new PositronReactRenderer(container);
+	const resizeObserver = new DisposableResizeObserver(
+		'PositronWelcomePage.contentSize',
+		props.onDidChangeContentSize,
+		getWindow(container),
+		{ resizeObserverCtor }
+	);
+	renderer.register(resizeObserver);
+	renderer.register(resizeObserver.observe(container));
 	renderer.render(<PositronWelcomePage {...props} />);
 	return renderer;
 };

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/positronWelcomePage.vitest.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/positronWelcomePage.vitest.tsx
@@ -16,6 +16,24 @@ import { IResolvedWalkthrough, IWalkthroughsService } from '../../browser/gettin
 import { IEnvironmentHealthService } from '../../browser/positronWelcomePage/environmentHealthService.js';
 import { createPositronWelcomePage, PositronWelcomePage } from '../../browser/positronWelcomePage/positronWelcomePage.js';
 
+class FakeResizeObserver implements ResizeObserver {
+	public static instances: FakeResizeObserver[] = [];
+
+	private readonly callback: ResizeObserverCallback;
+	public readonly disconnect = vi.fn();
+	public readonly observe = vi.fn();
+	public readonly unobserve = vi.fn();
+
+	constructor(callback: ResizeObserverCallback) {
+		this.callback = callback;
+		FakeResizeObserver.instances.push(this);
+	}
+
+	public resize(): void {
+		this.callback([], this);
+	}
+}
+
 /**
  * The page renders the walkthrough banner, which reads this service. One
  * walkthrough with no `when` clause is what the real window always has, so the
@@ -80,6 +98,7 @@ describe('PositronWelcomePage', () => {
 				environmentHealthService={environmentHealthService} expandedByLanguage={new Map()}
 				footer={footer}
 				recentList={recentList}
+				onDidChangeContentSize={vi.fn()}
 				onDidMount={vi.fn()}
 			/>
 		);
@@ -90,7 +109,7 @@ describe('PositronWelcomePage', () => {
 	it('omits the connect action when there is none, as on web', () => {
 		const { recentList, footer } = slottedDom();
 		rtl.render(
-			<PositronWelcomePage environmentHealthService={environmentHealthService} expandedByLanguage={new Map()} footer={footer} recentList={recentList} onDidMount={vi.fn()} />
+			<PositronWelcomePage environmentHealthService={environmentHealthService} expandedByLanguage={new Map()} footer={footer} recentList={recentList} onDidChangeContentSize={vi.fn()} onDidMount={vi.fn()} />
 		);
 
 		expect(screen.queryByText('Connect to...')).not.toBeInTheDocument();
@@ -113,6 +132,7 @@ describe('PositronWelcomePage', () => {
 				environmentHealthService={environmentHealthService} expandedByLanguage={new Map()}
 				footer={footer}
 				recentList={recentList}
+				onDidChangeContentSize={vi.fn()}
 				onDidMount={onDidMount}
 			/>
 		);
@@ -131,6 +151,7 @@ describe('createPositronWelcomePage', () => {
 		.build();
 
 	beforeEach(() => {
+		FakeResizeObserver.instances = [];
 		// createPositronWelcomePage builds its own PositronReactRenderer, whose
 		// provider reads this singleton rather than taking services as an
 		// argument. Nothing else can reach into that renderer to supply them.
@@ -141,12 +162,16 @@ describe('createPositronWelcomePage', () => {
 		PositronReactServices.services = undefined!;
 	});
 
-	const renderInto = (container: HTMLElement) => {
+	const renderInto = (container: HTMLElement, onDidChangeContentSize = vi.fn()) => {
 		const recentList = document.createElement('div');
 		recentList.textContent = 'Recent';
 		const footer = document.createElement('div');
 
-		return createPositronWelcomePage(container, { environmentHealthService, expandedByLanguage: new Map(), recentList, footer, onDidMount: vi.fn() });
+		return createPositronWelcomePage(
+			container,
+			{ environmentHealthService, expandedByLanguage: new Map(), recentList, footer, onDidMount: vi.fn(), onDidChangeContentSize },
+			FakeResizeObserver
+		);
 	};
 
 	it('makes the container the page layout element', () => {
@@ -157,6 +182,27 @@ describe('createPositronWelcomePage', () => {
 		expect(container).toHaveClass('positron-welcome-page');
 
 		renderer.dispose();
+	});
+
+	it('reports page size changes and disconnects the observer when disposed', () => {
+		const container = document.createElement('div');
+		const onDidChangeContentSize = vi.fn();
+		const renderer = renderInto(container, onDidChangeContentSize);
+		const observer = FakeResizeObserver.instances[0];
+
+		observer.resize();
+		expect({
+			callbackCount: onDidChangeContentSize.mock.calls.length,
+			observedElements: observer.observe.mock.calls.map(call => call[0]),
+			disconnected: observer.disconnect.mock.calls.length,
+		}).toEqual({
+			callbackCount: 1,
+			observedElements: [container],
+			disconnected: 0,
+		});
+
+		renderer.dispose();
+		expect(observer.disconnect).toHaveBeenCalledOnce();
 	});
 
 	it('unmounts the page when the renderer is disposed', async () => {


### PR DESCRIPTION
Fixes #15989

This PR fixes the welcome page scrollbar becoming stale when dynamically rendered content changes height. The page now remeasures its content and updates the scrollbar whenever environment checks, expandable sections, or other dynamic content change its height.

The resize observer is tied to the welcome page's lifecycle, so it is disconnected whenever the page is rebuilt or closed.

### Screenshots

**BEFORE**

https://github.com/user-attachments/assets/275d6d56-db70-4eb3-af7a-61d8ca6e9a21

**AFTER**

https://github.com/user-attachments/assets/791bdf65-e26a-4d02-a9d0-89af2acdc951

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed welcome page controls becoming unreachable after expanding environment setup details (#15989)

### Validation Steps

@:welcome

Manual:

1. Open the welcome page in a window short enough for the page to scroll.
2. Scroll to the bottom and confirm the startup checkbox is visible.
3. Expand a successful R or Python environment setup group.
4. Confirm the scrollbar updates and the startup checkbox remains reachable.
5. Collapse the group and confirm the scrollbar range shrinks without excess blank space.
