### PR TITLE
drive-positron: automation launch arguments, quick pick enumeration, and warm relaunch

### DIFF
--- a/.claude/skills/drive-positron/SKILL.md
+++ b/.claude/skills/drive-positron/SKILL.md
@@ -77,9 +77,6 @@ Run:
 
 ```bash
 .claude/skills/drive-positron/scripts/launch.sh -- \
-	--use-mock-keychain \
-	--disable-workspace-trust \
-	--skip-welcome \
 	--folder-uri file:///private/tmp/myworkspace
 ```
 
@@ -100,16 +97,24 @@ The launcher:
 - converts the profile paths for the native binary on Windows;
 - waits for CDP and verifies that the app remains alive before returning.
 
-### Required launch arguments
+### Pass the workspace yourself
 
 | Argument | Purpose |
 |---|---|
 | `--folder-uri file:///private/tmp/myworkspace` | Open a workspace reliably. Do not pass a bare positional folder: Positron may discard it. On macOS, use the canonical `/private/tmp` path rather than `/tmp`. On Windows the URI needs a drive letter, so build it with `cygpath -m`: `--folder-uri "file:///$(cygpath -m /tmp/myworkspace)"`. |
-| `--disable-workspace-trust` | Prevent a modal trust dialog from blocking automation when the seed profile has no trust state. |
+
+### Arguments the launcher supplies
+
+You do not pass these, and should not need to think about them:
+
+| Argument | Purpose |
+|---|---|
+| `--disable-workspace-trust` | Prevent a modal trust dialog from blocking automation when the seed profile has no trust state. Without it the app starts in restricted mode with extensions disabled, so interpreter discovery never runs and an empty picker looks like a product bug. |
 | `--use-mock-keychain` | Avoid using the per-user OS keychain from the disposable instance. A `GitHubLoginFailed` message in the log is expected. |
 | `--skip-welcome` | Keep the Welcome editor from receiving the initial focus. |
+| `--shared-data-dir` | Keep the disposable instance off the normal `~/.positron-shared` store. |
 
-The launcher supplies `--shared-data-dir` automatically, so the disposable instance does not use the normal `~/.positron-shared` store.
+Repeating one of the first three after `--` overrides the supplied copy. Pass `--no-default-app-args` before `--` to launch without any of them, which is only useful when the scenario under test is one of the behaviors they suppress, such as the workspace trust prompt itself.
 
 ## Protect the source profile
 

--- a/.claude/skills/drive-positron/SKILL.md
+++ b/.claude/skills/drive-positron/SKILL.md
@@ -49,7 +49,8 @@ Tools they expect on `PATH`:
 | `node`, `npx` | all | `@playwright/cli` resolves from the repo's `node_modules` |
 | `curl` | `launch.sh`, `stop.sh` | CDP readiness and liveness probes |
 | `rsync` or `tar` | `launch.sh` | `rsync` preferred; `tar` is the fallback, and is what Git Bash has |
-| `jq` | `monaco-paste.sh` | not present in a bare Git Bash; install it separately |
+| `jq` | `monaco-paste.sh`, `quickpick-enum.sh` | not present in a bare Git Bash; install it separately |
+| `sqlite3` | `reseed.sh --list-keys` | optional; only used to print the seeded storage keys |
 | `cygpath` | `launch.sh` on Windows | ships with Git Bash |
 | `tasklist`, `powershell` | `launch.sh` on Windows | liveness check and the WMI launch below |
 
