### PR TITLE
temp: Measure console exec times

### DIFF
--- a/.github/workflows/test-e2e-console-timing.yml
+++ b/.github/workflows/test-e2e-console-timing.yml
@@ -1,0 +1,368 @@
+name: "Test: E2E Console Execution Timing (Ubuntu)"
+
+# Focused entry point for the console-execution latency investigation
+# (posit-dev/positron#15466). Runs one spec on one worker and collects a
+# correlated timeline across the harness, renderer, extension host and Ark.
+#
+# Runner and container match test-e2e-ubuntu.yml deliberately: a faster runner
+# would shorten iteration at the cost of the behaviour being measured. Two
+# things the production lane has are absent here, and both are recorded in the
+# run manifest as deviations rather than being treated as equivalent: the
+# postgres service container and the 1Password/AWS credential steps. Trimming
+# concurrent load can itself change the measurement, so a run that fails to
+# reproduce the signal must be compared against the full lane before concluding
+# the signal is gone.
+#
+# Metric upload is suppressed by POSITRON_PERF_TRACE_DIR (see
+# test/e2e/utils/metrics/api.ts), so these samples never reach the dashboard.
+
+on:
+  # Added to run this via an unmerged PR instead of workflow_dispatch, which
+  # GitHub only allows once a workflow file exists on the default branch.
+  # `pull_request` has no equivalent restriction: it runs the head branch's
+  # own copy of the file. Values below are hardcoded for this event since
+  # `pull_request` carries no `inputs` context to read from.
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      samples:
+        required: false
+        description: "Samples per arm. Each is a separate Playwright invocation, so each gets a fresh app and session lifecycle. 1 to smoke, 10 to compare."
+        default: 1
+        type: number
+      ark_ref:
+        required: false
+        description: "Ark git ref to build from source and run against. Leave blank to use the binary the extension downloads."
+        default: ""
+        type: string
+      arm_label:
+        required: false
+        description: "Label for this arm, recorded in the manifest so paired runs can be joined."
+        default: "baseline"
+        type: string
+      trace:
+        required: false
+        description: "Collect timing markers. Turn off for an overhead comparison against the same commit."
+        default: true
+        type: boolean
+
+# A new push measures new code, so the run in flight is stale rather than
+# something to keep alongside it.
+concurrency:
+  group: console-timing-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+jobs:
+  console-timing:
+    name: console-timing
+    timeout-minutes: 150
+    runs-on: ubuntu-latest-8x
+    container:
+      image: ghcr.io/posit-dev/positron-ubuntu24:24.18.0
+      options: --user 0:0 --init
+      credentials:
+        username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+        password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      POSITRON_BUILD_NUMBER: 0
+      HOME: /root
+      R_LIBS_SITE: /usr/local/lib/R/site-library
+      R_LIBS_USER: /usr/local/lib/R/site-library
+      RETICULATE_PYTHON: /root/.venv/bin/python
+      SPEC: test/e2e/tests/console/performance/console-code-execution.test.ts
+      # Lower this to 1 for a smoke run that proves the pipeline before spending
+      # a full lane on it. The Ark build cache is keyed on the Ark commit, so the
+      # run after a smoke run skips the expensive part.
+      SAMPLES: ${{ github.event_name == 'pull_request' && 10 || inputs.samples }}
+      TRACE_DIR: ${{ github.workspace }}/perf-trace
+      ARTIFACT_NAME: console-timing-${{ github.event_name == 'pull_request' && 'r-vs-python' || inputs.arm_label }}
+
+    steps:
+      - name: Record setup start
+        run: echo "SETUP_START=$(date +%s)" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: 📦 Restore caches
+        id: restore-caches
+        uses: ./.github/actions/restore-build-caches
+
+      - name: Install node dependencies
+        if: steps.restore-caches.outputs.cache-npm-core-hit != 'true' ||
+            steps.restore-caches.outputs.cache-npm-extensions-volatile-hit != 'true' ||
+            steps.restore-caches.outputs.cache-npm-extensions-stable-hit != 'true'
+        uses: nick-fields/retry@v4
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          POSITRON_GITHUB_RO_PAT: ${{ github.token }}
+          POSITRON_PARALLEL_INSTALL: '0'
+          POSITRON_NPM_CONCURRENCY: '10'
+          NPM_CONFIG_AUDIT: 'false'
+          NPM_CONFIG_FUND: 'false'
+          NPM_CONFIG_UPDATE_NOTIFIER: 'false'
+          NPM_CONFIG_DEVDIR: '.node-gyp-cache'
+          DOCKER_CONFIG: /tmp/.docker
+          POSITRON_EXTENSIONS_FILTER: ${{ (steps.restore-caches.outputs.cache-npm-extensions-volatile-hit == 'true' && steps.restore-caches.outputs.cache-npm-extensions-stable-hit != 'true' && 'stable') || (steps.restore-caches.outputs.cache-npm-extensions-volatile-hit != 'true' && steps.restore-caches.outputs.cache-npm-extensions-stable-hit == 'true' && 'volatile') || '' }}
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 5
+          shell: bash
+          command: bash scripts/install-npm-parallel.sh
+
+      - name: Download binaries (Ark, Kallichore)
+        uses: ./.github/actions/download-binaries
+        with:
+          cache-hit: ${{ steps.restore-caches.outputs.cache-npm-extensions-volatile-hit == 'true' ||
+                         steps.restore-caches.outputs.cache-npm-extensions-stable-hit == 'true' }}
+
+      # A submodule build outranks the downloaded binary in getArkKernelPath(),
+      # so building here is what actually swaps the kernel. Overwriting
+      # resources/ark/ark instead would be silently ignored.
+      - name: Check out requested Ark ref
+        if: ${{ github.event_name == 'pull_request' || inputs.ark_ref != '' }}
+        working-directory: extensions/positron-r/ark
+        run: |
+          git fetch origin "${{ github.event_name == 'pull_request' && 'perf' || inputs.ark_ref }}" --depth 1
+          git checkout FETCH_HEAD
+          echo "ARK_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      # Keyed on the Ark commit alone, and kept out of the Oak runtime cache the
+      # experiment controls, so alternating arms never rebuild identical artifacts.
+      - name: Cache Ark build
+        if: ${{ github.event_name == 'pull_request' || inputs.ark_ref != '' }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            extensions/positron-r/ark/target
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ark-timing-${{ runner.os }}-${{ env.ARK_SHA }}
+          restore-keys: ark-timing-${{ runner.os }}-
+
+      - name: Build Ark
+        if: ${{ github.event_name == 'pull_request' || inputs.ark_ref != '' }}
+        working-directory: extensions/positron-r/ark
+        run: cargo build --release
+
+      - name: Install E2E test dependencies
+        run: npm --prefix test/e2e ci --prefer-offline --no-audit --no-fund
+
+      - name: Compile Positron and Download Electron
+        run: npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron x64"
+
+      - name: Install Playwright browsers
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: .playwright-browsers
+        run: npx playwright install
+
+      - name: Prelaunch
+        run: npm run prelaunch
+
+      # After Prelaunch, which re-extracts Electron and resets permissions.
+      - name: Set permissions on SUID sandbox helper
+        run: |
+          ELECTRON_ROOT=.build/electron
+          sudo chown root $ELECTRON_ROOT/chrome-sandbox
+          sudo chmod 4755 $ELECTRON_ROOT/chrome-sandbox
+          stat $ELECTRON_ROOT/chrome-sandbox
+
+      - name: Compile E2E tests
+        run: npm --prefix test/e2e run compile
+
+      - name: Setup Xvfb
+        uses: ./.github/actions/setup-xvfb
+
+      - name: Alter AppArmor Restrictions for Playwright
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Record setup end
+        run: |
+          echo "SETUP_END=$(date +%s)" >> $GITHUB_ENV
+          mkdir -p "${TRACE_DIR}"
+
+      - name: 🧪 Run console timing spec
+        id: run-spec
+        shell: bash
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: .playwright-browsers
+          POSITRON_PY_VER_SEL: "3.10.12"
+          POSITRON_R_VER_SEL: 4.5.2
+          POSITRON_PY_ALT_VER_SEL: "3.13.0"
+          POSITRON_R_ALT_VER_SEL: 4.4.2
+          POSITRON_HIDDEN_PY: "3.12.10 (Conda)"
+          POSITRON_HIDDEN_R: 4.4.1
+          PW_JSON_FILE: test-results/console-timing.json
+          # Deliberately absent: CONNECT_API_KEY. Nothing here should publish.
+          POSITRON_PERF_TRACE_DIR: ${{ (github.event_name == 'pull_request' || inputs.trace) && env.TRACE_DIR || '' }}
+          POSITRON_PERF_TRACE_RUN_ID: ${{ github.run_id }}-${{ github.event_name == 'pull_request' && 'r-vs-python' || inputs.arm_label }}
+        run: |
+          echo "TEST_START=$(date +%s)" >> $GITHUB_ENV
+          # One Playwright invocation per sample, rather than --repeat-each.
+          # The app and sessions are worker-scoped, so a repetition would run
+          # the same expression into the same warm console: that breaks the
+          # spec's exact-count assertion and measures a different experiment.
+          # A fresh invocation gives the fresh app and session lifecycle the
+          # comparison needs.
+          #
+          # All four cases run in their declared order. Grepping down to one
+          # case would change the preceding workload and could remove the
+          # effect being looked for.
+          samples="${SAMPLES}"
+          failed=0
+          for i in $(seq 1 "$samples"); do
+            echo "::group::sample $i of $samples"
+            status=0
+            POSITRON_PERF_TRACE_SAMPLE_TAG="i${i}" \
+            SKIP_BOOTSTRAP=true npx playwright test "${SPEC}" \
+              --project e2e-electron \
+              --workers 1 \
+              --reporter=list || status=$?
+            echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              # Recorded as a failed sample, not silently retried into an
+              # ordinary one.
+              failed=$((failed + 1))
+              echo "sample $i failed with status $status" >> "${TRACE_DIR}/failed-samples.txt"
+            fi
+          done
+          echo "TEST_END=$(date +%s)" >> $GITHUB_ENV
+          if [ "$failed" -gt 0 ]; then
+            echo "Failed samples:"; cat "${TRACE_DIR}/failed-samples.txt"
+          fi
+          # One failed sample out of several still leaves a comparison to make.
+          # No successful sample leaves nothing, so the job says so rather than
+          # reporting green over an empty artifact.
+          if [ "$failed" -eq "$samples" ]; then
+            echo "::error::all $samples samples failed"
+            exit 1
+          fi
+
+      - name: Record test end on failure
+        if: ${{ failure() }}
+        run: echo "TEST_END=$(date +%s)" >> $GITHUB_ENV
+
+      # Written after the run so it reports the versions and paths that were
+      # actually used, including which Ark binary the R extension resolved.
+      - name: Write run manifest
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          mkdir -p "${TRACE_DIR}"
+          ARK_RESOLVED="$(grep -rhoE 'Loading Ark from [^\"]+' test-logs 2>/dev/null | head -1 || true)"
+          ARK_BUNDLED="$(ls -l extensions/positron-r/resources/ark/ark 2>/dev/null || true)"
+          ARK_SUBMODULE_BUILD="$(ls -l extensions/positron-r/ark/target/release/ark 2>/dev/null || true)"
+          cat > "${TRACE_DIR}/manifest.json" <<EOF
+          {
+            "arm_label": "${{ github.event_name == 'pull_request' && 'r-vs-python' || inputs.arm_label }}",
+            "run_id": "${{ github.run_id }}",
+            "attempt": "${{ github.run_attempt }}",
+            "samples_requested": ${SAMPLES},
+            "trace_enabled": ${{ github.event_name == 'pull_request' || inputs.trace }},
+            "spec": "${SPEC}",
+            "playwright_project": "e2e-electron",
+            "workers": 1,
+            "positron_sha": "${{ github.sha }}",
+            "positron_ref": "${{ github.ref_name }}",
+            "ark_ref_input": "${{ github.event_name == 'pull_request' && 'perf' || inputs.ark_ref }}",
+            "ark_sha": "${ARK_SHA:-unset}",
+            "ark_submodule_sha": "$(git -C extensions/positron-r/ark rev-parse HEAD 2>/dev/null || echo unknown)",
+            "ark_resolved_log_line": "${ARK_RESOLVED}",
+            "ark_bundled_binary": "${ARK_BUNDLED}",
+            "ark_submodule_build": "${ARK_SUBMODULE_BUILD}",
+            "runner_image": "ghcr.io/posit-dev/positron-ubuntu24:24.18.0",
+            "runner_label": "ubuntu-latest-8x",
+            "runner_nproc": "$(nproc)",
+            "runner_mem_kb": "$(awk '/MemTotal/ {print \$2}' /proc/meminfo)",
+            "node_version": "$(node --version)",
+            "playwright_version": "$(npx playwright --version 2>/dev/null || echo unknown)",
+            "electron_version": "$(cat .build/electron/version 2>/dev/null || echo unknown)",
+            "r_version": "$(R --version 2>/dev/null | head -1 || echo unknown)",
+            "python_version": "$(python3 --version 2>/dev/null || echo unknown)",
+            "r_ver_sel": "4.5.2",
+            "py_ver_sel": "3.10.12",
+            "rust_log_setting": "set by the spec via positron.r.kernel.env",
+            "setup_seconds": $(( ${SETUP_END:-0} - ${SETUP_START:-0} )),
+            "test_seconds": $(( ${TEST_END:-0} - ${TEST_START:-0} )),
+            "deviations_from_production_lane": [
+              "no postgres service container",
+              "no 1Password secret loading",
+              "no AWS S3 credentials or report upload",
+              "single worker instead of the lane default",
+              "single spec instead of a tag-selected set"
+            ],
+            "source_fetching_override": "none applied; effective behaviour is whatever this Ark revision defaults to"
+          }
+          EOF
+          cat "${TRACE_DIR}/manifest.json"
+
+      - name: Collect Ark and supervisor logs
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          mkdir -p "${TRACE_DIR}"
+
+          # Ark writes its markers to the kernel log the supervisor creates under
+          # TMPDIR, and nothing copies those into test-logs. Placed flat in the
+          # trace directory because analyze.mts reads that directory's own files
+          # and no deeper.
+          #
+          # Both patterns are needed: the supervisor uses a per-session directory
+          # on a fresh start and a flat file when a session reconnects.
+          logs=$(find "${TMPDIR:-/tmp}" -maxdepth 2 \( -path '*/kernel-*/kernel.log' -o -name 'kernel-*.log' \) 2>/dev/null)
+          n=0
+          for f in $logs; do
+            # Only logs that carry markers: a session that ran outside a sample
+            # would contribute events that join to nothing.
+            grep -q PERFTRACE "$f" || continue
+            n=$((n + 1))
+            cp "$f" "${TRACE_DIR}/ark-kernel-${n}.log"
+          done
+          echo "ark kernel logs carrying markers: ${n}"
+
+          # Diagnostics, kept next to the trace. Nested one level down so the
+          # analyzer cannot read the same markers a second time from the kernel
+          # channel's copy of them.
+          mkdir -p "${TRACE_DIR}/logs"
+          find test-logs -type f \( -name '*.log' -o -name '*.out' \) -exec cp --parents {} "${TRACE_DIR}/logs" \; 2>/dev/null || true
+          ls -R "${TRACE_DIR}/logs" | head -50 || true
+
+      - name: Analyze timeline
+        if: ${{ always() && (github.event_name == 'pull_request' || inputs.trace) }}
+        continue-on-error: true
+        run: |
+          # Node strips the types, so the version is part of whether this step
+          # works at all.
+          node --version
+          node test/e2e/utils/perf-trace/analyze.mts "${TRACE_DIR}" --out "${TRACE_DIR}/analysis"
+
+      - name: Upload timing artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: |
+            perf-trace
+            test-results/console-timing.json
+          if-no-files-found: warn
+
+      - name: Upload test logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}-logs
+          path: test-logs
+          if-no-files-found: ignore

--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend/console.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend/console.py
@@ -21,6 +21,7 @@ import hashlib
 import inspect
 import io
 import logging
+import time
 from typing import TYPE_CHECKING, Any, cast
 
 import matplotlib
@@ -94,6 +95,10 @@ def _detach_library_figures() -> None:
     Plain matplotlib figures are intentionally left in the registry to preserve Positron's
     cross-cell figure persistence (updating or re-showing a plot across cells).
     """
+    # Perf investigation: this is the plot-flush-equivalent step for console sessions,
+    # run via post_execute on every cell regardless of whether a plot was created.
+    perf_start = time.perf_counter()
+    detached = 0
     try:
         from matplotlib._pylab_helpers import Gcf
 
@@ -106,8 +111,12 @@ def _detach_library_figures() -> None:
                 # Pass the manager rather than its number: numbers freed here can be reused
                 # by matplotlib, so destroying by number could hit a different figure.
                 Gcf.destroy(manager)
+                detached += 1
     except Exception:
         logger.exception("Error detaching high-level library figures")
+    finally:
+        elapsed_ms = (time.perf_counter() - perf_start) * 1000
+        logger.debug(f"perf: post_execute plot flush detached {detached} figure(s) in {elapsed_ms:.3f} ms")
 
 
 class FigureManagerPositron(FigureManagerBase):

--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend/notebook.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend/notebook.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import time
 from typing import TYPE_CHECKING, Literal, cast
 
 import matplotlib
@@ -147,6 +148,10 @@ def _close_all_figures() -> None:
 
 def _show_figures():
     """Post execute hook to show the cell's figures and log errors."""
+    # Perf investigation: this is the plot-flush-equivalent step for notebook sessions,
+    # run via post_execute on every cell regardless of whether a plot was created.
+    perf_start = time.perf_counter()
+    shown = 0
     try:
         # Don't reuse `pyplot_show` here: it shows every figure, which would emit a second
         # output for a figure that user code already displayed via `plt.show()`/`fig.show()`.
@@ -156,10 +161,12 @@ def _show_figures():
         for manager in Gcf.get_all_fig_managers():
             if not isinstance(manager, FigureManagerPositronNotebook):
                 manager.show()
+                shown += 1
                 continue
 
             if not manager.displayed:
                 manager.show()
+                shown += 1
 
             # Reset even though the figure is about to be closed: should one ever outlive
             # the cell, showing it again beats silently swallowing its output.
@@ -168,6 +175,8 @@ def _show_figures():
         logger.exception("Error showing figures in post execute hook")
     finally:
         _close_all_figures()
+        elapsed_ms = (time.perf_counter() - perf_start) * 1000
+        logger.debug(f"perf: post_execute plot flush showed {shown} figure(s) in {elapsed_ms:.3f} ms")
 
 
 def install(shell: InteractiveShell) -> None:

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import sys
+import time
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Container, cast
@@ -450,6 +451,11 @@ class PositronShell(ZMQInteractiveShell):
         if not raw_cell or raw_cell.isspace():
             return
 
