### PR TITLE
e2e(redshift): select the User & Password connection mechanism before configuring

### DIFF
--- a/test/e2e/tests/data-connections/redshift.test.ts
+++ b/test/e2e/tests/data-connections/redshift.test.ts
@@ -86,7 +86,7 @@ test.describe('Data Connections - Redshift', {
 		await dataConnections.openDataConnectionsView();
 		await dataConnections.clickAddConnection();
 		await dataConnections.selectProvider('Redshift');
-		await dataConnections.selectConnectionMechanism('Use & Password');
+		await dataConnections.selectConnectionMechanism('User & Password');
 
 		// SSL is left on (the default), which the serverless endpoint requires.
 		await dataConnections.fillConnectionInputs({

--- a/test/e2e/tests/data-connections/redshift.test.ts
+++ b/test/e2e/tests/data-connections/redshift.test.ts
@@ -86,9 +86,9 @@ test.describe('Data Connections - Redshift', {
 		await dataConnections.openDataConnectionsView();
 		await dataConnections.clickAddConnection();
 		await dataConnections.selectProvider('Redshift');
-		// Redshift exposes a single connection mechanism (User & Password), so the flow advances
-		// straight to the configure step without a mechanism-selection dialog. SSL is left on (the
-		// default), which the serverless endpoint requires.
+		await dataConnections.selectConnectionMechanism('Use & Password');
+
+		// SSL is left on (the default), which the serverless endpoint requires.
 		await dataConnections.fillConnectionInputs({
 			'Connection Name': connectionName,
 			'Host': host,


### PR DESCRIPTION
Repairs the Redshift data connections e2e suite, which has been failing since #15956.

That PR added AWS IAM as a second connection mechanism for the Redshift driver. Redshift previously exposed only User & Password, so the new-connection flow advanced straight from provider selection to the configure step, and the test relied on that. With two mechanisms the flow now stops at a mechanism-selection step, and the test's next action -- filling the connection inputs -- had nothing to fill.

The fix is a one-line addition to the suite's `beforeAll`: select **User & Password** after picking the Redshift provider, before filling in the host, port, database, user, and password. The stale comment explaining why no mechanism selection was needed is replaced with the call itself; the note about leaving SSL on (which the serverless endpoint requires) is kept.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:web @:win @:connections @:workbench

The Redshift suite needs `REDSHIFT_TEST_HOST` / `REDSHIFT_TEST_USERNAME` / `REDSHIFT_TEST_PASSWORD` and Tailscale access to the private serverless workgroup; it skips itself where those aren't provisioned. On a rig that has them, confirm `test/e2e/tests/data-connections/redshift.test.ts` gets past `beforeAll` and all three tests pass:

npx playwright test test/e2e/tests/data-connections/redshift.test.ts --project e2e-electron

🤖 Generated with [Claude Code](https://claude.com/claude-code)