@@ -144,6 +145,29 @@ Then launch with it before the `--`, since it is a launcher argument:
 	--folder-uri file:///private/tmp/myworkspace
 ```
 
+## Launch a second time with the state the first run wrote
+
+A fresh profile only exercises the cold-start path. Anything that depends on
+state from a previous run -- the runtime discovery cache, storage-backed
+migrations, the recently opened list -- is untested by a single launch, so a bug
+that only appears on the second launch cannot be seen at all.
+
+To carry the profile forward, stop the instance and turn its profile into a
+seed:
+
+```bash
+.claude/skills/drive-positron/scripts/reseed.sh \
+	--run-dir "$RUN_DIR" --seed /tmp/positron-warm-seed \
+	--cdp-port "$CDP_PORT" --list-keys
+```
+
+`reseed.sh` stops the instance without deleting its run directory, copies the
+profile database and settings into the seed, and prints the launch command for
+the warm run. The instance has to be stopped first: the running app holds
+`User/globalStorage/state.vscdb` open and a copy taken mid-write can be torn.
+
+It leaves the run directory in place, so still remove it during cleanup.
+
 ## Attach Playwright
 
 Use a literal session name and reuse it for every command:
@@ -156,6 +180,11 @@ npx @playwright/cli -s=positron snapshot
 ```
 
 Do not derive the session name from `$$`. Separate shell invocations receive different process IDs and would silently create different sessions.
+
+Run every `npx @playwright/cli` command from the repository root. From another
+working directory `npx` installs its own copy of the CLI, which keeps its
+sessions elsewhere and reports the attached session as `The browser 'NAME' is
+not open`.
 
 Common operations:
 
@@ -193,6 +222,24 @@ Do not use `type` or `fill` for notebook cell editors or chat inputs backed by M
 ```
 
 Use individual `press` operations when testing actual keyboard handling.
+
+### Read a whole quick pick
+
+Do not count `.monaco-list-row` elements and do not set `scrollTop`. Quick picks
+render only a window of rows and move it with a transform, so both report a
+short list without failing. Use:
+
+```bash
+.claude/skills/drive-positron/scripts/quickpick-enum.sh --session positron
+```
+
+It walks the picker with ArrowDown and prints
+`index|kind|label|description|detail|active` for every row, headings included,
+leaving the picker on the item it started from.
+
+Read `references/reading-ui-state.md` before trusting any other reading of a
+list, tree, or quick input widget. It covers the virtualization, the hidden
+widgets left behind by closed pickers, and how separators are rendered.
 
 ## Account for Positron behavior
 

--- a/.claude/skills/drive-positron/SKILL.md
+++ b/.claude/skills/drive-positron/SKILL.md
@@ -97,11 +97,17 @@ The launcher:
 - converts the profile paths for the native binary on Windows;
 - waits for CDP and verifies that the app remains alive before returning.
 
-### Pass the workspace yourself
+### Arguments to pass yourself
+
+Everything before the `--` configures the launcher; everything after it is
+handed to the app. Putting a launcher argument after the `--` does not warn:
+the app ignores it and the launcher uses its default instead. Misplacing
+`--source-user-data-dir` this way copies the real `~/.positron-dev` profile.
 
 | Argument | Purpose |
 |---|---|
 | `--folder-uri file:///private/tmp/myworkspace` | Open a workspace reliably. Do not pass a bare positional folder: Positron may discard it. On macOS, use the canonical `/private/tmp` path rather than `/tmp`. On Windows the URI needs a drive letter, so build it with `cygpath -m`: `--folder-uri "file:///$(cygpath -m /tmp/myworkspace)"`. |
+| `--log debug` | Recommended. At the default level the `[Runtime startup] Phase changed to ...` lines are absent, so runtime startup, discovery, and cache replay cannot be told apart from the log. |
 
 ### Arguments the launcher supplies
 
@@ -130,10 +136,12 @@ echo '{"positron.notebook.enabled": true}' \
 	> /tmp/positron-seed/User/settings.json
 ```
 
-Then launch with:
+Then launch with it before the `--`, since it is a launcher argument:
 
 ```bash