+        # Perf investigation: this is Python's closest equivalent to ark's post-execution
+        # completion handling (handle_active_request), run synchronously within the same
+        # execute_request's busy/idle window, via IPython's post_run_cell event.
+        perf_start = time.perf_counter()
+
         # TODO: Split these to separate callbacks?
         # Check for changes to the working directory
         try:
@@ -461,6 +467,9 @@ class PositronShell(ZMQInteractiveShell):
             self.kernel.variables_service.poll_variables()
         except Exception:
             logger.exception("Error polling variables")
+
+        elapsed_ms = (time.perf_counter() - perf_start) * 1000
+        logger.debug(f"perf: post_run_cell completion handling took {elapsed_ms:.3f} ms")
 
     def _add_editor_dir_to_sys_path(self) -> str | None:
         """
@@ -614,6 +623,7 @@ class PositronIPyKernel(IPythonKernel):
         # to override the parent to do that.
         parent = cast("PositronIPKernelApp", kwargs["parent"])
         self.session_mode = parent.session_mode
+        self._execute_request_start: float | None = None
 
         super().__init__(**kwargs)
 
@@ -801,12 +811,31 @@ class PositronIPyKernel(IPythonKernel):
         except Exception as e:
             self.log.debug("Error in super().pre_handler_hook(): %s", e, exc_info=False)
 
+        # Perf investigation: this is the earliest first-party hook point after
+        # ipykernel's dispatch_shell publishes "busy", so it's the closest available
+        # marker for "execute_request received".
+        if self._is_execute_request():
+            self._execute_request_start = time.perf_counter()
+            logger.debug("perf: execute_request received")
+
     def post_handler_hook(self):
         # see the pre_handler_hook for details
         try:
             super().post_handler_hook()
         except Exception as e:
             self.log.debug("Error in super().post_handler_hook(): %s", e, exc_info=False)
+
+        # Perf investigation: this is the latest first-party hook point before
+        # ipykernel's dispatch_shell publishes "idle" and sends the reply.
+        if self._execute_request_start is not None:
+            elapsed_ms = (time.perf_counter() - self._execute_request_start) * 1000
+            self._execute_request_start = None
+            logger.debug(f"perf: execute_request handled in {elapsed_ms:.3f} ms")
+
+    def _is_execute_request(self) -> bool:
+        parent = self.get_parent("shell")
+        header = parent.get("header", {}) if parent else {}
+        return header.get("msg_type") == "execute_request"
 
 
 class PositronIPKernelApp(IPKernelApp):

--- a/extensions/positron-python/python_files/posit/positron/variables.py
+++ b/extensions/positron-python/python_files/posit/positron/variables.py
@@ -173,28 +173,53 @@ class VariablesService:
             ...
         }
         """
+        # Perf investigation: this is the per-comm "environment changed" notification
+        # step, comparable to ark's comm_notify_environment_changed. Unlike ark, it
+        # only touches comms tied to variables that actually changed, rather than
+        # looping over every open comm.
+        perf_start = time.perf_counter()
+        notified_comms = self._notify_environment_changed(assigned, unevaluated, removed)
+        elapsed_ms = (time.perf_counter() - perf_start) * 1000
+        logger.debug(
+            f"perf: environment-changed notification touched {notified_comms} "
+            f"comm(s) in {elapsed_ms:.3f} ms"
+        )
+
+    def _notify_environment_changed(
+        self,
+        assigned: Mapping[str, Any],
+        unevaluated: Mapping[str, Any],
+        removed: set[str],
+    ) -> int:
+        """Notify the affected comms, and return how many were notified."""
         # Look for any assigned or removed variables that are active
         # in the data explorer service
         exp_service = self.kernel.data_explorer_service
         con_service = self.kernel.connections_service
+        notified_comms = 0
         for name in removed:
             if exp_service.variable_has_active_explorers(name):
                 exp_service.handle_variable_deleted(name)
+                notified_comms += 1
 
             if con_service.variable_has_active_connection(name):
                 con_service.handle_variable_deleted(name)
+                notified_comms += 1
 
         updated = {**assigned, **unevaluated}
         for name, value in updated.items():
             if exp_service.variable_has_active_explorers(name):
                 exp_service.handle_variable_updated(name, value)
+                notified_comms += 1
 
             if con_service.variable_has_active_connection(name):
                 con_service.handle_variable_updated(name, value)
+                notified_comms += 1
 
         # Ensure the number of changes does not exceed our maximum items
         if len(assigned) > MAX_ITEMS or len(removed) > MAX_ITEMS:
-            return self.send_refresh_event()
+            self.send_refresh_event()
+            return notified_comms + 1
 
         # Filter out hidden assigned variables
         variables = self._get_filtered_vars(assigned)
@@ -215,8 +240,8 @@ class VariablesService:
                 version=0,
             )
             self._send_event(VariablesFrontendEvent.Update.value, msg.dict())