---source-user-data-dir /tmp/positron-seed
+.claude/skills/drive-positron/scripts/launch.sh \
+	--source-user-data-dir /tmp/positron-seed -- \
+	--folder-uri file:///private/tmp/myworkspace
 ```
 
 ## Attach Playwright

--- a/.claude/skills/drive-positron/references/reading-ui-state.md
+++ b/.claude/skills/drive-positron/references/reading-ui-state.md
@@ -1,0 +1,77 @@
+# Reading UI state without lying to yourself
+
+Every failure below produces a plausible, wrong answer rather than an error. If
+a reading of the workbench disagrees with a screenshot, the reading is wrong
+until proven otherwise.
+
+## Virtualized lists are moved with a transform, not `scrollTop`
+
+Lists built on `monaco-list` -- the quick pick, the tree views, the notebook
+cell list -- render only a window of rows around the focused one. The rows that
+are off screen are not in the DOM, and the window is positioned by a CSS
+transform on `.monaco-list-rows`.
+
+Consequences:
+
+- Counting `.monaco-list-row` elements counts the render window, not the list.
+  A list of 40 items reads as 12 rows and looks like it is missing items.
+- Setting `element.scrollTop` does nothing and reports no error. Reading
+  `scrollTop` back gives `0` whatever the list is showing.
+- Each row's real position is `data-index`. Use it rather than the position of
+  the element among its siblings, which is the position in the render window.
+
+To read a whole list, drive it with the keys the widget itself handles and
+harvest the rows that render at each step. `scripts/quickpick-enum.sh` does this
+for a quick pick.
+
+## Closed quick input widgets stay in the DOM
+
+Dismissing a quick pick hides its widget; it does not remove it. A second picker
+adds another `.quick-input-widget` to the DOM, so `querySelector` returns
+whichever is first, which is usually the stale one.
+
+Select the live widget by visibility:
+
+```js
+Array.from(document.querySelectorAll('.quick-input-widget'))
+    .find(w => w.offsetParent !== null)
+```
+
+The same hazard applies to keystrokes: a `press` aimed at a picker that has
+already closed lands wherever focus actually is, which is often the console, so
+the keys are silently executed as input.
+
+## Quick pick headings are rows, and arrow keys skip them
+
+A separator can appear two ways, and which one you get depends on the pick:
+
+- as its own row, whose `.quick-input-list-entry` carries
+  `quick-input-list-separator-as-item`;
+- attached to the item below it, in a `.quick-input-list-separator` element
+  inside that item's entry, hidden with `display: none` when the item has no
+  separator.
+
+Arrow-key focus only ever lands on items, never on separator rows
+(`quickInputList.ts` filters focus to `QuickPickItemElement`). So a walk of the
+list reports items in order but has to pick up headings from the rows that
+happen to be rendered, and `data-index` is what interleaves the two back into
+list order.
+
+Single-select picks loop at the end of the list (`shouldLoop = !canSelectMany`).
+A walk that expects to stop at the bottom will run forever; a walk that stops
+when focus returns to its starting row also leaves the picker as it found it.
+
+## Confirm the measurement can see what you think it sees
+
+Before reporting that something is absent, prove the reading method can see a
+thing you know is present. A selector that matches nothing, a list read through
+the wrong container, and a genuinely empty list are indistinguishable in the
+output.
+
+Cheap checks that catch most of it:
+
+- Take a screenshot and compare it against the reading. Disagreement means the
+  reading is wrong.
+- Read back a value you just set, rather than assuming the write took effect.
+- Count something with a known answer, such as the number of headings visible
+  in the screenshot, before trusting a count with an unknown one.

--- a/.claude/skills/drive-positron/scripts/launch.sh
+++ b/.claude/skills/drive-positron/scripts/launch.sh
@@ -17,7 +17,8 @@
 #
 # Usage:
 #   launch.sh [--agents] [--source-user-data-dir <path>] [--repo <vscode-repo-root>]
-#             [--clone-extensions] [--full] [-- <extra code.sh args>]
+#             [--clone-extensions] [--full] [--no-default-app-args]
+#             [-- <extra code.sh args>]
 #
 # Flags:
 #   --clone-extensions  Copy the source extensions/ into the new profile (~10s).
@@ -123,6 +124,12 @@ REPO=""
 EXTRA_ARGS=()
 CLONE_EXTENSIONS=0
 FULL=0
+DEFAULT_APP_ARGS=1
+
+# Supplied by the launcher, not the caller: without --disable-workspace-trust a
+# fresh profile starts in restricted mode with extensions disabled, which reads
+# as missing functionality rather than as a launch problem.
+AUTOMATION_ARGS=(--use-mock-keychain --disable-workspace-trust --skip-welcome)
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -131,6 +138,7 @@ while [[ $# -gt 0 ]]; do
 		--repo) REPO="$2"; shift 2 ;;
 		--clone-extensions|--copy-extensions) CLONE_EXTENSIONS=1; shift ;;
 		--full) FULL=1; shift ;;
+		--no-default-app-args) DEFAULT_APP_ARGS=0; shift ;;
 		--) shift; EXTRA_ARGS=("$@"); break ;;
 		*) echo "Unknown arg: $1" >&2; exit 2 ;;
 	esac
@@ -287,6 +295,20 @@ ARGS=(
 )
 if [[ "$AGENTS" == "1" ]]; then
 	ARGS=("--agents" "${ARGS[@]}")
+fi
+if [[ "$DEFAULT_APP_ARGS" == "1" ]]; then
+	for automation_arg in "${AUTOMATION_ARGS[@]}"; do
+		supplied=0
+		for extra_arg in ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}; do
+			if [[ "$extra_arg" == "$automation_arg" || "$extra_arg" == "$automation_arg="* ]]; then
+				supplied=1
+				break
+			fi
+		done
+		if (( supplied == 0 )); then
+			ARGS+=("$automation_arg")
+		fi
+	done
 fi
 if (( ${#EXTRA_ARGS[@]} )); then
 	ARGS+=("${EXTRA_ARGS[@]}")

--- a/.claude/skills/drive-positron/scripts/quickpick-enum.sh
+++ b/.claude/skills/drive-positron/scripts/quickpick-enum.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Enumerates every row of the quick pick that is currently on screen, in list
+# order, through the attached @playwright/cli CDP session.
+#
+# Reading the rows straight out of the DOM under-reports the list. The quick
+# pick renders into a virtualized Monaco tree: only a window of rows around the
+# focused one exists, the rest are not in the DOM at all, and the window is
+# moved with a CSS transform rather than `scrollTop`. Setting `scrollTop` on the
+# list therefore appears to work and changes nothing, so a snapshot taken after
+# it looks like the list is missing items.
+#
+# This script instead walks the list with ArrowDown, which the quick pick
+# handles by revealing the next row, and harvests every rendered row at each
+# step. A single-select quick pick loops at the end (`shouldLoop = !canSelectMany`
+# in quickInput.ts), so the walk stops when focus returns to where it started,
+# which also leaves the picker on its original item. A multi-select pick does not
+# loop; there the walk stops when focus no longer moves.
+#
+# Usage:
+#   scripts/quickpick-enum.sh
+#   scripts/quickpick-enum.sh --session positron
+#   scripts/quickpick-enum.sh --max 200
+#   scripts/quickpick-enum.sh --json
+#
+# Stdout: one pipe-delimited line per row, ordered by list index:
+#   index|kind|label|description|detail|active
+# `kind` is `group` for a separator heading and `item` for a selectable row, so
+# the heading order and the item order within each heading are both readable.
+# `active` is `active` on the row the picker had focused when the walk started
+# (the recommended item), empty otherwise. With --json, the raw result object.
+# Stderr: the column header and a one-line summary.
+#
+# Exit code:
+#   0  enumerated at least one row
+#   1  no visible quick pick, eval failed, or the walk hit --max
+#   2  argument/usage error, or a required tool is missing
+#
+# Required tools on PATH: npx (with @playwright/cli reachable), jq.
+#
+# Assumes you have already run
+# `npx @playwright/cli [-s=NAME] attach --cdp=http://127.0.0.1:$CDP` and that
+# the quick pick is open. Closed quick input widgets stay in the DOM, so the
+# script picks the one whose `offsetParent` is not null; without that filter it
+# would read a stale list from a previous picker.
+
+set -u
+
+MAX=500
+JSON=0
+PW_SESSION_OVERRIDE=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--max) MAX="$2"; shift 2 ;;
+		--max=*) MAX="${1#--max=}"; shift ;;
+		--json) JSON=1; shift ;;
+		--session) PW_SESSION_OVERRIDE="$2"; shift 2 ;;
+		--session=*) PW_SESSION_OVERRIDE="${1#--session=}"; shift ;;
+		-h|--help)
+			sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+			exit 0 ;;
+		*) echo "quickpick-enum.sh: unknown arg $1" >&2; exit 2 ;;
+	esac
+done
+
+if [[ ! "$MAX" =~ ^[0-9]+$ ]] || (( MAX < 1 )); then
+	echo "quickpick-enum.sh: --max must be a positive integer" >&2
+	exit 2
+fi
+
+for tool in npx jq; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "quickpick-enum.sh: required tool '$tool' not on PATH" >&2
+		exit 2
+	fi
+done
+
+SESSION="${PW_SESSION_OVERRIDE:-${PW_SESSION:-}}"
+PW_ARGS=()
+[[ -n "$SESSION" ]] && PW_ARGS=("-s=$SESSION")
+
+# The whole walk runs inside one eval. Doing it from bash would spend a process
+# launch per keystroke, and the extra time between steps gives the picker room
+# to lose focus or refilter between reads.
+JS=$(cat <<'JSEOF'
+(async () => {
+	const MAX = __MAX__;
+	const widget = Array.from(document.querySelectorAll('.quick-input-widget'))
+		.find(w => w.offsetParent !== null);
+	if (!widget) {
+		return JSON.stringify({ ok: false, error: 'no visible quick-input widget' });
+	}
+	const list = widget.querySelector('.quick-input-list');
+	if (!list) {
+		return JSON.stringify({ ok: false, error: 'visible quick-input widget has no list' });
+	}
+	const input = widget.querySelector('.quick-input-box input');
+
+	const frame = () => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+	const clean = el => el ? el.textContent.replace(/\s+/g, ' ').trim() : '';
+	const focused = () => list.querySelector('.monaco-list-row.focused');
+	const indexOf = row => row ? Number(row.getAttribute('data-index')) : NaN;
+
+	const readRow = row => {
+		const entry = row.querySelector('.quick-input-list-entry');
+		const cells = row.querySelectorAll('.quick-input-list-rows > .quick-input-list-row');
+		const head = cells[0];
+		return {
+			index: indexOf(row),
+			kind: entry && entry.classList.contains('quick-input-list-separator-as-item') ? 'group' : 'item',
+			label: clean(head && head.querySelector('.label-name')),
+			description: clean(head && head.querySelector('.label-description')),
+			detail: clean(row.querySelector('.quick-input-list-label-meta'))
+		};
+	};
+
+	// A heading reaches the DOM one of two ways: as its own row, or attached to
+	// the item below it. The attached element is part of a recycled row
+	// template, and the renderer hides it with `display: none` without clearing
+	// its text, so a stale heading from a previous item stays readable. Take it
+	// only while it is actually displayed.
+	const readAttachedGroup = row => {
+		const separator = row.querySelector('.quick-input-list-separator');
+		if (!separator || separator.offsetParent === null) { return undefined; }
+		const label = clean(separator);
+		return label ? label : undefined;
+	};
+
+	// Every row in the render window is readable, not just the focused one, so
+	// each keystroke can contribute several rows.
+	const seen = new Map();
+	const groups = new Map();
+	const harvest = () => {
+		for (const row of list.querySelectorAll('.monaco-list-row')) {
+			if (row.offsetParent === null) { continue; }
+			const read = readRow(row);
+			if (!Number.isFinite(read.index)) { continue; }
+			seen.set(read.index, read);
+			const group = readAttachedGroup(row);
+			if (group !== undefined) { groups.set(read.index, group); }
+		}
+	};
+
+	const arrowDown = () => {
+		const target = input || widget;
+		target.focus();
+		target.dispatchEvent(new KeyboardEvent('keydown', {
+			key: 'ArrowDown', code: 'ArrowDown', keyCode: 40, which: 40,
+			bubbles: true, cancelable: true
+		}));
+	};
+
+	harvest();
+	if (!focused()) {
+		// Nothing is focused yet, for instance right after the picker opened
+		// with an empty filter. One ArrowDown focuses the first item.
+		arrowDown();
+		await frame();
+		harvest();
+	}
+	const startIndex = indexOf(focused());
+	if (!Number.isFinite(startIndex)) {
+		return JSON.stringify({ ok: false, error: 'no focused row after ArrowDown; is the quick pick empty?' });
+	}
+
+	let steps = 0;
+	let previous = startIndex;
+	let stop = 'wrapped';
+	while (true) {
+		if (++steps > MAX) { stop = 'hit-max'; break; }
+		arrowDown();
+		await frame();
+		harvest();
+		const current = indexOf(focused());
+		if (!Number.isFinite(current)) { stop = 'lost-focus'; break; }
+		if (current === startIndex) { stop = 'wrapped'; break; }
+		if (current === previous) { stop = 'no-loop-end'; break; }
+		previous = current;
+	}
+
+	// Interleave the attached headings back in, each one immediately above the
+	// item it was rendered on.
+	const rows = [];
+	for (const row of Array.from(seen.values()).sort((a, b) => a.index - b.index)) {
+		const group = groups.get(row.index);
+		if (group !== undefined) {
+			rows.push({ index: row.index, kind: 'group', label: group, description: '', detail: '' });
+		}
+		rows.push(row);
+	}
+	return JSON.stringify({
+		ok: rows.length > 0 && stop !== 'hit-max',
+		stop,
+		steps,
+		startIndex,
+		rows,
+		error: stop === 'hit-max' ? 'walk did not terminate within --max steps' : undefined
+	});
+})()
+JSEOF
+)
+JS="${JS//__MAX__/$MAX}"
+
+RAW=$(npx @playwright/cli ${PW_ARGS[@]+"${PW_ARGS[@]}"} eval "$JS" 2>&1) || {
+	echo "quickpick-enum.sh: @playwright/cli eval failed" >&2
+	echo "$RAW" >&2
+	exit 1
+}
+
+RESULT_LINE=$(echo "$RAW" | grep -A 1 '### Result' | tail -n1)
+if [[ -z "$RESULT_LINE" ]]; then
+	echo "quickpick-enum.sh: no ### Result section in eval output" >&2
+	echo "$RAW" >&2
+	exit 1
+fi
+
+# RESULT_LINE is a JSON-encoded string wrapping the result object.
+RESULT=$(echo "$RESULT_LINE" | jq -r 'fromjson' 2>/dev/null) || {
+	echo "quickpick-enum.sh: failed to parse result line" >&2
+	echo "$RESULT_LINE" >&2
+	exit 1
+}
+
+if [[ "$JSON" == "1" ]]; then
+	echo "$RESULT" | jq .
+else
+	echo "index|kind|label|description|detail|active" >&2
+	echo "$RESULT" | jq -r --argjson start "$(echo "$RESULT" | jq '.startIndex // -1')" '
+		.rows // [] | .[] |
+		[ (.index | tostring), .kind, .label, .description, .detail,
+		  (if .kind == "item" and .index == $start then "active" else "" end) ] | join("|")'
+fi
+
+ERROR=$(echo "$RESULT" | jq -r '.error // empty')
+echo "quickpick-enum.sh: $(echo "$RESULT" | jq -r '(.rows // []) | length') rows, stop=$(echo "$RESULT" | jq -r '.stop // "none"'), steps=$(echo "$RESULT" | jq -r '.steps // 0')${ERROR:+, error=$ERROR}" >&2
+
+[[ "$(echo "$RESULT" | jq -r '.ok')" == "true" ]]