-            return None
-        return None
+            notified_comms += 1
+        return notified_comms
 
     def send_refresh_event(self) -> None:
         """

--- a/extensions/positron-r/src/input-boundaries.ts
+++ b/extensions/positron-r/src/input-boundaries.ts
@@ -6,6 +6,7 @@
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { LanguageClient, RequestType } from 'vscode-languageclient/node';
+import { perfMark } from './perfTrace';
 
 export interface InputBoundariesParams {
 	text: string;
@@ -47,8 +48,11 @@ export class RInputBoundaryProvider implements positron.InputBoundaryProvider {
 		range: vscode.Range,
 		token: vscode.CancellationToken
 	): Promise<positron.InputBoundary[]> {
+		perfMark('exthost.r.boundaries.provider.entry');
 		const text = document.getText(range);
+		perfMark('exthost.r.lsp.send');
 		const response = await this._client.sendRequest(InputBoundariesRequest.type, { text }, token);
+		perfMark('exthost.r.lsp.response', undefined, { boundary_count: response.boundaries?.length ?? -1 });
 
 		return response.boundaries;
 	}

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { perfMark } from './perfTrace';
 import * as positron from 'positron';
 import * as path from 'path';
 import { PromiseHandles, timeout } from './util';
@@ -294,6 +295,7 @@ export class ArkLsp implements vscode.Disposable {
 			// Convert the state to our own enum
 			switch (event.newState) {
 				case State.Starting:
+					perfMark('exthost.r.lsp.client.starting');
 					this.setState(ArkLspState.Starting);
 					break;
 				case State.Running:
@@ -306,6 +308,10 @@ export class ArkLsp implements vscode.Disposable {
 						}
 						out.resolve();
 					}
+					// The handshake this closes runs inside the measured
+					// interval on the first R submission, because the harness's
+					// focus chord makes R the foreground session.
+					perfMark('exthost.r.lsp.client.running');
 					this.setState(ArkLspState.Running);
 					break;
 				case State.Stopped:

--- a/extensions/positron-r/src/perfTrace.ts
+++ b/extensions/positron-r/src/perfTrace.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { performance } from 'perf_hooks';
+
+/**
+ * Opt-in timing markers for the console-execution latency investigation.
+ *
+ * Events buffer in memory and flush on an interval, so a measured interval never
+ * pays for a synchronous file write.
+ *
+ * See `test/e2e/utils/perf-trace/schema.ts` for the event shape. Correlation
+ * needs no new wire field: `ExecuteRequest` reuses Positron's execution id as
+ * the Jupyter `msg_id`, so `execution_id` and `jupyter_msg_id` are the same
+ * value and Ark's `parent_msg_id` already points back at the submission.
+ */
+
+/**
+ * Where the harness leaves its pid and the trace directory, for processes that
+ * cannot see its environment.
+ *
+ * The extension host is one of those: `getResolvedShellEnv` returns `{}` when
+ * the app was launched from a CLI (`shellEnv.ts`), which is exactly how
+ * Playwright starts it, so `POSITRON_PERF_TRACE_DIR` never arrives here. That
+ * empty environment is also why the path is hardcoded rather than taken from
+ * `os.tmpdir()`: with no `TMPDIR` set, this process would resolve a different
+ * directory than the harness did.
+ */
+const POINTER_FILE = process.platform === 'win32'
+	? path.join(os.tmpdir(), 'positron-perf-trace-dir')
+	: '/tmp/positron-perf-trace-dir';
+
+let resolved = false;
+let traceDir: string | undefined;
+
+/**
+ * Resolved on first use rather than at module load, because the harness writes
+ * the pointer before launching the app but this module may be evaluated either
+ * side of that.
+ */
+function dir(): string | undefined {
+	if (!resolved) {
+		resolved = true;
+		traceDir = process.env.POSITRON_PERF_TRACE_DIR || pointedDir();
+	}
+	return traceDir;
+}
+
+/**
+ * The trace directory named by the pointer, if the harness that wrote it is
+ * still running.
+ *
+ * A crashed run leaves both the pointer and its trace directory behind, so
+ * neither one's existence distinguishes an ordinary session from a measured
+ * one. The writer's liveness does, and it is what stops a stale pointer from
+ * making every later session append trace files.
+ */
+function pointedDir(): string | undefined {
+	try {
+		const [pid, pointed] = fs.readFileSync(POINTER_FILE, 'utf8').trim().split('\n');
+		if (!pointed || !fs.existsSync(pointed) || !alive(Number(pid))) {
+			return undefined;
+		}
+		return pointed;
+	} catch {
+		return undefined;
+	}
+}
+
+function alive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		// EPERM means the process exists but belongs to another user.
+		return (err as NodeJS.ErrnoException).code === 'EPERM';
+	}
+}
+
+export function perfTraceEnabled(): boolean {
+	return dir() !== undefined;
+}
+
+type PerfTraceIds = {
+	sample_id?: string;
+	submission_id?: string;
+	execution_id?: string;
+	jupyter_msg_id?: string;
+	parent_msg_id?: string;
+	lsp_request_id?: string | number;
+};
+
+type PerfTraceAttrs = Record<string, string | number | boolean | null>;
+
+const RUN_ID = process.env.POSITRON_PERF_TRACE_RUN_ID || process.env.GITHUB_RUN_ID || 'local';
+
+let buffer: string[] = [];
+let file: string | undefined;
+let timer: NodeJS.Timeout | undefined;
+
+function sink(target: string): string {
+	if (!file) {
+		file = path.join(target, `exthost-r-${process.pid}.jsonl`);
+		fs.mkdirSync(target, { recursive: true });
+	}
+	return file;
+}
+
+/**
+ * Starts the periodic flush.
+ *
+ * Driven from the first marker rather than from the first flush: a run that
+ * never fills the buffer would otherwise never schedule a flush, and every event
+ * would be lost when the extension host exits.
+ */
+function ensureFlushing(): void {
+	if (timer) {
+		return;
+	}
+	// 250ms rather than a second: the extension host is killed on app
+	// shutdown, so an `exit` handler is not reliably reached, and a sample that
+	// emits only a handful of events would otherwise never be written at all.
+	// The write blocks the loop that relays IOPub messages, but at a few hundred
+	// bytes it stays under the noise floor of the intervals being measured.
+	timer = setInterval(flushPerfTrace, 250);
+	timer.unref();
+	process.on('exit', flushPerfTrace);
+}
+
+export function flushPerfTrace(): void {
+	const target = dir();
+	if (buffer.length === 0 || !target) {
+		return;
+	}
+	const lines = buffer.join('\n') + '\n';
+	buffer = [];
+	try {
+		fs.appendFileSync(sink(target), lines);
+	} catch {
+		// A dropped timing line must never disturb the session being measured.
+	}
+}
+
+/**
+ * Records a checkpoint.
+ *
+ * `attrs` is metadata only. Code and output bodies stay out: the point is a
+ * readable timeline, and copying payloads would land in the measured interval.
+ */
+export function perfMark(name: string, ids?: PerfTraceIds, attrs?: PerfTraceAttrs): void {
+	if (!perfTraceEnabled()) {
+		return;
+	}
+
+	ensureFlushing();
+
+	const mono = performance.now();
+	buffer.push(JSON.stringify({
+		v: 1,
+		run_id: RUN_ID,
+		proc: 'exthost',
+		pid: process.pid,
+		name,
+		t_mono_us: Math.round(mono * 1000),
+		t_wall_us: Math.round((performance.timeOrigin + mono) * 1000),
+		...(ids ? { ids } : {}),
+		...(attrs ? { attrs } : {}),
+	}));
+
+	if (buffer.length > 512) {
+		flushPerfTrace();
+	}
+}
+
+/** Emits a paired clock reading, so the analysis can align this process's monotonic clock. */
+export function perfClockPair(): void {
+	perfMark('clock.pair');
+}

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -38,6 +38,7 @@ import { SocketSession } from './ws/SocketSession';
 import { KernelOutputMessage } from './ws/KernelMessage';
 import { UICommRequest } from './UICommRequest';
 import { createUniqueId, summarizeError, summarizeAxiosError } from './util';
+import { perfMark } from './perfTrace';
 import { AdoptedSession } from './AdoptedSession';
 import { DebugRequest } from './jupyter/DebugRequest';
 import { JupyterMessageType } from './jupyter/JupyterMessageType.js';
@@ -837,6 +838,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		codeLocation?: positron.Utf8Location,
 		executionMetadata?: Record<string, unknown>
 	): Promise<void> {
+		perfMark('exthost.supervisor.execute.entry', { execution_id: id, jupyter_msg_id: id }, { mode });
 
 		// For unprocessed code, check completeness ourselves before executing.
 		// This eliminates a client-to-(remote-)supervisor roundtrip: the
@@ -845,7 +847,9 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// incomplete, throw so the console can show the continuation prompt; if
 		// the submission is cancelled while we wait, throw a cancellation error.
 		if (mode === positron.RuntimeCodeExecutionMode.Unprocessed) {
+			perfMark('exthost.supervisor.completeness.start', { execution_id: id }, { path: 'unprocessed' });
 			await this.checkUnprocessedCompleteness(code, id);
+			perfMark('exthost.supervisor.completeness.end', { execution_id: id }, { path: 'unprocessed' });
 		}
 
 		// Translate the parameters into a Jupyter execute request. `Unprocessed`
@@ -949,7 +953,9 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			code
 		};
 		const isComplete = new IsCompleteRequest(request);
+		perfMark('exthost.supervisor.completeness.start', { jupyter_msg_id: isComplete.msgId }, { path: 'is_complete_request' });
 		const reply = await this.sendRequest(isComplete);
+		perfMark('exthost.supervisor.completeness.end', { jupyter_msg_id: isComplete.msgId }, { path: 'is_complete_request' });
 		switch (reply.status) {
 			case 'complete':
 				return positron.RuntimeCodeFragmentStatus.Complete;
@@ -1808,6 +1814,9 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			this._socket.ws.onmessage = (msg: any) => {
 				try {
 					const data = JSON.parse(msg.data.toString());
+					perfMark('exthost.supervisor.iopub.recv',
+						{ jupyter_msg_id: data.header?.msg_id, parent_msg_id: data.parent_header?.msg_id },
+						{ kind: data.kind });
 					this.handleMessage(data);
 				} catch (err) {
 					this.log(`Could not parse message: ${err}`, vscode.LogLevel.Error);
@@ -2324,6 +2333,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			const request = this._pendingRequests.get(msg.parent_header.msg_id);
 			if (request) {
 				if (request.replyType === msg.header.msg_type) {
+					perfMark('exthost.supervisor.pending.resolve', { jupyter_msg_id: msg.parent_header.msg_id }, { reply_type: msg.header.msg_type });
 					request.resolve(msg.content);
 					this._pendingRequests.delete(msg.parent_header.msg_id);
 
@@ -2417,6 +2427,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		}
 
 		// Translate the Jupyter message to a LanguageRuntimeMessage and emit it
+		perfMark('exthost.supervisor.event.emit', { parent_msg_id: msg.parent_header?.msg_id }, { msg_type: msg.header.msg_type });
 		this._messages.emitJupyter(msg);
 	}
 
@@ -2446,13 +2457,16 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 	async sendRequest<T>(request: JupyterRequest<any, T>): Promise<T> {
 		// Ensure we're connected before sending the request; if requests are
 		// sent before the connection is established, they'll fail
+		perfMark('exthost.supervisor.barrier.wait.start', { jupyter_msg_id: request.msgId });
 		await this._connected.wait();
+		perfMark('exthost.supervisor.barrier.wait.end', { jupyter_msg_id: request.msgId });
 
 		// Add the request to the pending requests map so we can match up the
 		// reply when it arrives
 		this._pendingRequests.set(request.msgId, request);
 
 		// Send the request over the websocket
+		perfMark('exthost.supervisor.msg.build', { jupyter_msg_id: request.msgId }, { reply_type: request.replyType });
 		return request.sendRpc(this._socket!);
 	}
 

--- a/extensions/positron-supervisor/src/jupyter/JupyterCommand.ts
+++ b/extensions/positron-supervisor/src/jupyter/JupyterCommand.ts
@@ -8,6 +8,7 @@ import { JupyterChannel } from './JupyterChannel';
 import { JupyterMessageHeader } from './JupyterMessageHeader';
 import { unpackSerializedObjectWithBuffers } from '../util';
 import { JupyterMessageType } from './JupyterMessageType.js';
+import { perfMark } from '../perfTrace';
 
 /**
  * Base class for Jupyter commands; commands are messages to the kernel that do
@@ -93,6 +94,7 @@ export abstract class JupyterCommand<T> {
 		};
 		const text = JSON.stringify(payload);
 		socket.channel.debug(`>>> SEND ${this.commandType} [${this.channel}]: ${JSON.stringify(this.commandPayload)}`);
+		perfMark('exthost.supervisor.socket.send', { jupyter_msg_id: this.msgId }, { msg_type: this.commandType });
 		socket.ws.send(text);
 	}
 }

--- a/extensions/positron-supervisor/src/perfTrace.ts
+++ b/extensions/positron-supervisor/src/perfTrace.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { performance } from 'perf_hooks';
+
+/**
+ * Opt-in timing markers for the console-execution latency investigation.
+ *
+ * Events buffer in memory and flush on an interval, so a measured interval never
+ * pays for a synchronous file write.
+ *
+ * See `test/e2e/utils/perf-trace/schema.ts` for the event shape. Correlation
+ * needs no new wire field: `ExecuteRequest` reuses Positron's execution id as
+ * the Jupyter `msg_id`, so `execution_id` and `jupyter_msg_id` are the same
+ * value and Ark's `parent_msg_id` already points back at the submission.
+ */
+
+/**
+ * Where the harness leaves its pid and the trace directory, for processes that
+ * cannot see its environment.
+ *
+ * The extension host is one of those: `getResolvedShellEnv` returns `{}` when
+ * the app was launched from a CLI (`shellEnv.ts`), which is exactly how
+ * Playwright starts it, so `POSITRON_PERF_TRACE_DIR` never arrives here. That
+ * empty environment is also why the path is hardcoded rather than taken from
+ * `os.tmpdir()`: with no `TMPDIR` set, this process would resolve a different
+ * directory than the harness did.
+ */
+const POINTER_FILE = process.platform === 'win32'
+	? path.join(os.tmpdir(), 'positron-perf-trace-dir')
+	: '/tmp/positron-perf-trace-dir';
+
+let resolved = false;
+let traceDir: string | undefined;
+
+/**
+ * Resolved on first use rather than at module load, because the harness writes
+ * the pointer before launching the app but this module may be evaluated either
+ * side of that.
+ */
+function dir(): string | undefined {
+	if (!resolved) {
+		resolved = true;
+		traceDir = process.env.POSITRON_PERF_TRACE_DIR || pointedDir();
+	}
+	return traceDir;
+}
+
+/**
+ * The trace directory named by the pointer, if the harness that wrote it is
+ * still running.
+ *
+ * A crashed run leaves both the pointer and its trace directory behind, so
+ * neither one's existence distinguishes an ordinary session from a measured
+ * one. The writer's liveness does, and it is what stops a stale pointer from
+ * making every later session append trace files.
+ */
+function pointedDir(): string | undefined {
+	try {
+		const [pid, pointed] = fs.readFileSync(POINTER_FILE, 'utf8').trim().split('\n');
+		if (!pointed || !fs.existsSync(pointed) || !alive(Number(pid))) {
+			return undefined;
+		}
+		return pointed;
+	} catch {
+		return undefined;
+	}
+}
+
+function alive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		// EPERM means the process exists but belongs to another user.
+		return (err as NodeJS.ErrnoException).code === 'EPERM';
+	}
+}
+
+export function perfTraceEnabled(): boolean {
+	return dir() !== undefined;
+}
+
+type PerfTraceIds = {
+	sample_id?: string;
+	submission_id?: string;
+	execution_id?: string;
+	jupyter_msg_id?: string;
+	parent_msg_id?: string;
+	lsp_request_id?: string | number;
+};
+
+type PerfTraceAttrs = Record<string, string | number | boolean | null>;
+
+const RUN_ID = process.env.POSITRON_PERF_TRACE_RUN_ID || process.env.GITHUB_RUN_ID || 'local';
+
+let buffer: string[] = [];
+let file: string | undefined;
+let timer: NodeJS.Timeout | undefined;
+
+function sink(target: string): string {
+	if (!file) {
+		file = path.join(target, `exthost-supervisor-${process.pid}.jsonl`);
+		fs.mkdirSync(target, { recursive: true });
+	}
+	return file;
+}
+
+/**
+ * Starts the periodic flush.
+ *
+ * Driven from the first marker rather than from the first flush: a run that
+ * never fills the buffer would otherwise never schedule a flush, and every event
+ * would be lost when the extension host exits.
+ */
+function ensureFlushing(): void {
+	if (timer) {
+		return;
+	}
+	// 250ms rather than a second: the extension host is killed on app
+	// shutdown, so an `exit` handler is not reliably reached, and a sample that
+	// emits only a handful of events would otherwise never be written at all.
+	// The write blocks the loop that relays IOPub messages, but at a few hundred
+	// bytes it stays under the noise floor of the intervals being measured.
+	timer = setInterval(flushPerfTrace, 250);
+	timer.unref();
+	process.on('exit', flushPerfTrace);
+}
+
+export function flushPerfTrace(): void {
+	const target = dir();
+	if (buffer.length === 0 || !target) {
+		return;
+	}
+	const lines = buffer.join('\n') + '\n';
+	buffer = [];
+	try {
+		fs.appendFileSync(sink(target), lines);
+	} catch {
+		// A dropped timing line must never disturb the session being measured.
+	}
+}
+
+/**
+ * Records a checkpoint.
+ *
+ * `attrs` is metadata only. Code and output bodies stay out: the point is a
+ * readable timeline, and copying payloads would land in the measured interval.
+ */
+export function perfMark(name: string, ids?: PerfTraceIds, attrs?: PerfTraceAttrs): void {
+	if (!perfTraceEnabled()) {
+		return;
+	}
+
+	ensureFlushing();
+
+	const mono = performance.now();
+	buffer.push(JSON.stringify({
+		v: 1,
+		run_id: RUN_ID,
+		proc: 'exthost',
+		pid: process.pid,
+		name,
+		t_mono_us: Math.round(mono * 1000),
+		t_wall_us: Math.round((performance.timeOrigin + mono) * 1000),
+		...(ids ? { ids } : {}),
+		...(attrs ? { attrs } : {}),
+	}));
+
+	if (buffer.length > 512) {
+		flushPerfTrace();
+	}
+}
+
+/** Emits a paired clock reading, so the analysis can align this process's monotonic clock. */
+export function perfClockPair(): void {
+	perfMark('clock.pair');
+}

--- a/src/vs/base/common/positronPerfTrace.ts
+++ b/src/vs/base/common/positronPerfTrace.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Opt-in timing markers for the console-execution latency investigation.
+ *
+ * Disabled unless an e2e sample installs `__positronPerfTrace` on the global and
+ * sets `enabled`, so a normal session allocates no buffer and each call site
+ * costs a property read plus the `ids` and `attrs` literals its caller builds.
+ * Those literals are the entire disabled-path cost on the per-message call
+ * sites, which is why none of them derives a value from the message payload.
+ *
+ * Events buffer in memory and the harness drains them after the measured
+ * interval; nothing is written to disk or sent over IPC while a measurement is
+ * running.
+ *
+ * See `test/e2e/utils/perf-trace/schema.ts` for the event shape and the
+ * identifier chain that joins these events to the extension host and Ark.
+ */
+
+type PerfTraceIds = {
+	sample_id?: string;
+	submission_id?: string;
+	execution_id?: string;
+	jupyter_msg_id?: string;
+	parent_msg_id?: string;
+	lsp_request_id?: string | number;
+};
+
+type PerfTraceAttrs = Record<string, string | number | boolean | null>;
+
+type PerfTraceEvent = {
+	v: number;
+	run_id: string;
+	proc: 'renderer';
+	pid: number;
+	name: string;
+	t_mono_us: number;
+	t_wall_us: number;
+	ids?: PerfTraceIds;
+	attrs?: PerfTraceAttrs;
+};
+
+type PerfTraceState = {
+	enabled: boolean;
+	runId?: string;
+	sampleId?: string;
+	events: PerfTraceEvent[];
+};
+
+function state(): PerfTraceState | undefined {
+	const candidate = (globalThis as { __positronPerfTrace?: PerfTraceState }).__positronPerfTrace;
+	return candidate?.enabled ? candidate : undefined;
+}
+
+export function isPerfTraceEnabled(): boolean {
+	return state() !== undefined;
+}
+
+/**
+ * Records a checkpoint on the browser clock.
+ *
+ * `attrs` is for metadata only. Output bodies and source text are deliberately
+ * excluded: they would dominate the artifact and the copying would land inside
+ * the interval being measured.
+ */
+export function perfMark(name: string, ids?: PerfTraceIds, attrs?: PerfTraceAttrs): void {
+	const trace = state();
+	if (!trace) {
+		return;
+	}
+
+	const mono = performance.now();
+	trace.events.push({
+		v: 1,
+		run_id: trace.runId ?? 'unknown',
+		proc: 'renderer',
+		pid: 0,
+		name,
+		t_mono_us: Math.round(mono * 1000),
+		t_wall_us: Math.round((performance.timeOrigin + mono) * 1000),
+		ids: { sample_id: trace.sampleId, ...ids },
+		...(attrs ? { attrs } : {}),
+	});
+}
+
+/**
+ * Mints a submission identifier for one Enter.
+ *
+ * Ordinal-based rather than random so a timeline stays readable, and so two
+ * submissions of the same expression in one sample remain distinguishable
+ * without correlating by their text.
+ */
+let submissionOrdinal = 0;
+export function nextPerfSubmissionId(): string | undefined {
+	const trace = state();
+	if (!trace) {
+		return undefined;
+	}
+	submissionOrdinal++;
+	return `${trace.sampleId ?? 'nosample'}-s${submissionOrdinal}`;
+}

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -16,6 +16,7 @@ import { extHostNamedCustomer, IExtHostContext } from '../../../services/extensi
 import { IHostedLanguageContribution, ILanguageRuntimeClientCreatedEvent, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageCommClosed, ILanguageRuntimeMessageCommData, ILanguageRuntimeMessageCommOpen, ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, ILanguageRuntimeMetadata, ILanguageRuntimeSessionState as ILanguageRuntimeSessionState, ILanguageRuntimeService, ILanguageRuntimeStartupFailure, LanguageRuntimeMessageType, RuntimeBusyBehavior, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeExit, RuntimeOutputKind, RuntimeExitReason, ILanguageRuntimeMessageWebOutput, PositronOutputLocation, LanguageRuntimeSessionMode, ILanguageRuntimeMessageResult, ILanguageRuntimeMessageClearOutput, ILanguageRuntimeMessageIPyWidget, IRuntimeManager, IRuntimeRootSignature, ILanguageRuntimeMessageUpdateOutput, ILanguageRuntimeResourceUsage, ILanguageRuntimeLaunchInfo } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimePackage, ILanguageRuntimePackageManager, ILanguageRuntimeSession, ILanguageRuntimeSessionManager, IPackageRepositoryRequest, IPackageRepositoryResponse, IPackageSpec, IRuntimeConsoleError, IRuntimeExecutionStatistics, IRuntimeMissingPackage, IRuntimeMissingPackagesTarget, IRuntimeSessionMetadata, IRuntimeSessionService, RuntimeStartMode } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { isPerfTraceEnabled, perfMark } from '../../../../base/common/positronPerfTrace.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IPositronVariablesService } from '../../../services/positronVariables/common/interfaces/positronVariablesService.js';
@@ -278,6 +279,8 @@ export class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements 
 
 	/** Timer used to ensure event queue processing occurs within a set interval */
 	private _eventQueueTimer: Timeout | undefined;
+
+	private _perfDeferStart: number | undefined;
 
 	/** The handle uniquely identifying this runtime session with the extension host*/
 	private handle: number;
@@ -703,6 +706,7 @@ export class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements 
 			}
 		}
 
+		perfMark('renderer.execute.proxy_send', { execution_id: id });
 		return this._proxy.$executeCode(this.handle, code, id, mode, errorBehavior, codeLocation, undefined, executionMetadata);
 	}
 
@@ -1039,6 +1043,17 @@ export class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements 
 				clearTimeout(this._eventQueueTimer);
 				this._eventQueueTimer = undefined;
 			}
+			// An event arriving out of sequence holds every queued event,
+			// including output, for up to 250ms. Recorded so that hold shows up
+			// as its own stage rather than as time attributed to the kernel.
+			if (isPerfTraceEnabled()) {
+				this._perfDeferStart = Date.now();
+			}
+			perfMark('renderer.event_queue.defer', undefined, {
+				clock,
+				awaiting: this._eventClock + 1,
+				queued: this._eventQueue.length,
+			});
 			this._eventQueueTimer = setTimeout(() => {
 				// Warn that we're processing the queue after a timeout; this usually
 				// means we're going to process messages out of order because the
@@ -1052,8 +1067,16 @@ export class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements 
 
 	private processEventQueue(): void {
 		// Clear the timer, if there is one.
+		const wasDeferred = this._eventQueueTimer !== undefined;
 		clearTimeout(this._eventQueueTimer);
 		this._eventQueueTimer = undefined;
+
+		perfMark('renderer.event_queue.process', undefined, {
+			queued: this._eventQueue.length,
+			deferred: wasDeferred,
+			delayed_ms: wasDeferred && this._perfDeferStart !== undefined ? Date.now() - this._perfDeferStart : 0,
+		});
+		this._perfDeferStart = undefined;
 
 		// Typically, there's only ever 1 message in the queue; if there are 2
 		// or more, it means that we've received messages out of order

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -38,6 +38,7 @@ import { HistoryInfixMatchStrategy } from '../../common/historyInfixMatchStrateg
 import { HistoryPrefixMatchStrategy } from '../../common/historyPrefixMatchStrategy.js';
 import { EmptyHistoryMatchStrategy, HistoryMatch, HistoryMatchStrategy } from '../../common/historyMatchStrategy.js';
 import { CodeSubmissionResult, IPositronConsoleInstance, PositronConsoleState } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
+import { perfMark } from '../../../../../base/common/positronPerfTrace.js';
 import { ContentHoverController } from '../../../../../editor/contrib/hover/browser/contentHoverController.js';
 import { IInputHistoryEntry } from '../../../../services/positronHistory/common/executionHistoryService.js';
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../../services/positronConsole/common/positronConsoleCodeExecution.js';
@@ -629,6 +630,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				// Try to execute the code editor widget's code.
 				// Consume the event before the await to prevent it from being handled concurrently.
 				consumeEvent();
+				perfMark('renderer.enter.handler');
 				if (!await executeCodeEditorWidgetCodeIfPossible()) {
 					// The code was not executed, insert a new line.
 					services.commandService.executeCommand('editor.action.insertLineAfter');

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -28,6 +28,7 @@ import { ServicesAccessor } from '../../../../platform/instantiation/common/inst
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IStatementRange, IStatementRangeSuccess, StatementRangeKind, StatementRangeRejectionKind, StatementRangeProvider, Location } from '../../../../editor/common/languages.js';
 import { toAction } from '../../../../base/common/actions.js';
+import { perfMark } from '../../../../base/common/positronPerfTrace.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
@@ -1285,9 +1286,14 @@ export function registerPositronConsoleActions() {
 		async run(accessor: ServicesAccessor) {
 			const viewsService = accessor.get(IViewsService);
 
+			// Brackets the command handler itself, so a cost inside `openView`
+			// (e.g. view/extension activation on first focus) is distinguished
+			// from a cost upstream of it (keybinding dispatch, CDP in a test).
+			perfMark('renderer.focus_console.start');
 			// Ensure that the panel and console are visible. This is essentially
 			// equivalent to what `workbench.panel.positronConsole.focus` does.
 			await viewsService.openView(POSITRON_CONSOLE_VIEW_ID, true);
+			perfMark('renderer.focus_console.end');
 		}
 	});
 

--- a/src/vs/workbench/services/positronConsole/browser/classes/throttledEmitter.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/throttledEmitter.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter } from '../../../../../base/common/event.js';
+import { isPerfTraceEnabled, perfMark } from '../../../../../base/common/positronPerfTrace.js';
 
 /**
  * ThrottledEmitter class.
@@ -35,6 +36,16 @@ export class ThrottledEmitter<T> extends Emitter<T> {
 	 * Gets or sets the last event.
 	 */
 	private _lastEvent?: T;
+
+	/**
+	 * Count of fires coalesced into the pending deferred delivery, for perf tracing.
+	 */
+	private _perfPendingCount = 0;
+
+	/**
+	 * Timestamp (`Date.now()`) when the current deferral began, for perf tracing.
+	 */
+	private _perfDeferralStart: number | undefined;
 
 	//#endregion Private Properties
 
@@ -89,6 +100,8 @@ export class ThrottledEmitter<T> extends Emitter<T> {
 		// If the event is being throttled, set the last event and return.
 		if (this._throttleEventTimeout) {
 			this._lastEvent = event;
+			this._perfPendingCount++;
+			perfMark('renderer.items_emitter.throttled', undefined, { pending: this._perfPendingCount });
 			return;
 		}
 
@@ -100,8 +113,18 @@ export class ThrottledEmitter<T> extends Emitter<T> {
 
 		// Set the last event and schedule the throttle event timeout.
 		this._lastEvent = event;
+		this._perfPendingCount = 1;
+		if (isPerfTraceEnabled()) {
+			this._perfDeferralStart = Date.now();
+		}
+		perfMark('renderer.items_emitter.throttled', undefined, { pending: this._perfPendingCount });
 		this._throttleEventTimeout = setTimeout(() => {
 			this._throttleEventTimeout = undefined;
+			if (this._perfDeferralStart !== undefined) {
+				perfMark('renderer.items_emitter.delivered', undefined, { delayed_ms: Date.now() - this._perfDeferralStart });
+				this._perfDeferralStart = undefined;
+			}
+			this._perfPendingCount = 0;
 			super.fire(this._lastEvent!);
 		}, this._throttleInterval);
 	}

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -23,6 +23,7 @@ import { IStorageService, StorageScope, StorageTarget } from '../../../../platfo
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { RuntimeItem } from './classes/runtimeItem.js';
+import { nextPerfSubmissionId, perfMark } from '../../../../base/common/positronPerfTrace.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ThrottledEmitter } from './classes/throttledEmitter.js';
 import { RuntimeItemTrace } from './classes/runtimeItemTrace.js';
@@ -1223,6 +1224,11 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 	 * Queue of pending code fragments waiting to be executed.
 	 */
 	private _pendingCodeQueue: IPendingCodeFragment[] = [];
+
+	/**
+	 * The submission id minted for the in-flight `submitCode` call, for perf tracing.
+	 */
+	private _perfSubmissionId: string | undefined;
 
 	/**
 	 * Gets or sets the session, if attached.
@@ -2444,9 +2450,13 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 		// returns. The runtime's parser normalizes source the same way.
 		code = code.replace(/\r\n?/g, '\n');
 
+		this._perfSubmissionId = nextPerfSubmissionId();
+		perfMark('renderer.submit.entry', { submission_id: this._perfSubmissionId });
+
 		// Flow 3 short-circuit: completeness checking is disabled, so run the
 		// code as-is with no checks, no roundtrips, and no submission visuals.
 		if (this._configurationService.getValue<boolean>(promptWhenIncompleteSettingId) === false) {
+			perfMark('renderer.submit.flow', { submission_id: this._perfSubmissionId }, { flow: 3 });
 			this.setPendingCode();
 			await this.doExecuteCode(code, attribution, RuntimeCodeExecutionMode.Interactive);
 			return CodeSubmissionResult.Executed;
@@ -2515,8 +2525,11 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 			// Flow 1: try the input boundary provider.
 			let boundaries: IInputBoundary[] | undefined;
 			try {
+				perfMark('renderer.boundaries.request', { submission_id: this._perfSubmissionId });
 				boundaries = await this.tryProvideInputBoundaries(code, token);
+				perfMark('renderer.boundaries.response', { submission_id: this._perfSubmissionId }, { provided: boundaries !== undefined });
 			} catch (err) {
+				perfMark('renderer.boundaries.response', { submission_id: this._perfSubmissionId }, { provided: false });
 				if (isCancellationError(err)) {
 					return CodeSubmissionResult.Cancelled;
 				}
@@ -2536,6 +2549,7 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 					fragments = undefined;
 				}
 				if (fragments) {
+					perfMark('renderer.submit.flow', { submission_id: this._perfSubmissionId }, { flow: 1 });
 					const result = this.submitViaBoundaries(code, attribution, fragments);
 					if (result === CodeSubmissionResult.Executed) {
 						dispatched = true;
@@ -2550,6 +2564,7 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 
 			// Flow 2: no provider (or malformed boundaries). Execute with the
 			// Unprocessed mode; the session checks completeness first.
+			perfMark('renderer.submit.flow', { submission_id: this._perfSubmissionId }, { flow: 2 });
 			const result = await this.doExecuteCode(
 				code,
 				attribution,
@@ -3085,6 +3100,9 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 		// Set the new state and raise the onDidChangeState event.
 		this._state = state;
 		this._onDidChangeStateEmitter.fire(this._state);
+		if (state === PositronConsoleState.Ready) {
+			perfMark('renderer.state.ready');
+		}
 	}
 
 	//#endregion Public Methods
@@ -3359,6 +3377,8 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 		// Add the onDidReceiveRuntimeMessageOutput event handler.
 		const handleDidReceiveRuntimeMessageOutput = (
 			(languageRuntimeMessageOutput: ILanguageRuntimeMessageOutput) => {
+				perfMark('renderer.runtime.msg.output', { parent_msg_id: languageRuntimeMessageOutput.parent_id });
+
 				// If trace is enabled, add a trace runtime item.
 				if (this._trace) {
 					this.addRuntimeItemTrace(
@@ -3382,6 +3402,8 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 
 		// Add the onDidReceiveRuntimeMessageStream event handler.
 		this._runtimeDisposableStore.add(this._session.onDidReceiveRuntimeMessageStream(languageRuntimeMessageStream => {
+			perfMark('renderer.runtime.msg.output', { parent_msg_id: languageRuntimeMessageStream.parent_id }, { kind: 'stream' });
+
 			// If trace is enabled, add a trace runtime item.
 			if (this._trace) {
 				// Get the sanitized trace output.
@@ -3472,6 +3494,8 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 		// Add the onDidReceiveRuntimeMessageState event handler.
 		this._runtimeDisposableStore.add(this._session.onDidReceiveRuntimeMessageState(
 			languageRuntimeMessageState => {
+				perfMark('renderer.runtime.msg.state', { parent_msg_id: languageRuntimeMessageState.parent_id }, { state: languageRuntimeMessageState.state });
+
 				// If trace is enabled, add a trace runtime item.
 				if (this._trace) {
 					this.addRuntimeItemTrace(
@@ -4331,6 +4355,7 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 			this._pendingBusyExecutionId = id;
 			this._pendingBusyStart = Date.now();
 			try {
+				perfMark('renderer.execute.dispatch', { submission_id: this._perfSubmissionId, execution_id: id }, { awaited: true });
 				await session.execute(code, id, wireMode, errorBehavior, attribution, executionMetadata);
 			} catch (err) {
 				// Nothing was echoed to the console, so there is nothing to roll
@@ -4354,12 +4379,14 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 
 			// Accepted: echo the input and fire the event.
 			addProvisionalInput();
+			perfMark('renderer.provisional_input.echo', { execution_id: id });
 			fireExecutedEvent();
 			return CodeSubmissionResult.Executed;
 		}
 
 		// Standard (non-unprocessed) execution: echo immediately, then execute.
 		addProvisionalInput();
+		perfMark('renderer.provisional_input.echo', { execution_id: id });
 
 		/**
 		 * Execute the code.
@@ -4372,6 +4399,7 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 		 * failure) is logged since there is no interactive submission to
 		 * surface it to.
 		 */
+		perfMark('renderer.execute.dispatch', { submission_id: this._perfSubmissionId, execution_id: id }, { awaited: false });
 		Promise.resolve(session.execute(
 			code,
 			id,
@@ -4419,6 +4447,7 @@ export class PositronConsoleInstance extends Disposable implements IPositronCons
 			this.trimScrollback();
 
 			// Fire the onDidChangeRuntimeItems event.
+			perfMark('renderer.model.update');
 			this._onDidChangeRuntimeItemsEmitter.fire();
 		} else {
 			// No activity runtime item was found, so create a new one and add the activity item to it.

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -9,6 +9,8 @@ import { QuickInput } from './quickInput';
 import { HotKeys } from './hotKeys';
 import { availableRuntimes, SessionRuntimes } from './sessions';
 import { ContextMenu, MenuItemState } from './dialog-contextMenu';
+import { mark, span } from '../utils/perf-trace/recorder.js';
+import { TraceName } from '../utils/perf-trace/schema.js';
 
 const CONSOLE_INPUT = '.console-input';
 export const ACTIVE_CONSOLE_INSTANCE = '.console-instance[style*="z-index: auto"]';
@@ -193,10 +195,15 @@ export class Console {
 	async waitForReady(prompt: string, timeout = 30000): Promise<void> {
 		// Retry the focus + check together in case another panel (e.g. Terminal) steals
 		// focus after the console is focused but before the assertion completes.
+		//
+		// `focus()` sends the Cmd+K F chord, so it is automation work, not a
+		// prompt check. Its markers separate that cost from the wait for the
+		// prompt itself; both repeat when `toPass` retries.
 		await expect(async () => {
-			await this.focus();
+			await span(TraceName.harness.focusStart, TraceName.harness.focusEnd, () => this.focus());
 			const activeLine = this.code.driver.currentPage.locator(`${ACTIVE_CONSOLE_INSTANCE} .active-line-number`);
-			await expect(activeLine).toHaveText(prompt, { timeout: 5000 });
+			await span(TraceName.harness.promptAssertStart, TraceName.harness.promptAssertEnd,
+				() => expect(activeLine).toHaveText(prompt, { timeout: 5000 }));
 		}).toPass({ timeout });
 	}
 
@@ -268,8 +275,18 @@ export class Console {
 			// Normal case: waiting for `expectedCount` occurrences
 			const matchingLines = this.code.driver.currentPage.locator(CONSOLE_LINES).getByText(consoleTextOrRegex, { exact });
 
-			await expect(matchingLines).toHaveCount(expectedCount, { timeout });
-			return expectedCount ? matchingLines.allTextContents() : [];
+			// The text retrieval after the count assertion is a further CDP
+			// round trip inside whatever interval encloses this call, so it is
+			// bracketed separately from the wait it follows.
+			await span(TraceName.harness.outputAssertStart, TraceName.harness.outputAssertEnd,
+				() => expect(matchingLines).toHaveCount(expectedCount, { timeout }));
+			if (!expectedCount) {
+				return [];
+			}
+			mark(TraceName.harness.textRetrieveStart);
+			const contents = await matchingLines.allTextContents();
+			mark(TraceName.harness.textRetrieveEnd);
+			return contents;
 		});
 	}
 

--- a/test/e2e/tests/console/performance/console-code-execution.test.ts
+++ b/test/e2e/tests/console/performance/console-code-execution.test.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { expect, test, tags } from '../../_test.setup';
+import { TraceRecorder, makeSampleId, setCurrentRecorder, traceEnabled } from '../../../utils/perf-trace/recorder.js';
+import { armConsoleDomTrace, drainConsoleDomTrace, domSampleToEvents } from '../../../utils/perf-trace/console-dom.js';
+import { TraceName } from '../../../utils/perf-trace/schema.js';
 
 test.use({
 	suiteId: __filename
@@ -49,22 +52,54 @@ test.describe('Console Performance: Code Execution', {
 	// in any scenario here, and trimming-path regressions would go undetected.
 	const SCROLLBACK_SIZE = 2000;
 
+	// Ark emits its timing markers on the `perftrace` log target. Routing only
+	// that target at trace level keeps the rest of ark quiet, so the log stays
+	// small enough not to perturb what it measures. `kernel.env` is spread over
+	// `RUST_LOG` in kernel-spec.ts, which is what lets a setting override it.
+	const ARK_TRACE_SETTINGS: Record<string, unknown> = {
+		'positron.r.kernel.env': { RUST_LOG: 'warn,ark=warn,perftrace=trace' },
+		// `getArkKernelPath()` prefers a submodule build over the bundled
+		// binary, so an instrumented ark built in a different checkout is only
+		// picked up by pinning it here, which is also the highest-priority
+		// lookup. The manifest records which binary actually launched.
+		...(process.env.POSITRON_PERF_TRACE_ARK
+			? { 'positron.r.kernel.path': process.env.POSITRON_PERF_TRACE_ARK }
+			: {}),
+	};
+
 	test.beforeAll(async function ({ settings }) {
-		await settings.set({ 'console.scrollbackSize': SCROLLBACK_SIZE });
+		await settings.set({
+			'console.scrollbackSize': SCROLLBACK_SIZE,
+			...(traceEnabled ? ARK_TRACE_SETTINGS : {}),
+		});
 	});
 
 	test.afterAll(async function ({ settings }) {
-		await settings.remove(['console.scrollbackSize']);
+		await settings.remove(['console.scrollbackSize', ...(traceEnabled ? Object.keys(ARK_TRACE_SETTINGS) : [])]);
 	});
+
+	// Opt-in experiment: submit one untimed R expression before the timed
+	// `simple_expression` sample, so it is not the first submission into a
+	// freshly started R session. Isolates first-submission cost (services
+	// activation on the focus chord) from execution cost. Off by default: the
+	// production spec's ordering is what the dashboard's history was recorded
+	// under, and must not change except under this explicit flag.
+	const warmRBeforeSimple = process.env.POSITRON_PERF_TRACE_WARM_R === '1';
 
 	for (const { lang, runtime, target, prompt } of LANGUAGES) {
 		for (const scenario of SCENARIOS) {
 			const code = lang === 'Python' ? scenario.python : scenario.r;
 
 			test(`${lang} - ${scenario.name}`,
-				async function ({ app, page, sessions, metric }) {
+				async function ({ app, page, sessions, metric }, testInfo) {
 					const { console: positronConsole } = app.workbench;
 					await sessions.start(runtime, { reuse: true });
+
+					if (warmRBeforeSimple && lang === 'R' && scenario.variant === 'simple_expression') {
+						await positronConsole.waitForReady(prompt);
+						await positronConsole.pasteCodeToConsole('1 + 1', true);
+						await positronConsole.waitForReady(prompt);
+					}
 
 					// Pre-timer setup: ensure console is focused and idle, then stage the code.
 					// pasteCodeToConsole dispatches a ClipboardEvent directly to the input
@@ -73,22 +108,62 @@ test.describe('Console Performance: Code Execution', {
 					await positronConsole.pasteCodeToConsole(code);
 					await page.waitForTimeout(200);
 
-					// Metric: Enter keypress → output appears → prompt returns.
-					// waitForConsoleContents guards against Enter missing the console —
-					// if focus was lost, no output appears and the test fails rather than
-					// recording a false near-0ms result from an already-idle prompt.
-					const { duration_ms } = await metric.console.executeCode(async () => {
-						await page.keyboard.press('Enter');
-						await positronConsole.waitForConsoleContents(scenario.output, { timeout: 60000 });
-						await positronConsole.waitForReady(prompt, 60000);
-					}, target, {
-						language: lang,
-						description: `${lang}: ${scenario.name}`,
-						variant: scenario.variant,
-					});
+					const sampleId = makeSampleId(testInfo.title, testInfo.repeatEachIndex);
+					const recorder = new TraceRecorder(sampleId);
+					setCurrentRecorder(recorder);
 
-					expect(duration_ms).toBeGreaterThan(0);
-					if (!process.env.CI) { console.log(`[perf] execute_code ${target} (${scenario.name}): ${duration_ms} ms`); }
+					// Arming is a CDP round trip, so it happens before the timer
+					// starts. The observer it installs reports when the DOM
+					// actually changed, which the polled assertions below cannot.
+					if (traceEnabled) {
+						await recorder.span(TraceName.harness.armStart, TraceName.harness.armEnd, () =>
+							armConsoleDomTrace(page, { expectedOutput: scenario.output, prompt, sampleId }));
+					}
+
+					try {
+						// Metric: Enter keypress → output appears → prompt returns.
+						// waitForConsoleContents guards against Enter missing the console —
+						// if focus was lost, no output appears and the test fails rather than
+						// recording a false near-0ms result from an already-idle prompt.
+						//
+						// The helpers are called unchanged so the recorded duration stays
+						// comparable to the dashboard's history; the markers inside them
+						// attribute that duration without altering it.
+						const { duration_ms } = await metric.console.executeCode(async () => {
+							recorder.mark(TraceName.harness.sampleStart);
+							await recorder.span(TraceName.harness.enterPressStart, TraceName.harness.enterPressEnd,
+								() => page.keyboard.press('Enter'));
+							await positronConsole.waitForConsoleContents(scenario.output, { timeout: 60000 });
+							await positronConsole.waitForReady(prompt, 60000);
+							recorder.mark(TraceName.harness.sampleEnd);
+						}, target, {
+							language: lang,
+							description: `${lang}: ${scenario.name}`,
+							variant: scenario.variant,
+						});
+
+						expect(duration_ms).toBeGreaterThan(0);
+						if (!process.env.CI) { console.log(`[perf] execute_code ${target} (${scenario.name}): ${duration_ms} ms`); }
+					} finally {
+						// Drained in `finally` so a timed-out assertion still yields
+						// the timeline that shows which stage never completed. A drain
+						// that throws is swallowed: it would otherwise replace the
+						// failure being investigated with its own.
+						if (traceEnabled) {
+							try {
+								recorder.mark(TraceName.harness.drainStart);
+								const { dom, rendererEvents } = await drainConsoleDomTrace(page);
+								recorder.mark(TraceName.harness.drainEnd);
+								recorder.adopt(rendererEvents);
+								recorder.adopt(domSampleToEvents(dom, { sample_id: sampleId }));
+							} catch (err) {
+								console.log(`[perf] trace drain failed: ${err}`);
+							}
+							recorder.clockPair();
+							recorder.flush();
+						}
+						setCurrentRecorder(undefined);
+					}
 				}
 			);
 		}

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -30,6 +30,10 @@
 		// them via `test/e2e/**/*.vitest.ts` in vitest.tsconfig.json. Compiling
 		// them here fails in CI, where the e2e lanes install only the Playwright
 		// dependencies and `vitest` is not resolvable.
-		"**/*.vitest.ts"
+		"**/*.vitest.ts",
+		// Run directly by `node`, which strips its types, so it imports
+		// `./schema.ts` by its real path. This project emits, and tsc rejects a
+		// `.ts` import specifier outside `noEmit`.
+		"utils/perf-trace/analyze.mts"
 	]
 }

--- a/test/e2e/utils/metrics/api.ts
+++ b/test/e2e/utils/metrics/api.ts
@@ -69,6 +69,19 @@ export async function logMetric(
 	isElectronApp: boolean,
 	logger: MultiLogger
 ): Promise<MetricResponse> {
+	// A timing-investigation run produces samples for a hand-built comparison,
+	// not for the dashboard's history. Gating on the variable that already
+	// enables tracing means such a run cannot publish by forgetting a second
+	// flag, and it holds whatever branch or key the run happens to have.
+	if (process.env.POSITRON_PERF_TRACE_DIR) {
+		logger.log('Perf trace run: skipping metric upload.');
+		return {
+			statusCode: 0,
+			ok: false,
+			body: 'Perf trace run: upload suppressed'
+		};
+	}
+
 	if (process.env.CI && !CONNECT_API_KEY) {
 		logger.log('Missing CONNECT_API_KEY. Skipping metric logging.');
 		return {

--- a/test/e2e/utils/perf-trace/README.md
+++ b/test/e2e/utils/perf-trace/README.md
@@ -1,0 +1,156 @@
+# Console execution timing trace
+
+Opt-in instrumentation for the console-execution latency investigation
+(posit-dev/positron#15466). It produces a correlated per-submission timeline
+across five processes so elapsed time can be attributed to a stage instead of
+guessed at.
+
+Everything here is inert unless `POSITRON_PERF_TRACE_DIR` is set. With it unset,
+each marker is a property or boolean read plus the small `ids` and `attrs`
+objects its caller builds, no buffer is allocated, and nothing is written.
+
+## Fastest run
+
+```bash
+# Playwright needs the Node version pinned in .nvmrc; on a newer Node it fails
+# to load its own config with a misleading "Cannot find module './lanes.js'".
+export PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH"
+
+# The submodule build outranks the bundled binary in getArkKernelPath(), so
+# building in place is what swaps the kernel. `cargo check` produces no binary,
+# and a build older than the instrumentation yields a trace with no ark events.
+(cd extensions/positron-r/ark && cargo build --release)
+
+# Local, one sample of all four cases in their declared order. Set
+# POSITRON_PERF_TRACE_ARK to an absolute path instead when the instrumented ark
+# lives in another checkout; it pins `positron.r.kernel.path`, which outranks
+# the submodule.
+POSITRON_PERF_TRACE_DIR=$PWD/perf-trace \
+POSITRON_PERF_TRACE_RUN_ID=local-$(date +%s) \
+env -u ELECTRON_RUN_AS_NODE -u ELECTRON_NO_ATTACH_CONSOLE -u BUILD \
+  npx playwright test test/e2e/tests/console/performance/console-code-execution.test.ts \
+    --project e2e-electron --workers 1 --reporter=list
+
+# Ark streams its markers to a kernel log under TMPDIR, not into test-logs.
+# Copy only the newest one that actually contains markers: an older run's log
+# would add events that join to nothing and inflate the unattributed count.
+for f in $(ls -dt "${TMPDIR:-/tmp}"/kernel-*/kernel.log); do
+  grep -q PERFTRACE "$f" \
+    && cp "$f" "perf-trace/ark-kernel-${POSITRON_PERF_TRACE_SAMPLE_TAG:-i1}.log" \
+    && break
+done
+
+node test/e2e/utils/perf-trace/analyze.mts perf-trace
+```
+
+`env -u ELECTRON_RUN_AS_NODE` matters when the shell was launched from inside the
+IDE; see `test/e2e/CLAUDE.md`.
+
+For several local samples, re-run the whole command with a distinct
+`POSITRON_PERF_TRACE_SAMPLE_TAG=i2`, `i3`, and so on. Do not reach for
+`--repeat-each`: the app and sessions are worker-scoped, so repetitions execute
+into the same warm console.
+
+In CI, dispatch `.github/workflows/test-e2e-console-timing.yml`:
+
+| Input | Meaning |
+|---|---|
+| `samples` | Samples per arm. 1 to smoke, 10 to compare. Each is a separate Playwright invocation, not `--repeat-each`: the app and sessions are worker-scoped, so a repetition would run the same expression into the same warm console, which breaks the spec's exact-count assertion and measures a different experiment. Failed samples are listed in `failed-samples.txt` rather than retried into ordinary ones. |
+| `ark_ref` | Ark ref to build from source. Blank uses the downloaded binary. |
+| `arm_label` | Label recorded in the manifest, for joining paired runs. |
+| `trace` | Off gives the tracing-disabled control for measuring instrumentation overhead. |
+
+The workflow uploads the trace directory, the analysis, the manifest, and all
+logs, on failure as well as success. It performs the same kernel-log copy as the
+local flow above, into `ark-kernel-<n>.log`, and reports how many logs carried
+markers. A run in which no sample succeeded fails rather than publishing an
+empty artifact as green.
+
+## What gets measured
+
+`schema.ts` is the contract: `TraceEvent` is the record shape, `TraceName` the
+event catalogue, and `STAGES` the intervals the analysis reports. `analyze.mts`
+imports `STAGES` from it, so adding a stage there is enough.
+
+Correlation uses identifiers the protocols already carry, so no message format
+changes and Kallichore needs no modification:
+
+```
+sample_id       harness, pushed into the renderer when a sample arms
+submission_id   renderer, one per Enter
+execution_id    renderer -> extension host
+jupyter_msg_id  identical to execution_id, because ExecuteRequest reuses it
+parent_msg_id   Ark's IOPub messages, pointing back at the submission
+```
+
+Clocks stay separate. `t_mono_us` is only ever subtracted within one process;
+cross-process stages are computed from `t_wall_us` and reported as approximate.
+Each process emits `clock.pair` at trace start and end, and the analysis reports
+the drift between them as the uncertainty on every cross-process figure.
+
+## Where the markers live
+
+| Layer | Files |
+|---|---|
+| Harness | `recorder.ts`, `console-dom.ts`, and markers inside the real `pages/console.ts` helpers |
+| Renderer | `src/vs/base/common/positronPerfTrace.ts` plus markers in the console service, console input, throttled emitter, and the runtime main-thread adapter |
+| Extension host | `extensions/positron-supervisor/src/perfTrace.ts`, `extensions/positron-r/src/perfTrace.ts` and their call sites |
+| Ark | `crates/amalthea/src/perf_trace.rs`, emitted as `PERFTRACE {json}` on the `perftrace` log target |
+
+On the first R submission the harness's focus chord makes R the foreground
+session, which starts the R LSP inside the measured interval. That path is
+covered end to end: `ark.lsp.server.start` through `ark.lsp.initialized` and
+`ark.lsp.index.warm.*` on the kernel side, `exthost.r.lsp.client.starting` and
+`.running` on the client side, and `renderer.longtask` for the main-thread blocks
+that would otherwise appear only as an absence of events.
+
+Ark is enabled by log filter alone, no new environment variable: the spec sets
+`positron.r.kernel.env` to `RUST_LOG=warn,ark=warn,perftrace=trace`, which
+`kernel-spec.ts` spreads over `RUST_LOG`. The rest of Ark stays quiet, so the log
+does not grow large enough to perturb what it measures.
+
+## Deliberate limits
+
+Read these before drawing a conclusion from a number.
+
+- **DOM readiness is not paint.** The `MutationObserver` fires when a node
+  enters the DOM. Nothing here measures rasterisation.
+- **Kallichore is bracketed, not instrumented.** The interval between
+  `exthost.supervisor.socket.send` and `ark.shell.recv` contains transport and
+  scheduling as well as the server's own work. It is not Kallichore processing
+  time.
+- **`lsp_request_id` is unavailable.** `vscode-languageclient`'s `sendRequest`
+  does not expose the JSON-RPC id, so the input-boundary hop joins by sample and
+  wall-clock containment rather than by id. The analysis flags those stages
+  `time_attributed`. No counter was substituted, because it would look like the
+  LSP's own id and would not be one.
+- **The extension-host half of `src/vs` is unmarked.** `extHostLanguageRuntime`
+  gets no marker, so `execute.renderer_to_supervisor` spans the RPC, the
+  `$executeCode` handler, and the session lookup together.
+- **The Python kernel emits no trace events.** Only Ark does. Python's side is
+  bracketed by the supervisor's send and receive markers, the same way
+  Kallichore is, so a Python sample attributes time down to "inside the kernel"
+  and no further. The `logger.debug` markers in `positron_ipkernel.py` and
+  `variables.py` are log-only and do not join this schema, so every `ark.*` stage
+  reads as missing for a Python sample.
+- **Services activation is not marked.** The foreground-session change that
+  triggers LSP startup is visible only as a log line in `R Supervisor.log`, so
+  the cost attributes to the focus chord that triggered it rather than to the
+  activation itself.
+- **An enqueue is not a send.** Ark's IOPub path has three hops, and only
+  `ark.iopub.socket.send` is a transmission. An execute reply is likewise not
+  evidence that output is visible.
+- **Repeated markers are not summed.** `harness.focus.start` and
+  `harness.prompt.assert.start` repeat when `toPass` retries, and
+  `renderer.runtime.msg.output` fires per message. The analysis takes the first
+  occurrence of each endpoint and flags the stage `ambiguous`.
+- **The reduced CI job is not the production lane.** It drops the postgres
+  service and the credential steps. Trimming concurrent load can change the
+  measurement, so a run that does not reproduce the signal has to be compared
+  against the full lane before concluding the signal is absent.
+
+## Side effects
+
+Metric upload is suppressed whenever `POSITRON_PERF_TRACE_DIR` is set
+(`test/e2e/utils/metrics/api.ts`), so investigation samples cannot reach the
+production dashboard. The timing workflow also never receives `CONNECT_API_KEY`.

--- a/test/e2e/utils/perf-trace/analyze.mts
+++ b/test/e2e/utils/perf-trace/analyze.mts
@@ -1,0 +1,864 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Offline analysis for console-execution latency traces.
+ *
+ * Reads the JSONL/log files a trace run produces, joins events across the five
+ * emitting processes, and writes a timeline, a stage-duration table, a grouped
+ * summary, and a gaps report. Zero dependencies, and Node strips the types, so a
+ * timing investigation does not depend on the same build pipeline it is
+ * measuring.
+ *
+ * The `.mts` extension and the `.ts` import specifier are what keep that true,
+ * the same way `scripts/format.mts` runs. `test/e2e/tsconfig.json` excludes this
+ * file because the emitting project rejects that specifier, and going through
+ * `out/` would put a build between a trace and its report.
+ *
+ * Usage: node test/e2e/utils/perf-trace/analyze.mts <trace-dir> [--out <dir>]
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { STAGES, TraceName, type TraceEvent, type TraceIds, type TraceProc } from './schema.ts';
+
+type AttributedEvent = {
+	event: TraceEvent;
+	attribution: 'id_attributed' | 'time_attributed';
+};
+
+type Sample = {
+	sampleId: string;
+	events: AttributedEvent[];
+	idSpace: Set<string>;
+	lspSpace: Set<string>;
+};
+
+type Counters = { malformed: number };
+
+type StageRow = {
+	sampleId: string;
+	language: string;
+	variant: string;
+	stage: string;
+	durationMs: number | undefined;
+	exactApprox: 'exact' | 'approx' | '';
+	flags: string[];
+	fromCount: number;
+	toCount: number;
+};
+
+type NumericStageRow = StageRow & { durationMs: number };
+
+type ClockAlignment = {
+	key: string;
+	count: number;
+	offsetUs: number;
+	driftUs: number | undefined;
+};
+
+type GapsContext = {
+	samples: Map<string, Sample>;
+	unattributed: { event: TraceEvent; reason: string }[];
+	allRows: StageRow[];
+	malformed: number;
+	malformedByFile: Map<string, number>;
+	clockAlignment: ClockAlignment[];
+};
+
+const CLOCK_PAIR_NAME = TraceName.clockPair;
+const KEYDOWN_NAME = TraceName.renderer.enterKeydown;
+const VALID_PROCS = new Set<TraceProc>(['harness', 'renderer', 'exthost', 'ark']);
+
+/**
+ * The id fields that share one namespace, because `ExecuteRequest` reuses
+ * Positron's execution id as the Jupyter `msg_id`.
+ */
+const JOINED_ID_FIELDS = ['execution_id', 'jupyter_msg_id', 'parent_msg_id'] as const;
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the balanced `{...}` object following `marker` in `line`.
+ *
+ * A greedy end-of-line regex would swallow trailing log text into the JSON
+ * string; scanning brace depth (skipping braces inside quoted strings) finds
+ * the true end regardless of what the tracing pretty-formatter appends.
+ */
+function extractJsonAfter(line: string, marker: string): string | undefined {
+	const markerIdx = line.indexOf(marker);
+	if (markerIdx === -1) {
+		return undefined;
+	}
+	const braceStart = line.indexOf('{', markerIdx + marker.length);
+	if (braceStart === -1) {
+		return undefined;
+	}
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let i = braceStart; i < line.length; i++) {
+		const ch = line[i];
+		if (inString) {
+			if (escaped) {
+				escaped = false;
+			} else if (ch === '\\') {
+				escaped = true;
+			} else if (ch === '"') {
+				inString = false;
+			}
+			continue;
+		}
+		if (ch === '"') {
+			inString = true;
+		} else if (ch === '{') {
+			depth++;
+		} else if (ch === '}') {
+			depth--;
+			if (depth === 0) {
+				return line.slice(braceStart, i + 1);
+			}
+		}
+	}
+	return undefined;
+}
+
+function isValidEvent(obj: unknown): obj is TraceEvent {
+	if (typeof obj !== 'object' || obj === null) {
+		return false;
+	}
+	const event = obj as Partial<TraceEvent>;
+	return typeof event.v === 'number'
+		&& typeof event.run_id === 'string'
+		&& typeof event.proc === 'string' && VALID_PROCS.has(event.proc)
+		&& typeof event.pid === 'number'
+		&& typeof event.name === 'string'
+		&& typeof event.t_mono_us === 'number'
+		&& typeof event.t_wall_us === 'number';
+}
+
+function readJsonlFile(filePath: string, counters: Counters): TraceEvent[] {
+	const events = [];
+	const text = readFileSync(filePath, 'utf8');
+	for (const line of text.split('\n')) {
+		const trimmed = line.trim();
+		if (trimmed === '') {
+			continue;
+		}
+		let obj;
+		try {
+			obj = JSON.parse(trimmed);
+		} catch {
+			counters.malformed++;
+			continue;
+		}
+		if (!isValidEvent(obj)) {
+			counters.malformed++;
+			continue;
+		}
+		events.push(obj);
+	}
+	return events;
+}
+
+/**
+ * Ark markers ride inside ordinary tracing-formatted log lines. Every other
+ * line in the file is ignored, not counted as malformed: only lines that
+ * carry the marker but fail to yield a valid event count against the total.
+ */
+function readLogFile(filePath: string, counters: Counters): TraceEvent[] {
+	const events = [];
+	const text = readFileSync(filePath, 'utf8');
+	for (const line of text.split('\n')) {
+		if (!line.includes('PERFTRACE')) {
+			continue;
+		}
+		const jsonText = extractJsonAfter(line, 'PERFTRACE');
+		if (jsonText === undefined) {
+			counters.malformed++;
+			continue;
+		}
+		let obj;
+		try {
+			obj = JSON.parse(jsonText);
+		} catch {
+			counters.malformed++;
+			continue;
+		}
+		if (!isValidEvent(obj)) {
+			counters.malformed++;
+			continue;
+		}
+		events.push(obj);
+	}
+	return events;
+}
+
+function loadAllEvents(traceDir: string): { events: TraceEvent[]; malformed: number; malformedByFile: Map<string, number> } {
+	const counters: Counters = { malformed: 0 };
+	const malformedByFile = new Map();
+	const events = [];
+	const entries = readdirSync(traceDir, { withFileTypes: true })
+		.filter(d => d.isFile())
+		.map(d => d.name)
+		.sort();
+	for (const name of entries) {
+		const filePath = join(traceDir, name);
+		const before = counters.malformed;
+		if (/^harness-.*\.jsonl$/.test(name) || /^exthost-.*\.jsonl$/.test(name)) {
+			events.push(...readJsonlFile(filePath, counters));
+		} else if (/\.log$/.test(name)) {
+			events.push(...readLogFile(filePath, counters));
+		} else {
+			continue;
+		}
+		if (counters.malformed > before) {
+			malformedByFile.set(name, counters.malformed - before);
+		}
+	}
+	return { events, malformed: counters.malformed, malformedByFile };
+}
+
+// ---------------------------------------------------------------------------
+// Correlation
+// ---------------------------------------------------------------------------
+
+function normId(v: string | number | undefined | null) {
+	return v === undefined || v === null ? undefined : String(v);
+}
+
+/** Adds the ids an event carries to its sample's join sets. */
+function addIdsToSpace(sample: Sample, event: TraceEvent) {
+	const ids = event.ids;
+	if (!ids) {
+		return;
+	}
+	for (const field of JOINED_ID_FIELDS) {
+		const v = normId(ids[field]);
+		if (v !== undefined) {
+			sample.idSpace.add(v);
+		}
+	}
+	const lsp = normId(ids.lsp_request_id);
+	if (lsp !== undefined) {
+		sample.lspSpace.add(lsp);
+	}
+}
+
+function eventJoinsSample(event: TraceEvent, sample: Sample): boolean {
+	const ids = event.ids;
+	if (!ids) {
+		return false;
+	}
+	for (const field of JOINED_ID_FIELDS) {
+		const v = normId(ids[field]);
+		if (v !== undefined && sample.idSpace.has(v)) {
+			return true;
+		}
+	}
+	const lsp = normId(ids.lsp_request_id);
+	return lsp !== undefined && sample.lspSpace.has(lsp);
+}
+
+/**
+ * Groups events by sample and attributes the ones that cannot be joined
+ * directly (ark and exthost carry no `sample_id`).
+ */
+function buildSamples(events: TraceEvent[]): { samples: Map<string, Sample>; unattributed: { event: TraceEvent; reason: string }[] } {
+	const samples = new Map<string, Sample>();
+	const direct: { event: TraceEvent; sampleId: string }[] = [];
+	const rest: TraceEvent[] = [];
+	for (const event of events) {
+		const sampleId = event.ids?.sample_id;
+		if (sampleId) {
+			direct.push({ event, sampleId });
+		} else {
+			rest.push(event);
+		}
+	}
+	for (const { event, sampleId } of direct) {
+		let sample = samples.get(sampleId);
+		if (!sample) {
+			sample = { sampleId, events: [], idSpace: new Set(), lspSpace: new Set() };
+			samples.set(sampleId, sample);
+		}
+		sample.events.push({ event, attribution: 'id_attributed' });
+		addIdsToSpace(sample, event);
+	}
+
+	// Fixed-point pass: an ark/exthost event that joins can itself introduce
+	// ids (e.g. an iopub reply's own msg_id) that let a later sibling join too.
+	const pending = new Set(rest);
+	const ambiguousIdEvents = [];
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const e of Array.from(pending)) {
+			const matches = [];
+			for (const sample of samples.values()) {
+				if (eventJoinsSample(e, sample)) {
+					matches.push(sample);
+				}
+			}
+			if (matches.length === 1) {
+				matches[0].events.push({ event: e, attribution: 'id_attributed' });
+				addIdsToSpace(matches[0], e);
+				pending.delete(e);
+				changed = true;
+			} else if (matches.length > 1) {
+				ambiguousIdEvents.push(e);
+				pending.delete(e);
+			}
+		}
+	}
+
+	// Time-attribution fallback: containment within the sample's own
+	// id-joined wall interval. Deliberately conservative -- an event whose
+	// timestamp falls in more than one sample's interval joins neither,
+	// since guessing wrong here is worse than leaving it unattributed.
+	const wallIntervals = new Map();
+	for (const sample of samples.values()) {
+		// Folded rather than spread: a large-output sample carries enough events
+		// to exceed the argument limit.
+		let lo = Infinity;
+		let hi = -Infinity;
+		for (const { event } of sample.events) {
+			lo = Math.min(lo, event.t_wall_us);
+			hi = Math.max(hi, event.t_wall_us);
+		}
+		wallIntervals.set(sample.sampleId, [lo, hi]);
+	}
+	const unattributed = [];
+	for (const e of pending) {
+		const containing = [];
+		for (const sample of samples.values()) {
+			const [lo, hi] = wallIntervals.get(sample.sampleId);
+			if (e.t_wall_us >= lo && e.t_wall_us <= hi) {
+				containing.push(sample);
+			}
+		}
+		if (containing.length === 1) {
+			containing[0].events.push({ event: e, attribution: 'time_attributed' });
+		} else if (containing.length === 0) {
+			unattributed.push({ event: e, reason: 'no_join' });
+		} else {
+			unattributed.push({ event: e, reason: 'ambiguous_time_containment' });
+		}
+	}
+	for (const e of ambiguousIdEvents) {
+		unattributed.push({ event: e, reason: 'ambiguous_id_match' });
+	}
+
+	return { samples, unattributed };
+}
+
+// ---------------------------------------------------------------------------
+// Stage computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Picks the first occurrence of `from`, then the first occurrence of `to` at
+ * or after it, per stage. Never sums repeats and never substitutes a nearby
+ * event for a missing endpoint.
+ */
+function computeStages(sample: Sample): StageRow[] {
+	const rows = [];
+	for (const spec of STAGES) {
+		const fromOccs = sample.events
+			.filter(x => x.event.name === spec.from)
+			.sort((a, b) => a.event.t_wall_us - b.event.t_wall_us);
+		const toOccsAll = sample.events
+			.filter(x => x.event.name === spec.to)
+			.sort((a, b) => a.event.t_wall_us - b.event.t_wall_us);
+
+		const flags = new Set<string>();
+		if (fromOccs.length === 0) {
+			flags.add('missing_from');
+		}
+		if (fromOccs.length > 1 || toOccsAll.length > 1) {
+			flags.add('ambiguous');
+		}
+
+		let fromEntry: AttributedEvent | undefined;
+		let toEntry: AttributedEvent | undefined;
+		if (fromOccs.length > 0) {
+			const first = fromOccs[0];
+			fromEntry = first;
+			const toAfter = toOccsAll.filter(x => x.event.t_wall_us >= first.event.t_wall_us);
+			if (toAfter.length > 0) {
+				toEntry = toAfter[0];
+			}
+		}
+		if (!toEntry) {
+			flags.add('missing_to');
+		}
+
+		let durationMs;
+		let exactApprox: 'exact' | 'approx' | '' = '';
+		if (fromEntry && toEntry) {
+			if (fromEntry.attribution === 'time_attributed' || toEntry.attribution === 'time_attributed') {
+				flags.add('time_attributed');
+			}
+			if (spec.same_process) {
+				if (fromEntry.event.proc === toEntry.event.proc && fromEntry.event.pid === toEntry.event.pid) {
+					durationMs = (toEntry.event.t_mono_us - fromEntry.event.t_mono_us) / 1000;
+					exactApprox = 'exact';
+				} else {
+					flags.add('proc_mismatch');
+				}
+			} else {
+				durationMs = (toEntry.event.t_wall_us - fromEntry.event.t_wall_us) / 1000;
+				exactApprox = 'approx';
+			}
+			if (durationMs !== undefined && durationMs < 0) {
+				flags.add('negative');
+			}
+		}
+
+		rows.push({
+			sampleId: sample.sampleId,
+			language: '',
+			variant: '',
+			stage: spec.stage,
+			durationMs,
+			exactApprox,
+			flags: Array.from(flags),
+			fromCount: fromOccs.length,
+			toCount: toOccsAll.length,
+		});
+	}
+	return rows;
+}
+
+/**
+ * Prefers `language`/`variant` on a harness event's `attrs` when present;
+ * otherwise parses the sample id, which has the form
+ * `<test-title-slug>-r<repeatIndex>`. The slug has no reserved separator for
+ * a variant token, so absent attrs, `variant` falls back to the full slug.
+ */
+function sampleLanguageVariant(sample: Sample): { language: string; variant: string } {
+	for (const { event } of sample.events) {
+		if (event.proc === 'harness' && event.attrs) {
+			const lang = event.attrs.language;
+			const variant = event.attrs.variant;
+			if (typeof lang === 'string' || typeof variant === 'string') {
+				return {
+					language: typeof lang === 'string' ? lang : 'unknown',
+					variant: typeof variant === 'string' ? variant : 'unknown',
+				};
+			}
+		}
+	}
+	const slug = sample.sampleId.replace(/-r\d+$/, '');
+	const langMatch = slug.match(/(?:^|-)(python|r)(?:-|$)/);
+	return { language: langMatch ? langMatch[1] : 'unknown', variant: slug };
+}
+
+// ---------------------------------------------------------------------------
+// Clock alignment
+// ---------------------------------------------------------------------------
+
+function computeClockAlignment(events: TraceEvent[]): ClockAlignment[] {
+	const groups = new Map<string, TraceEvent[]>();
+	for (const e of events) {
+		if (e.name !== CLOCK_PAIR_NAME) {
+			continue;
+		}
+		const key = `${e.proc}:${e.pid}`;
+		let list = groups.get(key);
+		if (!list) {
+			list = [];
+			groups.set(key, list);
+		}
+		list.push(e);
+	}
+	const report = [];
+	for (const [key, list] of Array.from(groups).sort((a, b) => a[0].localeCompare(b[0]))) {
+		list.sort((a, b) => a.t_mono_us - b.t_mono_us);
+		const offsets = list.map(e => e.t_wall_us - e.t_mono_us);
+		const first = offsets[0];
+		const last = offsets[offsets.length - 1];
+		report.push({
+			key,
+			count: list.length,
+			offsetUs: first,
+			driftUs: list.length > 1 ? (last - first) : undefined,
+		});
+	}
+	return report;
+}
+
+// ---------------------------------------------------------------------------
+// Output: timeline-<sample_id>.txt
+// ---------------------------------------------------------------------------
+
+function padEndTo(s: string, width: number) {
+	return s.length >= width ? s : s.padEnd(width);
+}
+
+function padStartTo(s: string, width: number) {
+	return s.length >= width ? s : s.padStart(width);
+}
+
+function formatWallTime(tWallUs: number) {
+	const epochMs = Math.floor(tWallUs / 1000);
+	const microRemainder = tWallUs - epochMs * 1000;
+	const d = new Date(epochMs);
+	const hh = String(d.getHours()).padStart(2, '0');
+	const mm = String(d.getMinutes()).padStart(2, '0');
+	const ss = String(d.getSeconds()).padStart(2, '0');
+	const millis = String(d.getMilliseconds()).padStart(3, '0');
+	const micros = String(microRemainder).padStart(3, '0');
+	return `${hh}:${mm}:${ss}.${millis}${micros}`;
+}
+
+function formatIds(ids: TraceIds | undefined) {
+	if (!ids) {
+		return '-';
+	}
+	const parts = [];
+	for (const [k, v] of Object.entries(ids)) {
+		if (v !== undefined && v !== null) {
+			parts.push(`${k}=${v}`);
+		}
+	}
+	return parts.length ? parts.join(' ') : '-';
+}
+
+function buildTimeline(sample: Sample): string {
+	const rows = [...sample.events].sort((a, b) => a.event.t_wall_us - b.event.t_wall_us);
+	const keydown = rows.find(x => x.event.name === KEYDOWN_NAME);
+	const header = [
+		padEndTo('wall_time', 17),
+		padStartTo('d_prev_ms', 10),
+		padStartTo('d_keydown_ms', 12),
+		padEndTo('proc', 9),
+		padStartTo('pid', 7),
+		padEndTo('thread', 8),
+		padEndTo('name', 40),
+		padEndTo('ids', 50),
+		padEndTo('attrs', 24),
+		'attrib',
+	].join(' ');
+	const lines = [header];
+	let prev;
+	for (const row of rows) {
+		const e = row.event;
+		const wall = formatWallTime(e.t_wall_us);
+		const dPrev = prev ? ((e.t_wall_us - prev.t_wall_us) / 1000).toFixed(3) : '-';
+		const dKey = keydown ? ((e.t_wall_us - keydown.event.t_wall_us) / 1000).toFixed(3) : '-';
+		const attrsStr = e.attrs ? JSON.stringify(e.attrs) : '-';
+		lines.push([
+			padEndTo(wall, 17),
+			padStartTo(dPrev, 10),
+			padStartTo(dKey, 12),
+			padEndTo(e.proc, 9),
+			padStartTo(String(e.pid), 7),
+			padEndTo(e.thread ?? '-', 8),
+			padEndTo(e.name, 40),
+			padEndTo(formatIds(e.ids), 50),
+			padEndTo(attrsStr, 24),
+			row.attribution === 'id_attributed' ? 'id' : 'time',
+		].join(' '));
+		prev = e;
+	}
+	return lines.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Output: stages.csv
+// ---------------------------------------------------------------------------
+
+function csvEscape(v: string | number) {
+	const s = String(v);
+	if (/[",\n]/.test(s)) {
+		return `"${s.replace(/"/g, '""')}"`;
+	}
+	return s;
+}
+
+function writeStagesCsv(outDir: string, rows: StageRow[]) {
+	const lines = ['sample_id,language,variant,stage,duration_ms,exact_or_approx,flags'];
+	for (const r of rows) {
+		lines.push([
+			csvEscape(r.sampleId),
+			csvEscape(r.language),
+			csvEscape(r.variant),
+			csvEscape(r.stage),
+			r.durationMs === undefined ? '' : r.durationMs.toFixed(3),
+			csvEscape(r.exactApprox),
+			csvEscape(r.flags.join(';')),
+		].join(','));
+	}
+	writeFileSync(join(outDir, 'stages.csv'), lines.join('\n') + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Output: summary.md
+// ---------------------------------------------------------------------------
+
+function median(nums: number[]) {
+	const sorted = [...nums].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function mean(nums: number[]) {
+	return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+function hasDuration(row: StageRow): row is NumericStageRow {
+	return row.durationMs !== undefined;
+}
+
+function summarizeFlags(rows: StageRow[]) {
+	const counts = new Map();
+	for (const r of rows) {
+		for (const f of r.flags) {
+			counts.set(f, (counts.get(f) ?? 0) + 1);
+		}
+	}
+	if (counts.size === 0) {
+		return 'no data';
+	}
+	return Array.from(counts.entries()).map(([f, c]) => `${f} x${c}`).join(', ');
+}
+
+function writeSummary(outDir: string, allRows: StageRow[]) {
+	const groups = new Map<string, { language: string; variant: string; stages: Map<string, StageRow[]> }>();
+	for (const r of allRows) {
+		const key = `${r.language} ${r.variant}`;
+		let g = groups.get(key);
+		if (!g) {
+			g = { language: r.language, variant: r.variant, stages: new Map() };
+			groups.set(key, g);
+		}
+		let stage = g.stages.get(r.stage);
+		if (!stage) {
+			stage = [];
+			g.stages.set(r.stage, stage);
+		}
+		stage.push(r);
+	}
+
+	const lines = ['# Console execution latency summary', ''];
+	for (const g of Array.from(groups.values()).sort((a, b) =>
+		(a.language + a.variant).localeCompare(b.language + b.variant))) {
+		lines.push(`## ${g.language} / ${g.variant}`, '');
+		for (const spec of STAGES) {
+			const rows = g.stages.get(spec.stage) ?? [];
+			const numeric = rows.filter(hasDuration);
+			lines.push(`### ${spec.stage}`, '');
+			if (numeric.length === 0) {
+				lines.push(`No numeric samples (${summarizeFlags(rows)}).`, '');
+				continue;
+			}
+			const vals = numeric.map(r => r.durationMs);
+			if (numeric.length < 3) {
+				lines.push(`n=${numeric.length} -- fewer than 3 samples, median/mean not reported as stable.`, '');
+			} else {
+				lines.push(
+					`n=${numeric.length}  median=${median(vals).toFixed(3)}ms  mean=${mean(vals).toFixed(3)}ms  ` +
+					`min=${Math.min(...vals).toFixed(3)}ms  max=${Math.max(...vals).toFixed(3)}ms`,
+					'',
+				);
+			}
+			lines.push('Raw values:', '');
+			for (const r of numeric) {
+				const flagStr = r.flags.length ? ` [${r.flags.join(';')}]` : '';
+				lines.push(`- ${r.sampleId}: ${r.durationMs.toFixed(3)}ms${flagStr}`);
+			}
+			lines.push('');
+		}
+	}
+	writeFileSync(join(outDir, 'summary.md'), lines.join('\n') + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Output: gaps.md
+// ---------------------------------------------------------------------------
+
+function writeGaps(outDir: string, ctx: GapsContext) {
+	const { samples, unattributed, allRows, malformed, malformedByFile, clockAlignment } = ctx;
+	const lines = ['# Gaps and uncertainty', ''];
+
+	lines.push('## Unparseable lines', '');
+	if (malformedByFile.size === 0) {
+		lines.push('None.', '');
+	} else {
+		for (const [file, count] of malformedByFile) {
+			lines.push(`- ${file}: ${count}`);
+		}
+		lines.push(`- total: ${malformed}`, '');
+	}
+
+	lines.push('## Clock alignment', '');
+	lines.push(
+		'Offset is t_wall_us minus t_mono_us at a clock.pair, in microseconds. Drift is the ' +
+		'change in offset between the first and last clock.pair on that process/pid, and is the ' +
+		'uncertainty attached to every cross-process (approx) stage above and beyond its own value.',
+		'',
+	);
+	if (clockAlignment.length === 0) {
+		lines.push('No clock.pair events found.', '');
+	} else {
+		for (const c of clockAlignment) {
+			const driftStr = c.driftUs === undefined ? 'n/a (single pair)' : `${c.driftUs}us`;
+			lines.push(`- ${c.key}: pairs=${c.count} offset=${c.offsetUs}us drift=${driftStr}`);
+		}
+		lines.push('');
+	}
+
+	lines.push('## Unattributed events', '');
+	lines.push(`Count: ${unattributed.length}`, '');
+	const byReason = new Map();
+	for (const u of unattributed) {
+		const key = `${u.reason} / ${u.event.name}`;
+		byReason.set(key, (byReason.get(key) ?? 0) + 1);
+	}
+	if (byReason.size === 0) {
+		lines.push('None.', '');
+	} else {
+		for (const [key, count] of byReason) {
+			lines.push(`- ${key}: ${count}`);
+		}
+		lines.push('');
+	}
+
+	lines.push('## Samples missing expected events', '');
+	const allNames = new Set<string>();
+	for (const spec of STAGES) {
+		allNames.add(spec.from);
+		allNames.add(spec.to);
+	}
+	let anyMissing = false;
+	for (const sample of Array.from(samples.values()).sort((a, b) => a.sampleId.localeCompare(b.sampleId))) {
+		const seen = new Set(sample.events.map(x => x.event.name));
+		const missing = Array.from(allNames).filter(n => !seen.has(n));
+		if (missing.length > 0) {
+			anyMissing = true;
+			lines.push(`- ${sample.sampleId}: missing ${missing.join(', ')}`);
+		}
+	}
+	if (!anyMissing) {
+		lines.push('None.');
+	}
+	lines.push('');
+
+	lines.push('## Stages with no number', '');
+	const noNumber = allRows.filter(r => r.durationMs === undefined);
+	if (noNumber.length === 0) {
+		lines.push('None.', '');
+	} else {
+		for (const r of noNumber) {
+			lines.push(`- ${r.sampleId} / ${r.stage}: ${r.flags.join(';') || 'unknown'} (from_count=${r.fromCount} to_count=${r.toCount})`);
+		}
+		lines.push('');
+	}
+
+	lines.push('## Ambiguous endpoints', '');
+	const ambiguous = allRows.filter(r => r.flags.includes('ambiguous'));
+	if (ambiguous.length === 0) {
+		lines.push('None.', '');
+	} else {
+		for (const r of ambiguous) {
+			lines.push(`- ${r.sampleId} / ${r.stage}: from_count=${r.fromCount} to_count=${r.toCount}`);
+		}
+		lines.push('');
+	}
+
+	lines.push('## Negative durations', '');
+	const negative = allRows.filter(hasDuration).filter(r => r.flags.includes('negative'));
+	if (negative.length === 0) {
+		lines.push('None.', '');
+	} else {
+		for (const r of negative) {
+			lines.push(`- ${r.sampleId} / ${r.stage}: ${r.durationMs.toFixed(3)}ms`);
+		}
+		lines.push('');
+	}
+
+	lines.push('## time_attributed', '');
+	let timeAttributedEvents = 0;
+	for (const sample of samples.values()) {
+		timeAttributedEvents += sample.events.filter(x => x.attribution === 'time_attributed').length;
+	}
+	const timeAttributedStages = allRows.filter(r => r.flags.includes('time_attributed'));
+	lines.push(`Events attached by wall-clock containment rather than id: ${timeAttributedEvents}`);
+	lines.push(`Stages with a time_attributed endpoint: ${timeAttributedStages.length}`, '');
+
+	writeFileSync(join(outDir, 'gaps.md'), lines.join('\n') + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]) {
+	const args = argv.slice(2);
+	if (args.length === 0) {
+		console.error('usage: node analyze.mts <trace-dir> [--out <dir>]');
+		process.exit(1);
+	}
+	const traceDir = args[0];
+	let outDir;
+	for (let i = 1; i < args.length; i++) {
+		if (args[i] === '--out') {
+			outDir = args[i + 1];
+			i++;
+		}
+	}
+	return { traceDir, outDir: outDir ?? join(traceDir, 'analysis') };
+}
+
+function main() {
+	const { traceDir, outDir } = parseArgs(process.argv);
+	if (!existsSync(traceDir)) {
+		console.error(`trace directory not found: ${traceDir}`);
+		process.exit(1);
+	}
+	mkdirSync(outDir, { recursive: true });
+
+	const { events, malformed, malformedByFile } = loadAllEvents(traceDir);
+	const clockAlignment = computeClockAlignment(events);
+	const { samples, unattributed } = buildSamples(events);
+
+	const allRows = [];
+	for (const sample of Array.from(samples.values()).sort((a, b) => a.sampleId.localeCompare(b.sampleId))) {
+		const { language, variant } = sampleLanguageVariant(sample);
+		const rows = computeStages(sample).map(r => ({ ...r, language, variant }));
+		allRows.push(...rows);
+		writeFileSync(join(outDir, `timeline-${sample.sampleId}.txt`), buildTimeline(sample));
+	}
+
+	writeStagesCsv(outDir, allRows);
+	writeSummary(outDir, allRows);
+	writeGaps(outDir, { samples, unattributed, allRows, malformed, malformedByFile, clockAlignment });
+
+	const stagesComputed = allRows.filter(r => r.durationMs !== undefined).length;
+	const stagesFlagged = allRows.filter(r => r.flags.length > 0).length;
+	console.log(`samples found: ${samples.size}`);
+	console.log(`stages computed: ${stagesComputed}`);
+	console.log(`stages flagged: ${stagesFlagged}`);
+
+	// A layer whose log never reached the trace directory reports zero here.
+	// Read as an absence of events it is indistinguishable from a layer that
+	// stayed idle, and every stage crossing it is quietly dropped.
+	const byProc = new Map<TraceProc, number>(Array.from(VALID_PROCS, proc => [proc, 0] as const));
+	for (const e of events) {
+		byProc.set(e.proc, (byProc.get(e.proc) ?? 0) + 1);
+	}
+	console.log(`events by proc: ${Array.from(byProc, ([proc, n]) => `${proc}=${n}`).join(' ')}`);
+	for (const [proc, n] of byProc) {
+		if (n === 0) {
+			console.log(`WARNING: no ${proc} events found; every stage that crosses ${proc} is missing.`);
+		}
+	}
+	console.log(`output directory: ${outDir}`);
+}
+
+main();

--- a/test/e2e/utils/perf-trace/console-dom.ts
+++ b/test/e2e/utils/perf-trace/console-dom.ts
@@ -1,0 +1,326 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Page } from '@playwright/test';
+import { TraceEvent, TraceIds, TRACE_SCHEMA_VERSION, TraceName } from './schema.js';
+import { runId } from './recorder.js';
+
+/**
+ * Browser-side DOM readiness measurement, alongside the existing metric.
+ *
+ * The harness assertions poll the DOM through CDP, so they report the poll
+ * boundary a state change landed on rather than the change itself. A keydown
+ * listener and a `MutationObserver` on one browser clock give the change itself,
+ * and the difference between the two is the harness's own contribution.
+ *
+ * This observes DOM mutation, not paint. A node entering the DOM has not
+ * necessarily been rastered, so these numbers are not user-visible latency.
+ */
+
+const ACTIVE_CONSOLE_INSTANCE = '.console-instance[style*="z-index: auto"]';
+
+export type ConsoleDomSample = {
+	/** Browser `performance.timeOrigin`, for placing the browser clock on the wall timeline. */
+	timeOrigin: number;
+	/** Matches of the expected output already present when arming. */
+	baselineOutputCount: number;
+	/** `performance.now()` of the real Enter keydown on the console input. */
+	enter?: number;
+	/** First mutation at which a fresh match of the expected output is present. */
+	output?: number;
+	/** First observation of fresh output and a ready prompt together. */
+	ready?: number;
+	/** Whether the prompt was already ready when fresh output first appeared. */
+	promptReadyAtOutput: boolean;
+	/** Mutation batches the observer processed, to gauge its own cost. */
+	mutationBatches: number;
+	/** Conditions never observed, named rather than left as absent numbers. */
+	missing: string[];
+};
+
+/**
+ * The two globals the browser side installs.
+ *
+ * Declared so the evaluated code can reach them through one narrowing cast
+ * rather than an `any` at every access. `__positronPerfTrace` is the same object
+ * `src/vs/base/common/positronPerfTrace.ts` reads.
+ */
+type PerfDomWindow = Window & {
+	__positronPerfDom?: {
+		error?: string;
+		sample?: Omit<ConsoleDomSample, 'missing'>;
+		stop?: () => void;
+	};
+	__positronPerfTrace?: {
+		enabled: boolean;
+		runId?: string;
+		sampleId?: string;
+		events: TraceEvent[];
+	};
+};
+
+type ArmOptions = {
+	/** Text the executed expression is expected to produce. */
+	expectedOutput: string;
+	/** Prompt string that marks the console ready, e.g. `>` or `>>>`. */
+	prompt: string;
+	/** Propagated to renderer-side markers so they join the harness's sample. */
+	sampleId: string;
+};
+
+/**
+ * Installs the listener and observer, and switches on renderer-side markers.
+ *
+ * Call before pressing Enter and outside the measured interval: this is a CDP
+ * round trip and would otherwise be counted as execution latency.
+ */
+export async function armConsoleDomTrace(page: Page, options: ArmOptions): Promise<void> {
+	// Event names below are string literals, not `TraceName.*`: this callback is
+	// serialized and runs in the browser, which has no access to this module's
+	// scope. Referencing `TraceName` here type-checks but throws at runtime.
+	await page.evaluate(
+		({ activeSelector, expectedOutput, prompt, sampleId, traceRunId }) => {
+			const win = window as PerfDomWindow;
+			const active = document.querySelector(activeSelector);
+			if (!active) {
+				win.__positronPerfDom = { error: 'no active console instance' };
+				return;
+			}
+
+			// Renderer instrumentation is off until a sample arms it, so an
+			// ordinary run never allocates an event buffer.
+			const trace = {
+				enabled: true,
+				runId: traceRunId,
+				sampleId,
+				events: [] as TraceEvent[],
+			};
+			win.__positronPerfTrace = trace;
+
+			// Paired reading from the browser clock, so the analysis can report
+			// this process's drift rather than assuming there is none.
+			const armMono = performance.now();
+			trace.events.push({
+				v: 1,
+				run_id: traceRunId,
+				proc: 'renderer',
+				pid: 0,
+				name: 'clock.pair',
+				t_mono_us: Math.round(armMono * 1000),
+				t_wall_us: Math.round((performance.timeOrigin + armMono) * 1000),
+				ids: { sample_id: sampleId },
+			});
+
+			const freshOutputCount = () =>
+				Array.from(active.querySelectorAll('div span'))
+					.filter(node => (node.textContent ?? '').includes(expectedOutput)).length;
+
+			const promptReady = () => {
+				const line = active.querySelector('.active-line-number');
+				return (line?.textContent ?? '').trim() === prompt;
+			};
+
+			const baselineOutputCount = freshOutputCount();
+
+			const sample: {
+				timeOrigin: number;
+				baselineOutputCount: number;
+				enter?: number;
+				output?: number;
+				ready?: number;
+				promptReadyAtOutput: boolean;
+				mutationBatches: number;
+			} = {
+				timeOrigin: performance.timeOrigin,
+				baselineOutputCount,
+				promptReadyAtOutput: false,
+				mutationBatches: 0,
+			};
+
+			const onKeydown = (event: Event) => {
+				const key = event as KeyboardEvent;
+				if (key.key === 'Enter' && sample.enter === undefined) {
+					sample.enter = performance.now();
+				}
+				// The focus chord (`Cmd+K F`) is otherwise invisible here: this is
+				// the only marker for when the renderer actually receives it.
+				const now = performance.now();
+				trace.events.push({
+					v: 1,
+					run_id: traceRunId,
+					proc: 'renderer',
+					pid: 0,
+					name: 'renderer.keydown.any',
+					t_mono_us: Math.round(now * 1000),
+					t_wall_us: Math.round((performance.timeOrigin + now) * 1000),
+					ids: { sample_id: sampleId },
+					attrs: { key: key.key, code: key.code, ctrl: key.ctrlKey, meta: key.metaKey, alt: key.altKey, shift: key.shiftKey },
+				});
+			};
+			// Capture on the window: the console input's own element is replaced
+			// as the editor re-renders, so a listener bound to it can be lost.
+			window.addEventListener('keydown', onKeydown, true);
+
+			const check = () => {
+				const now = performance.now();
+				const hasFreshOutput = freshOutputCount() > baselineOutputCount;
+				if (!hasFreshOutput) {
+					return;
+				}
+				if (sample.output === undefined) {
+					sample.output = now;
+					sample.promptReadyAtOutput = promptReady();
+				}
+				// Both conditions are checked together, so a prompt that was
+				// already ready when output appeared does not wait for a further
+				// mutation that may never come.
+				if (sample.ready === undefined && promptReady()) {
+					sample.ready = now;
+					observer.disconnect();
+				}
+			};
+
+			const observer = new MutationObserver(() => {
+				sample.mutationBatches++;
+				check();
+			});
+			observer.observe(active, { childList: true, subtree: true, characterData: true });
+
+			// A blocked main thread produces no events at all, which reads the
+			// same as an idle one. Two detectors, because `longtask` did not
+			// report anything in the Electron renderer: the frame-gap fallback
+			// needs no entry-type support and catches the same stalls.
+			let longTasks: PerformanceObserver | undefined;
+			try {
+				longTasks = new PerformanceObserver(list => {
+					for (const entry of list.getEntries()) {
+						trace.events.push({
+							v: 1,
+							run_id: traceRunId,
+							proc: 'renderer',
+							pid: 0,
+							name: 'renderer.longtask',
+							t_mono_us: Math.round(entry.startTime * 1000),
+							t_wall_us: Math.round((performance.timeOrigin + entry.startTime) * 1000),
+							ids: { sample_id: sampleId },
+							attrs: { duration_ms: entry.duration, entry_name: entry.name },
+						});
+					}
+				});
+				longTasks.observe({ entryTypes: ['longtask'] });
+			} catch {
+				// Not every embedder supports the entry type; the frame-gap
+				// detector below covers the same ground without it.
+			}
+
+			// A frame that arrives late means the main thread was busy through
+			// it. Cheaper than it looks: one callback per frame, and it stops
+			// with the sample.
+			let framePending = true;
+			let lastFrame = performance.now();
+			const onFrame = () => {
+				if (!framePending) {
+					return;
+				}
+				const now = performance.now();
+				const gap = now - lastFrame;
+				if (gap >= 50) {
+					trace.events.push({
+						v: 1,
+						run_id: traceRunId,
+						proc: 'renderer',
+						pid: 0,
+						name: 'renderer.longtask',
+						t_mono_us: Math.round(lastFrame * 1000),
+						t_wall_us: Math.round((performance.timeOrigin + lastFrame) * 1000),
+						ids: { sample_id: sampleId },
+						attrs: { duration_ms: gap, entry_name: 'frame-gap' },
+					});
+				}
+				lastFrame = now;
+				requestAnimationFrame(onFrame);
+			};
+			requestAnimationFrame(onFrame);
+
+			win.__positronPerfDom = {
+				sample,
+				stop: () => {
+					framePending = false;
+					observer.disconnect();
+					longTasks?.disconnect();
+					window.removeEventListener('keydown', onKeydown, true);
+				},
+			};
+		},
+		{ activeSelector: ACTIVE_CONSOLE_INSTANCE, traceRunId: runId, ...options }
+	);
+}
+
+/**
+ * Retrieves the sample and tears down the observer.
+ *
+ * Call after the measured interval so the retrieval round trip is not part of
+ * what the browser clock reports.
+ */
+export async function drainConsoleDomTrace(page: Page): Promise<{ dom: ConsoleDomSample; rendererEvents: TraceEvent[] }> {
+	const raw = await page.evaluate(() => {
+		const win = window as PerfDomWindow;
+		const state = win.__positronPerfDom;
+		const trace = win.__positronPerfTrace;
+		const events: TraceEvent[] = trace?.events ?? [];
+		if (trace) { trace.enabled = false; }
+		if (!state || state.error || !state.sample) {
+			return { error: state?.error ?? 'not armed', sample: undefined, events };
+		}
+		state.stop?.();
+		return { error: undefined, sample: state.sample, events };
+	});
+
+	if (raw.error !== undefined || raw.sample === undefined) {
+		throw new Error(`Console DOM trace was not armed: ${raw.error ?? 'no sample'}`);
+	}
+
+	const sample = raw.sample;
+	const missing: string[] = [];
+	if (sample.enter === undefined) { missing.push('enter'); }
+	if (sample.output === undefined) { missing.push('output'); }
+	if (sample.ready === undefined) { missing.push('ready'); }
+
+	return {
+		dom: { ...sample, missing },
+		rendererEvents: raw.events,
+	};
+}
+
+/**
+ * Converts the browser-clock readings into trace events.
+ *
+ * The browser's `performance.now()` origin is unrelated to the harness's, so
+ * each reading is paired with its wall equivalent derived from the browser's own
+ * `timeOrigin` rather than being compared to a harness monotonic value.
+ */
+export function domSampleToEvents(dom: ConsoleDomSample, ids: TraceIds): TraceEvent[] {
+	const events: TraceEvent[] = [];
+
+	const push = (name: string, mono?: number) => {
+		if (mono === undefined) { return; }
+		events.push({
+			v: TRACE_SCHEMA_VERSION,
+			run_id: runId,
+			proc: 'renderer',
+			pid: 0,
+			name,
+			t_mono_us: Math.round(mono * 1000),
+			t_wall_us: Math.round((dom.timeOrigin + mono) * 1000),
+			ids,
+		});
+	};
+
+	push(TraceName.renderer.enterKeydown, dom.enter);
+	push(TraceName.renderer.domOutput, dom.output);
+	push(TraceName.renderer.domReady, dom.ready);
+
+	return events;
+}

--- a/test/e2e/utils/perf-trace/recorder.ts
+++ b/test/e2e/utils/perf-trace/recorder.ts
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { appendFileSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { performance } from 'perf_hooks';
+import os from 'os';
+import path from 'path';
+import { TraceEvent, TraceIds, TraceProc, TRACE_SCHEMA_VERSION, TraceName } from './schema.js';
+
+/**
+ * Harness-side trace recorder.
+ *
+ * Enabled only when `POSITRON_PERF_TRACE_DIR` is set, so an ordinary e2e run
+ * pays a boolean check per marker and nothing else. Events accumulate in memory
+ * and are appended once per sample: a synchronous write per marker would show up
+ * in the interval being measured.
+ */
+
+const TRACE_DIR = process.env.POSITRON_PERF_TRACE_DIR;
+
+export const traceEnabled = Boolean(TRACE_DIR);
+
+/**
+ * Hands this process's pid and trace directory to processes that cannot see its
+ * environment.
+ *
+ * The extension host is the case that forced this: `getResolvedShellEnv` returns
+ * `{}` when the app was launched from a CLI, which is how Playwright starts it,
+ * so `POSITRON_PERF_TRACE_DIR` never reaches the extensions. The path is
+ * hardcoded rather than `os.tmpdir()` for the same reason: with no `TMPDIR` in
+ * that empty environment, the extension host would resolve a different one.
+ *
+ * Written at module load, before the app fixture launches, and removed on exit.
+ * The pid is what makes a pointer this process never got to remove harmless: an
+ * extension traces only while the writer is alive, so a crashed run cannot leave
+ * every later session appending trace files.
+ */
+const POINTER_FILE = process.platform === 'win32'
+	? path.join(os.tmpdir(), 'positron-perf-trace-dir')
+	: '/tmp/positron-perf-trace-dir';
+
+if (TRACE_DIR) {
+	mkdirSync(TRACE_DIR, { recursive: true });
+	writeFileSync(POINTER_FILE, `${process.pid}\n${TRACE_DIR}`);
+	process.on('exit', () => {
+		try {
+			rmSync(POINTER_FILE, { force: true });
+		} catch {
+			// Nothing useful to do while exiting.
+		}
+	});
+}
+
+export const runId =
+	process.env.POSITRON_PERF_TRACE_RUN_ID ||
+	process.env.GITHUB_RUN_ID ||
+	`local-${Date.now()}`;
+
+/**
+ * Wall and monotonic microseconds, read back to back.
+ *
+ * `performance.timeOrigin` plus `performance.now()` keeps sub-millisecond wall
+ * resolution, which `Date.now()` would round away -- and rounding matters here,
+ * because several of the intervals under investigation are single-digit
+ * milliseconds.
+ */
+function clocks(): { t_mono_us: number; t_wall_us: number } {
+	const mono = performance.now();
+	return {
+		t_mono_us: Math.round(mono * 1000),
+		t_wall_us: Math.round((performance.timeOrigin + mono) * 1000),
+	};
+}
+
+export class TraceRecorder {
+	private readonly events: TraceEvent[] = [];
+	private readonly file: string;
+
+	constructor(public readonly sampleId: string) {
+		// One file per sample keeps concurrent workers from interleaving writes
+		// into a single file, and keeps a failed sample's events on disk.
+		this.file = path.join(TRACE_DIR ?? '.', `harness-${sampleId}.jsonl`);
+		if (traceEnabled) {
+			mkdirSync(TRACE_DIR!, { recursive: true });
+			this.clockPair();
+		}
+	}
+
+	/** Records a checkpoint. A no-op when tracing is off. */
+	mark(name: string, ids?: TraceIds, attrs?: TraceEvent['attrs']): void {
+		if (!traceEnabled) { return; }
+		this.push('harness', name, ids, attrs);
+	}
+
+	/**
+	 * Brackets an operation with `<name>.start` / `<name>.end` markers.
+	 *
+	 * The end marker is emitted even when the operation throws, so a timed-out
+	 * assertion still reports where the interval ended.
+	 */
+	async span<T>(startName: string, endName: string, operation: () => Promise<T>, ids?: TraceIds): Promise<T> {
+		this.mark(startName, ids);
+		try {
+			return await operation();
+		} finally {
+			this.mark(endName, ids);
+		}
+	}
+
+	/**
+	 * Adopts events produced in another process, rebasing nothing: they carry
+	 * their own clocks and the analysis aligns them.
+	 */
+	adopt(events: TraceEvent[]): void {
+		if (!traceEnabled) { return; }
+		this.events.push(...events);
+	}
+
+	clockPair(proc: TraceProc = 'harness'): void {
+		if (!traceEnabled) { return; }
+		this.push(proc, TraceName.clockPair);
+	}
+
+	/** Appends everything buffered so far. Safe to call more than once. */
+	flush(): void {
+		if (!traceEnabled || this.events.length === 0) { return; }
+		const lines = this.events.map(event => JSON.stringify(event)).join('\n') + '\n';
+		this.events.length = 0;
+		appendFileSync(this.file, lines);
+	}
+
+	private push(proc: TraceProc, name: string, ids?: TraceIds, attrs?: TraceEvent['attrs']): void {
+		this.events.push({
+			v: TRACE_SCHEMA_VERSION,
+			run_id: runId,
+			proc,
+			pid: process.pid,
+			name,
+			...clocks(),
+			ids: { sample_id: this.sampleId, ...ids },
+			...(attrs ? { attrs } : {}),
+		});
+	}
+}
+
+/**
+ * The recorder for the sample currently being measured.
+ *
+ * Page objects mark against this rather than receiving a recorder, so the
+ * shared `waitForConsoleContents()` and `waitForReady()` helpers can be
+ * instrumented in place. Instrumenting the real helpers is the point: a copy of
+ * their steps in the test would measure the copy, not what the metric runs.
+ * Single-valued because a timing run uses one worker.
+ */
+let current: TraceRecorder | undefined;
+
+export function setCurrentRecorder(recorder: TraceRecorder | undefined): void {
+	current = recorder;
+}
+
+/** Marks against the current sample, if a sample is being measured. */
+export function mark(name: string, ids?: TraceIds, attrs?: TraceEvent['attrs']): void {
+	current?.mark(name, ids, attrs);
+}
+
+/** Brackets an operation against the current sample. */
+export async function span<T>(startName: string, endName: string, operation: () => Promise<T>): Promise<T> {
+	if (!current) {
+		return operation();
+	}
+	return current.span(startName, endName, operation);
+}
+
+/**
+ * A stable, filesystem-safe sample identifier.
+ *
+ * Repeated measurement runs the whole Playwright invocation again rather than
+ * using `--repeat-each`, because the app and session are worker-scoped: a second
+ * repetition would execute the same expression into the same warm console, which
+ * both breaks the spec's exact-count assertion and measures a different
+ * experiment. The iteration therefore arrives from the environment, and the
+ * repeat index is kept only so an accidental `--repeat-each` still separates.
+ */
+export function makeSampleId(testTitle: string, repeatIndex: number): string {
+	const slug = testTitle.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '').toLowerCase();
+	const tag = process.env.POSITRON_PERF_TRACE_SAMPLE_TAG;
+	return `${slug}${tag ? `-${tag}` : ''}-r${repeatIndex}`;
+}

--- a/test/e2e/utils/perf-trace/schema.ts
+++ b/test/e2e/utils/perf-trace/schema.ts
@@ -1,0 +1,348 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Event schema shared by every layer that emits console-execution timing.
+ *
+ * Five processes emit events: the Playwright harness, the Electron renderer, the
+ * extension host (`positron-supervisor` and `positron-r`), and Ark. Each writes
+ * `TraceEvent` records as JSONL; the analysis tool joins them.
+ *
+ * Correlation rides on identifiers the protocols already carry rather than a new
+ * wire field, so no layer's message format changes and Kallichore needs no
+ * modification. The chain is:
+ *
+ *   sample_id      harness, set on the renderer at arm time
+ *   submission_id  renderer, one per Enter
+ *   execution_id   renderer -> extension host, Positron's own execution id
+ *   jupyter_msg_id extension host -> Ark, and Ark's IOPub `parent_msg_id`
+ *   lsp_request_id positron-r -> Ark, for the input-boundary hop
+ *
+ * Each layer logs the identifier it hands to the next, so the analysis can walk
+ * the chain without correlating by expression text (the same expression repeats
+ * across samples).
+ *
+ * Clocks: `t_mono_us` is process-local and only ever subtracted within one
+ * process. `t_wall_us` places events on a common timeline. Every process emits
+ * `clock.pair` at trace start and end, reading both clocks back to back, so the
+ * analysis can convert monotonic to wall with a measured offset and report the
+ * residual drift as uncertainty rather than hiding it.
+ */
+
+export const TRACE_SCHEMA_VERSION = 1;
+
+/** Which process emitted an event. Determines which clock origin applies. */
+export type TraceProc = 'harness' | 'renderer' | 'exthost' | 'ark';
+
+/**
+ * Identifiers carried by an event. Every field is optional: a layer records only
+ * the identifiers it actually has, and the analysis flags a broken chain rather
+ * than guessing across a gap.
+ */
+export type TraceIds = {
+	sample_id?: string;
+	submission_id?: string;
+	execution_id?: string;
+	jupyter_msg_id?: string;
+	parent_msg_id?: string;
+	lsp_request_id?: string | number;
+};
+
+/**
+ * One timing checkpoint.
+ *
+ * `attrs` carries metadata only, never output bodies or source text: a timing
+ * log that contains the console output is both large enough to perturb the
+ * measurement and unusable as an artifact.
+ */
+export type TraceEvent = {
+	v: number;
+	run_id: string;
+	proc: TraceProc;
+	pid: number;
+	/** Emitting thread where a process has more than one that matters (Ark). */
+	thread?: string;
+	name: string;
+	t_mono_us: number;
+	t_wall_us: number;
+	ids?: TraceIds;
+	attrs?: Record<string, string | number | boolean | null>;
+};
+
+/**
+ * Event names, grouped by emitting layer.
+ *
+ * The catalogue for harness call sites and for `STAGES` below. Product and
+ * extension call sites spell the same names as literals, since `src/vs` and the
+ * extensions cannot import from `test/`, so this file is the reference for them
+ * rather than the definition. `analyze.mts` reports any name in `STAGES` that no
+ * sample carries, which is what catches a literal that drifted from this list.
+ *
+ * A `.start`/`.end` pair brackets an interval measured in one process; a bare
+ * name is an instant.
+ */
+export const TraceName = {
+	clockPair: 'clock.pair',
+
+	harness: {
+		sampleStart: 'harness.sample.start',
+		armStart: 'harness.arm.start',
+		armEnd: 'harness.arm.end',
+		enterPressStart: 'harness.enter.press.start',
+		enterPressEnd: 'harness.enter.press.end',
+		outputAssertStart: 'harness.output.assert.start',
+		outputAssertEnd: 'harness.output.assert.end',
+		textRetrieveStart: 'harness.text.retrieve.start',
+		textRetrieveEnd: 'harness.text.retrieve.end',
+		focusStart: 'harness.focus.start',
+		focusEnd: 'harness.focus.end',
+		promptAssertStart: 'harness.prompt.assert.start',
+		promptAssertEnd: 'harness.prompt.assert.end',
+		sampleEnd: 'harness.sample.end',
+		drainStart: 'harness.drain.start',
+		drainEnd: 'harness.drain.end',
+	},
+
+	renderer: {
+		enterKeydown: 'renderer.enter.keydown',
+		enterHandler: 'renderer.enter.handler',
+		submitEntry: 'renderer.submit.entry',
+		submitFlow: 'renderer.submit.flow',
+		boundariesRequest: 'renderer.boundaries.request',
+		boundariesResponse: 'renderer.boundaries.response',
+		executeDispatch: 'renderer.execute.dispatch',
+		executeProxySend: 'renderer.execute.proxy_send',
+		provisionalInputEcho: 'renderer.provisional_input.echo',
+		runtimeMessageOutput: 'renderer.runtime.msg.output',
+		runtimeMessageState: 'renderer.runtime.msg.state',
+		modelUpdate: 'renderer.model.update',
+		/**
+		 * The runtime-items emitter coalesced a fire. Above 20 fires in a
+		 * rolling 50ms window it defers delivery by 50ms, which delays the
+		 * React re-render and so the appearance of output in the DOM.
+		 */
+		itemsEmitterThrottled: 'renderer.items_emitter.throttled',
+		itemsEmitterDelivered: 'renderer.items_emitter.delivered',
+		/**
+		 * A runtime event arrived out of Lamport-clock sequence, so the whole
+		 * queue -- output included -- waits up to 250ms for the missing
+		 * predecessor.
+		 */
+		eventQueueDefer: 'renderer.event_queue.defer',
+		eventQueueProcess: 'renderer.event_queue.process',
+		stateReady: 'renderer.state.ready',
+		/**
+		 * A main-thread block reported by `PerformanceObserver`. Without this a
+		 * stalled renderer shows up only as an absence of events, which cannot
+		 * be told apart from an idle one.
+		 */
+		longTask: 'renderer.longtask',
+		domOutput: 'renderer.dom.output',
+		domReady: 'renderer.dom.ready',
+		/**
+		 * Every keydown while a sample is armed, tagged with the key and its
+		 * modifiers. The focus chord (`Cmd+K F`) is otherwise invisible on this
+		 * timeline: nothing marks when the renderer actually receives it.
+		 */
+		keydownAny: 'renderer.keydown.any',
+		/**
+		 * Brackets `FocusConsole`'s command handler. Separates a cost inside it
+		 * (e.g. `openView` activating something on first focus) from a cost
+		 * upstream of it, between the harness's keypress and the handler running.
+		 */
+		focusConsoleStart: 'renderer.focus_console.start',
+		focusConsoleEnd: 'renderer.focus_console.end',
+	},
+
+	exthost: {
+		supervisorExecuteEntry: 'exthost.supervisor.execute.entry',
+		supervisorCompletenessStart: 'exthost.supervisor.completeness.start',
+		supervisorCompletenessEnd: 'exthost.supervisor.completeness.end',
+		supervisorBarrierWaitStart: 'exthost.supervisor.barrier.wait.start',
+		supervisorBarrierWaitEnd: 'exthost.supervisor.barrier.wait.end',
+		supervisorMessageBuild: 'exthost.supervisor.msg.build',
+		supervisorSocketSend: 'exthost.supervisor.socket.send',
+		supervisorIopubReceive: 'exthost.supervisor.iopub.recv',
+		supervisorPendingResolve: 'exthost.supervisor.pending.resolve',
+		supervisorEventEmit: 'exthost.supervisor.event.emit',
+		rBoundariesProviderEntry: 'exthost.r.boundaries.provider.entry',
+		/**
+		 * LSP client lifecycle. The `starting` to `running` handshake runs
+		 * inside the measured interval on the first R submission, because the
+		 * harness's focus chord makes R the foreground session and that starts
+		 * the LSP.
+		 */
+		rLspClientStarting: 'exthost.r.lsp.client.starting',
+		rLspClientRunning: 'exthost.r.lsp.client.running',
+		rLspSend: 'exthost.r.lsp.send',
+		rLspResponse: 'exthost.r.lsp.response',
+	},
+
+	ark: {
+		shellReceive: 'ark.shell.recv',
+		executeEnqueue: 'ark.execute.enqueue',
+		executePickup: 'ark.execute.pickup',
+		executeEvalStart: 'ark.execute.eval.start',
+		executeEvalEnd: 'ark.execute.eval.end',
+		executeReplySend: 'ark.execute.reply.send',
+		iopubEnqueue: 'ark.iopub.enqueue',
+		/**
+		 * The IOPub thread handed the message to the outbound channel. A third
+		 * thread performs the zmq write, so this is neither the enqueue nor the
+		 * transmission.
+		 */
+		iopubForward: 'ark.iopub.forward',
+		iopubSocketSend: 'ark.iopub.socket.send',
+		/**
+		 * Stream output is held in a buffer flushed on an 80ms tick, so stdout
+		 * carries a delay that has nothing to do with evaluation time.
+		 */
+		iopubStreamBufferFlush: 'ark.iopub.stream_buffer.flush',
+		/**
+		 * Top-level autoprint output is accumulated to ride on the execute
+		 * reply instead of going out over IOPub, which is why a bare expression
+		 * and a `cat()` call reach the frontend by different routes.
+		 */
+		autoprintBuffered: 'ark.autoprint.buffered',
+		lspBoundariesIngress: 'ark.lsp.boundaries.ingress',
+		lspBoundariesHandler: 'ark.lsp.boundaries.handler',
+		lspRtaskEnqueue: 'ark.lsp.rtask.enqueue',
+		/**
+		 * Fires for every sync R task, because a queued task carries no origin.
+		 * The boundary stage below therefore assumes the first pickup after its
+		 * enqueue is the one it wants.
+		 */
+		rtaskPickup: 'ark.rtask.pickup',
+		/**
+		 * Paired with the pickup above. Without it a quiet stretch in the
+		 * timeline cannot be distinguished from an idle R thread.
+		 */
+		rtaskComplete: 'ark.rtask.complete',
+		lspParseDone: 'ark.lsp.parse.done',
+		lspBoundariesResponse: 'ark.lsp.boundaries.response',
+		/**
+		 * LSP server startup. Every other `ark.lsp.*` marker covers input
+		 * boundaries or the synthetic write, so startup was entirely unmeasured
+		 * despite being the current leading suspect.
+		 */
+		lspServerStart: 'ark.lsp.server.start',
+		lspInitializeRequest: 'ark.lsp.initialize.request',
+		lspInitializeHandler: 'ark.lsp.initialize.handler',
+		lspInitializeResponse: 'ark.lsp.initialize.response',
+		lspInitialized: 'ark.lsp.initialized',
+		lspIndexWarmStart: 'ark.lsp.index.warm.start',
+		lspIndexWarmEnd: 'ark.lsp.index.warm.end',
+		lspSyntheticWriteStart: 'ark.lsp.synthetic_write.start',
+		lspSyntheticWriteEnd: 'ark.lsp.synthetic_write.end',
+		completeShellReceive: 'ark.complete.shell.recv',
+		completeRtaskPickup: 'ark.complete.rtask.pickup',
+		completeParseDone: 'ark.complete.parse.done',
+		completeReplySend: 'ark.complete.reply.send',
+	},
+} as const;
+
+/**
+ * Stage definitions the analysis tool turns into a duration table.
+ *
+ * `same_process` stages are subtracted from monotonic clocks and are exact.
+ * Cross-process stages are subtracted from wall clocks and inherit the
+ * clock-alignment uncertainty, which the report states alongside the value.
+ */
+export type StageSpec = {
+	stage: string;
+	from: string;
+	to: string;
+	same_process: boolean;
+};
+
+export const STAGES: readonly StageSpec[] = [
+	// Harness-visible intervals. These reproduce the shape of the existing
+	// metric, so a change in the metric can be attributed to one of its parts.
+	{ stage: 'harness.enter_press', from: TraceName.harness.enterPressStart, to: TraceName.harness.enterPressEnd, same_process: true },
+	{ stage: 'harness.output_assert', from: TraceName.harness.outputAssertStart, to: TraceName.harness.outputAssertEnd, same_process: true },
+	{ stage: 'harness.text_retrieve', from: TraceName.harness.textRetrieveStart, to: TraceName.harness.textRetrieveEnd, same_process: true },
+	{ stage: 'harness.focus', from: TraceName.harness.focusStart, to: TraceName.harness.focusEnd, same_process: true },
+	{ stage: 'harness.prompt_assert', from: TraceName.harness.promptAssertStart, to: TraceName.harness.promptAssertEnd, same_process: true },
+	{ stage: 'harness.total', from: TraceName.harness.sampleStart, to: TraceName.harness.sampleEnd, same_process: true },
+
+	// Browser DOM readiness, all on one clock, so these are the reference
+	// against which the harness intervals are judged.
+	{ stage: 'dom.enter_to_output', from: TraceName.renderer.enterKeydown, to: TraceName.renderer.domOutput, same_process: true },
+	{ stage: 'dom.enter_to_ready', from: TraceName.renderer.enterKeydown, to: TraceName.renderer.domReady, same_process: true },
+
+	// Renderer submission path, one clock throughout.
+	{ stage: 'renderer.keydown_to_submit', from: TraceName.renderer.enterKeydown, to: TraceName.renderer.submitEntry, same_process: true },
+	{ stage: 'renderer.boundaries_roundtrip', from: TraceName.renderer.boundariesRequest, to: TraceName.renderer.boundariesResponse, same_process: true },
+	{ stage: 'renderer.boundaries_to_dispatch', from: TraceName.renderer.boundariesResponse, to: TraceName.renderer.executeDispatch, same_process: true },
+	{ stage: 'renderer.dispatch_to_first_output_msg', from: TraceName.renderer.executeDispatch, to: TraceName.renderer.runtimeMessageOutput, same_process: true },
+	{ stage: 'renderer.output_msg_to_model', from: TraceName.renderer.runtimeMessageOutput, to: TraceName.renderer.modelUpdate, same_process: true },
+	{ stage: 'renderer.model_to_dom', from: TraceName.renderer.modelUpdate, to: TraceName.renderer.domOutput, same_process: true },
+	{ stage: 'renderer.output_msg_to_dom', from: TraceName.renderer.runtimeMessageOutput, to: TraceName.renderer.domOutput, same_process: true },
+	{ stage: 'renderer.state_ready_to_dom_ready', from: TraceName.renderer.stateReady, to: TraceName.renderer.domReady, same_process: true },
+	// Two renderer-side holds that would otherwise be misread as kernel or
+	// transport latency. Both are bounded waits on a timer, not work.
+	{ stage: 'renderer.event_queue_hold', from: TraceName.renderer.eventQueueDefer, to: TraceName.renderer.eventQueueProcess, same_process: true },
+	{ stage: 'renderer.items_emitter_hold', from: TraceName.renderer.itemsEmitterThrottled, to: TraceName.renderer.itemsEmitterDelivered, same_process: true },
+	{ stage: 'renderer.focus_console', from: TraceName.renderer.focusConsoleStart, to: TraceName.renderer.focusConsoleEnd, same_process: true },
+
+	// The input-boundary hop, split across three processes. The enclosing
+	// renderer round trip above stays reliable even where this subdivision does not.
+	{ stage: 'boundaries.renderer_to_provider', from: TraceName.renderer.boundariesRequest, to: TraceName.exthost.rBoundariesProviderEntry, same_process: false },
+	{ stage: 'boundaries.provider_to_lsp_send', from: TraceName.exthost.rBoundariesProviderEntry, to: TraceName.exthost.rLspSend, same_process: true },
+	{ stage: 'boundaries.lsp_send_to_ark_ingress', from: TraceName.exthost.rLspSend, to: TraceName.ark.lspBoundariesIngress, same_process: false },
+	{ stage: 'boundaries.ark_main_loop_wait', from: TraceName.ark.lspBoundariesIngress, to: TraceName.ark.lspBoundariesHandler, same_process: true },
+	{ stage: 'boundaries.ark_rtask_wait', from: TraceName.ark.lspRtaskEnqueue, to: TraceName.ark.rtaskPickup, same_process: true },
+	{ stage: 'boundaries.ark_parse', from: TraceName.ark.rtaskPickup, to: TraceName.ark.lspParseDone, same_process: true },
+	{ stage: 'boundaries.ark_response_to_exthost', from: TraceName.ark.lspBoundariesResponse, to: TraceName.exthost.rLspResponse, same_process: false },
+
+	// Execution dispatch through the supervisor and Kallichore. The relay is
+	// bracketed, not instrumented: this interval includes transport and
+	// scheduling as well as Kallichore's own work.
+	// Spans the RPC, `$executeCode`, and the session lookup together. The
+	// intermediate hop in `extHostLanguageRuntime` is not marked: the extension
+	// host half of `src/vs` has no file sink, and adding one there would buy a
+	// subdivision of an interval this already bounds.
+	{ stage: 'execute.renderer_to_supervisor', from: TraceName.renderer.executeProxySend, to: TraceName.exthost.supervisorExecuteEntry, same_process: false },
+	{ stage: 'execute.supervisor_barrier_wait', from: TraceName.exthost.supervisorBarrierWaitStart, to: TraceName.exthost.supervisorBarrierWaitEnd, same_process: true },
+	{ stage: 'execute.supervisor_build_to_send', from: TraceName.exthost.supervisorMessageBuild, to: TraceName.exthost.supervisorSocketSend, same_process: true },
+	{ stage: 'execute.relay_send_to_ark', from: TraceName.exthost.supervisorSocketSend, to: TraceName.ark.shellReceive, same_process: false },
+
+	// Ark execution, all on Ark's clock.
+	{ stage: 'ark.execute_queue_wait', from: TraceName.ark.executeEnqueue, to: TraceName.ark.executePickup, same_process: true },
+	{ stage: 'ark.execute_eval', from: TraceName.ark.executeEvalStart, to: TraceName.ark.executeEvalEnd, same_process: true },
+	{ stage: 'ark.iopub_enqueue_to_forward', from: TraceName.ark.iopubEnqueue, to: TraceName.ark.iopubForward, same_process: true },
+	{ stage: 'ark.iopub_forward_to_send', from: TraceName.ark.iopubForward, to: TraceName.ark.iopubSocketSend, same_process: true },
+	{ stage: 'ark.iopub_enqueue_to_send', from: TraceName.ark.iopubEnqueue, to: TraceName.ark.iopubSocketSend, same_process: true },
+	// The 80ms stream-buffer tick sits between output being produced and being
+	// transmitted, so it is measured on its own rather than folded into the
+	// enqueue-to-send total.
+	{ stage: 'ark.stream_buffer_hold', from: TraceName.ark.iopubEnqueue, to: TraceName.ark.iopubStreamBufferFlush, same_process: true },
+	// The synthetic Salsa write blocks the LSP main loop until every
+	// outstanding database reader drops, which is the mechanism #1315 introduced.
+	{ stage: 'ark.synthetic_write_wait', from: TraceName.ark.lspSyntheticWriteStart, to: TraceName.ark.lspSyntheticWriteEnd, same_process: true },
+	{ stage: 'ark.shell_recv_to_reply', from: TraceName.ark.shellReceive, to: TraceName.ark.executeReplySend, same_process: true },
+
+	// The return leg. `ark.iopub.socket.send` is the real transmission, not the
+	// enqueue, so this measures the relay rather than Ark's own queue.
+	{ stage: 'return.ark_send_to_supervisor', from: TraceName.ark.iopubSocketSend, to: TraceName.exthost.supervisorIopubReceive, same_process: false },
+	{ stage: 'return.supervisor_to_renderer', from: TraceName.exthost.supervisorEventEmit, to: TraceName.renderer.runtimeMessageOutput, same_process: false },
+
+	// LSP startup, the current leading suspect. On the first R submission this
+	// whole sequence runs inside the measured interval.
+	{ stage: 'lsp_startup.ark_server_start_to_initialize', from: TraceName.ark.lspServerStart, to: TraceName.ark.lspInitializeRequest, same_process: true },
+	{ stage: 'lsp_startup.ark_initialize', from: TraceName.ark.lspInitializeRequest, to: TraceName.ark.lspInitializeResponse, same_process: true },
+	{ stage: 'lsp_startup.ark_initialize_queue_wait', from: TraceName.ark.lspInitializeRequest, to: TraceName.ark.lspInitializeHandler, same_process: true },
+	{ stage: 'lsp_startup.ark_index_warm', from: TraceName.ark.lspIndexWarmStart, to: TraceName.ark.lspIndexWarmEnd, same_process: true },
+	{ stage: 'lsp_startup.client_handshake', from: TraceName.exthost.rLspClientStarting, to: TraceName.exthost.rLspClientRunning, same_process: true },
+	{ stage: 'lsp_startup.ark_start_to_client_running', from: TraceName.ark.lspServerStart, to: TraceName.exthost.rLspClientRunning, same_process: false },
+
+	// A queued task carries no origin, so this pairs the first pickup with the
+	// first completion and is flagged ambiguous whenever more than one ran.
+	{ stage: 'ark.rtask_duration', from: TraceName.ark.rtaskPickup, to: TraceName.ark.rtaskComplete, same_process: true },
+
+	// The gap the reassessment cares about: how much of the recorded metric is
+	// the harness noticing a state change that already happened.
+	{ stage: 'gap.dom_ready_to_harness_end', from: TraceName.renderer.domReady, to: TraceName.harness.sampleEnd, same_process: false },
+] as const;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: e2e feature tags are auto-added based on your changed
  files, so tests run automatically when you open this pull request. Add tags
  here yourself to run more.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