--- a/.claude/skills/drive-positron/scripts/reseed.sh
+++ b/.claude/skills/drive-positron/scripts/reseed.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Turns the profile of a disposable Positron instance into a seed directory, so
+# the next launch starts warm instead of cold.
+#
+# A fresh disposable profile only ever exercises the cold-start path. Anything
+# that depends on state written during the previous run -- the runtime discovery
+# cache, the recently opened list, storage-backed migrations -- is untested by a
+# single launch, and a bug that only appears on the second launch is invisible.
+#
+# The instance has to be stopped before the copy: the profile state lives in a
+# SQLite database (`User/globalStorage/state.vscdb`) that the running app holds
+# open, and a copy taken while it is writing can be torn. Stopping without
+# deleting the run directory is what `stop.sh` does when `--run-dir` is omitted,
+# which is the one thing that makes this workflow possible.
+#
+# Usage:
+#   scripts/reseed.sh --run-dir "$RUN_DIR" --seed /tmp/positron-seed --cdp-port "$CDP_PORT"
+#   scripts/reseed.sh --run-dir "$RUN_DIR" --seed /tmp/positron-seed --keep-running
+#   scripts/reseed.sh --run-dir "$RUN_DIR" --seed /tmp/positron-seed --list-keys
+#
+#   --run-dir       the `runDir` the launcher reported
+#   --seed          seed directory to create or overwrite
+#   --cdp-port      stop this instance first, without deleting its run directory
+#   --keep-running  copy without stopping; only safe when the app has already exited
+#   --include PATH  copy an extra profile-relative path (repeatable)
+#   --list-keys     print the storage keys in the seeded database (needs sqlite3)
+#
+# Copies, relative to the profile root, when present:
+#   User/globalStorage/state.vscdb (plus -wal and -shm)
+#   User/globalStorage/storage.json
+#   User/settings.json
+#   User/keybindings.json
+#
+# Workspace storage is deliberately not copied: it is per-workspace, the
+# launcher excludes it from its own seeding, and carrying it forward would make
+# the next run depend on a workspace path that may not be the one under test.
+#
+# Stdout: the launch command to run next.
+# Exit code: 0 on success, 1 when the copy could not be made, 2 on usage error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RUN_DIR=""
+SEED=""
+CDP_PORT=""
+KEEP_RUNNING=0
+LIST_KEYS=0
+EXTRA=()
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--run-dir) RUN_DIR="$2"; shift 2 ;;
+		--seed) SEED="$2"; shift 2 ;;
+		--cdp-port) CDP_PORT="$2"; shift 2 ;;
+		--keep-running) KEEP_RUNNING=1; shift ;;
+		--include) EXTRA+=("$2"); shift 2 ;;
+		--list-keys) LIST_KEYS=1; shift ;;
+		-h|--help)
+			sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
+			exit 0 ;;
+		*) echo "reseed.sh: unknown arg $1" >&2; exit 2 ;;
+	esac
+done
+
+if [[ -z "$RUN_DIR" || -z "$SEED" ]]; then
+	echo "Usage: reseed.sh --run-dir <dir> --seed <dir> [--cdp-port <port>] [--keep-running]" >&2
+	exit 2
+fi
+
+PROFILE="$RUN_DIR/user-data"
+if [[ ! -d "$PROFILE" ]]; then
+	echo "reseed.sh: no profile at $PROFILE; is --run-dir the runDir the launcher reported?" >&2
+	exit 1
+fi
+
+if [[ -n "$CDP_PORT" && "$KEEP_RUNNING" != "1" ]]; then
+	# No --run-dir here on purpose: that argument is what makes stop.sh delete
+	# the directory we are about to read.
+	echo "[reseed.sh] stopping the instance on CDP port $CDP_PORT, keeping $RUN_DIR" >&2
+	"$SCRIPT_DIR/stop.sh" --cdp-port "$CDP_PORT"
+elif [[ "$KEEP_RUNNING" != "1" ]]; then
+	echo "reseed.sh: pass --cdp-port to stop the instance, or --keep-running if it has already exited" >&2
+	exit 2
+fi
+
+# A live CDP port means the app is still writing to the database.
+if [[ -n "$CDP_PORT" ]] && curl -sf -o /dev/null --max-time 2 "http://127.0.0.1:$CDP_PORT/json/version" 2>/dev/null; then
+	echo "reseed.sh: CDP port $CDP_PORT still answers; the profile is in use and the copy would be unreliable" >&2
+	exit 1
+fi
+
+PATHS=(
+	'User/globalStorage/state.vscdb'
+	'User/globalStorage/state.vscdb-wal'
+	'User/globalStorage/state.vscdb-shm'
+	'User/globalStorage/storage.json'
+	'User/settings.json'
+	'User/keybindings.json'
+)
+PATHS+=(${EXTRA[@]+"${EXTRA[@]}"})
+
+rm -rf "$SEED"
+COPIED=0
+for rel in "${PATHS[@]}"; do
+	src="$PROFILE/$rel"
+	[[ -e "$src" ]] || continue
+	mkdir -p "$SEED/$(dirname "$rel")"
+	cp -R "$src" "$SEED/$rel"
+	echo "[reseed.sh] $rel" >&2
+	COPIED=$((COPIED + 1))
+done
+
+if (( COPIED == 0 )); then
+	echo "reseed.sh: nothing to copy from $PROFILE" >&2
+	exit 1
+fi
+
+if [[ "$LIST_KEYS" == "1" ]]; then
+	if command -v sqlite3 >/dev/null 2>&1 && [[ -f "$SEED/User/globalStorage/state.vscdb" ]]; then
+		echo "[reseed.sh] storage keys and value sizes:" >&2
+		sqlite3 "$SEED/User/globalStorage/state.vscdb" \
+			'SELECT key, length(value) FROM ItemTable ORDER BY key;' >&2 || true
+	else
+		echo "[reseed.sh] --list-keys needs sqlite3 on PATH and a copied state.vscdb" >&2
+	fi
+fi
+
+echo "[reseed.sh] seeded $COPIED path(s) into $SEED" >&2
+cat <<EOF
+.claude/skills/drive-positron/scripts/launch.sh \\
+	--source-user-data-dir $SEED -- \\
+	--log debug
+EOF


### PR DESCRIPTION
### Summary

`launch.sh` documented four required launch arguments but passed them all through from the caller, so omitting one failed silently: without `--disable-workspace-trust` the app starts in restricted mode with extensions disabled, and an empty interpreter picker looks like a product bug.

- The launcher now supplies `--use-mock-keychain`, `--disable-workspace-trust` and `--skip-welcome`; `--no-default-app-args` opts out.
- SKILL.md: launcher arguments go before the `--`, app arguments after. A misplaced `--source-user-data-dir` silently copies the real dev profile.
- SKILL.md: recommend `--log debug`; the `[Runtime startup]` phase lines do not exist at the default level.
- New `scripts/quickpick-enum.sh`: enumerate a quick pick by keyboard, since the DOM holds only a ~10-row window.
- New `scripts/reseed.sh`: reuse a stopped instance's profile, so warm-start paths like discovery cache replay are reachable.
- New `references/reading-ui-state.md`: the UI reads that return a plausible wrong answer instead of an error.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

1. `scripts/launch.sh -- --folder-uri <uri>` with no other flags: no trust prompt, interpreters discovered. Add `--no-default-app-args` and the prompt returns.
2. With a picker open, `scripts/quickpick-enum.sh --session <name>` lists every row, not the ~10 in the DOM. `scripts/reseed.sh` then relaunches to `Phase changed to 'loadingCache'`.

Skill and docs only, no product code. Verified on macOS; the `separator-as-item` path, multi-select, and `--json` are unexercised.
