### PR TITLE
fix: order interpreter picker headings by environment source

### DIFF
--- a/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -394,7 +394,6 @@ function getPrioritizedEnvironmentType(): EnvironmentType[] {
         EnvironmentType.Unknown,
     ];
 }
-
 // --- Start Positron ---
 const ENV_TYPE_RANKS = new Map(getPrioritizedEnvironmentType().map((envType, index) => [envType, index]));
 

--- a/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -355,8 +355,11 @@ function compareEnvironmentType(a: PythonEnvironment, b: PythonEnvironment): num
 
         return 0;
     }
-    const envTypeByPriority = getPrioritizedEnvironmentType();
-    return Math.sign(envTypeByPriority.indexOf(a.envType) - envTypeByPriority.indexOf(b.envType));
+    // --- Start Positron ---
+    // const envTypeByPriority = getPrioritizedEnvironmentType();
+    // return Math.sign(envTypeByPriority.indexOf(a.envType) - envTypeByPriority.indexOf(b.envType));
+    return Math.sign(getEnvironmentTypeRank(a.envType) - getEnvironmentTypeRank(b.envType));
+    // --- End Positron ---
 }
 
 function getPrioritizedEnvironmentType(): EnvironmentType[] {
@@ -367,6 +370,10 @@ function getPrioritizedEnvironmentType(): EnvironmentType[] {
         // --- End Positron ---
         EnvironmentType.Poetry,
         EnvironmentType.Pipenv,
+        // --- Start Positron ---
+        // Pixi was missing from this list, so it landed at index -1 and outranked everything.
+        EnvironmentType.Pixi,
+        // --- End Positron ---
         EnvironmentType.VirtualEnvWrapper,
         EnvironmentType.Hatch,
         EnvironmentType.Venv,
@@ -374,16 +381,31 @@ function getPrioritizedEnvironmentType(): EnvironmentType[] {
         EnvironmentType.ActiveState,
         EnvironmentType.Conda,
         EnvironmentType.Pyenv,
+        // --- Start Positron ---
+        // Module and Custom interpreters were deliberately made available, by a site admin
+        // through environment modules or by the user through python.interpreters.include,
+        // so they rank above whatever else happens to be installed on the machine.
+        EnvironmentType.Module,
+        EnvironmentType.Custom,
+        // --- End Positron ---
         EnvironmentType.MicrosoftStore,
         EnvironmentType.Global,
         EnvironmentType.System,
-        // --- Start Positron ---
-        EnvironmentType.Custom,
-        // --- End Positron ---
         EnvironmentType.Unknown,
     ];
 }
+
 // --- Start Positron ---
+const ENV_TYPE_RANKS = new Map(getPrioritizedEnvironmentType().map((envType, index) => [envType, index]));
+
+/**
+ * Rank an environment type by assumed usefulness, lowest first. Types missing from the priority
+ * list rank last rather than at index -1.
+ */
+export function getEnvironmentTypeRank(envType: EnvironmentType): number {
+    return ENV_TYPE_RANKS.get(envType) ?? Number.MAX_SAFE_INTEGER;
+}
+
 /**
  * Return true if the version name is not of the form x.y.z. This typically means it's a virtual environment name.
  */

--- a/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/environmentTypeComparer.ts
@@ -395,7 +395,14 @@ function getPrioritizedEnvironmentType(): EnvironmentType[] {
     ];
 }
 // --- Start Positron ---
-const ENV_TYPE_RANKS = new Map(getPrioritizedEnvironmentType().map((envType, index) => [envType, index]));
+// Spaced by 10 so that other extensions contributing Python runtimes -- reticulate, say -- can
+// slot a source between two of these without renumbering the list. These numbers are persisted in
+// the workbench's discovery cache, so changing one means bumping
+// RUNTIME_DISCOVERY_CACHE_SCHEMA_VERSION; otherwise cached entries sort on the old scale.
+const ENV_TYPE_RANK_SPACING = 10;
+const ENV_TYPE_RANKS = new Map(
+    getPrioritizedEnvironmentType().map((envType, index) => [envType, (index + 1) * ENV_TYPE_RANK_SPACING]),
+);
 
 /**
  * Rank an environment type by assumed usefulness, lowest first. Types missing from the priority

--- a/extensions/positron-python/src/client/positron/discoverer.ts
+++ b/extensions/positron-python/src/client/positron/discoverer.ts
@@ -15,6 +15,7 @@ import { PythonEnvironment } from '../pythonEnvironments/info';
 import { createPythonRuntimeMetadata } from './runtime';
 import {
     comparePythonVersionDescending,
+    getEnvironmentTypeRank,
     isProblematicCondaEnvironment,
 } from '../interpreter/configuration/environmentTypeComparer';
 import { shouldIncludeInterpreter } from './interpreterSettings';
@@ -145,8 +146,15 @@ function filterInterpreters(interpreters: PythonEnvironment[]): PythonEnvironmen
     });
 }
 
-// Returns a sorted copy of the array of Python environments, in descending order
-function sortInterpreters(
+/**
+ * Returns a sorted copy of the array of Python environments: the preferred interpreter first,
+ * then by environment type, then by descending Python version.
+ *
+ * This order is the order the runtimes are registered in, which is the order Positron shows the
+ * environment type headings in the interpreter picker. Ranking by environment type keeps a newer
+ * system Python from pulling the System heading above uv, venv and conda.
+ */
+export function sortInterpreters(
     interpreters: PythonEnvironment[],
     preferredInterpreter: PythonEnvironment | undefined,
 ): PythonEnvironment[] {
@@ -156,6 +164,12 @@ function sortInterpreters(
         if (preferredInterpreter) {
             if (preferredInterpreter.id === a.id) return -1;
             if (preferredInterpreter.id === b.id) return 1;
+        }
+
+        // Compare environment types, most to least useful
+        const envTypeComparison = getEnvironmentTypeRank(a.envType) - getEnvironmentTypeRank(b.envType);
+        if (envTypeComparison !== 0) {
+            return envTypeComparison;
         }
 
         // Compare versions in descending order

--- a/extensions/positron-python/src/client/positron/discoverer.ts
+++ b/extensions/positron-python/src/client/positron/discoverer.ts
@@ -150,9 +150,8 @@ function filterInterpreters(interpreters: PythonEnvironment[]): PythonEnvironmen
  * Returns a sorted copy of the array of Python environments: the preferred interpreter first,
  * then by environment type, then by descending Python version.
  *
- * This is the order the runtimes are yielded and registered in. It does not decide the order of
- * the environment type headings in the picker -- runtimes are also registered one at a time as
- * discovery finds them, so Positron sorts the headings by `runtimeSourceOrder` instead.
+ * This is the yield order only. It does not decide the picker's heading order -- runtimes are also
+ * registered one at a time as discovery finds them, so the picker sorts by `runtimeSourceOrder`.
  */
 export function sortInterpreters(
     interpreters: PythonEnvironment[],

--- a/extensions/positron-python/src/client/positron/discoverer.ts
+++ b/extensions/positron-python/src/client/positron/discoverer.ts
@@ -150,9 +150,9 @@ function filterInterpreters(interpreters: PythonEnvironment[]): PythonEnvironmen
  * Returns a sorted copy of the array of Python environments: the preferred interpreter first,
  * then by environment type, then by descending Python version.
  *
- * This order is the order the runtimes are registered in, which is the order Positron shows the
- * environment type headings in the interpreter picker. Ranking by environment type keeps a newer
- * system Python from pulling the System heading above uv, venv and conda.
+ * This is the order the runtimes are yielded and registered in. It does not decide the order of
+ * the environment type headings in the picker -- runtimes are also registered one at a time as
+ * discovery finds them, so Positron sorts the headings by `runtimeSourceOrder` instead.
  */
 export function sortInterpreters(
     interpreters: PythonEnvironment[],

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -17,6 +17,7 @@ import { IApplicationEnvironment, IWorkspaceService } from '../common/applicatio
 import { EXTENSION_ROOT_DIR, IPYKERNEL_VERSION, PYTHON_LANGUAGE } from '../common/constants';
 import {
     EnvLocationHeuristic,
+    getEnvironmentTypeRank,
     getEnvLocationHeuristic,
     isVersionSupported,
 } from '../interpreter/configuration/environmentTypeComparer';
@@ -109,7 +110,7 @@ function isPythonRuntimeCacheable(interpreter: PythonEnvironment, workspaceFolde
  * @param envName The environment name reported by discovery, if any.
  * @param pythonVersion The formatted Python version (e.g. '3.10.17').
  * @param moduleMetadata Module metadata for this interpreter, if module-provided.
- * @returns The runtime source and the short display name.
+ * @returns The runtime source, its rank among sources, and the short display name.
  */
 export function getRuntimeSourceAndShortName(
     interpreterPath: string,
@@ -117,7 +118,7 @@ export function getRuntimeSourceAndShortName(
     envName: string | undefined,
     pythonVersion: string,
     moduleMetadata: ModuleMetadata | undefined,
-): { runtimeSource: EnvironmentType; runtimeShortName: string } {
+): { runtimeSource: EnvironmentType; runtimeSourceOrder: number; runtimeShortName: string } {
     // Get the environment name, using parent directory name for .venv/.conda
     // folders (like uv does). Module environments use their configured name.
     let resolvedEnvName = envName ?? '';
@@ -146,7 +147,7 @@ export function getRuntimeSourceAndShortName(
     }
     runtimeShortName += ')';
 
-    return { runtimeSource, runtimeShortName };
+    return { runtimeSource, runtimeSourceOrder: getEnvironmentTypeRank(runtimeSource), runtimeShortName };
 }
 
 export async function createPythonRuntimeMetadata(
@@ -227,7 +228,7 @@ export async function createPythonRuntimeMetadata(
     const moduleMetadata = moduleMetadataMap.get(interpreter.path);
 
     // Determine the display source (e.g. 'Venv', 'Module') and short name.
-    const { runtimeSource, runtimeShortName } = getRuntimeSourceAndShortName(
+    const { runtimeSource, runtimeSourceOrder, runtimeShortName } = getRuntimeSourceAndShortName(
         interpreter.path,
         interpreter.envType,
         interpreter.envName,
@@ -286,6 +287,7 @@ export async function createPythonRuntimeMetadata(
         runtimePath,
         runtimeVersion: applicationEnv.packageJson.version,
         runtimeSource,
+        runtimeSourceOrder,
         languageId: PYTHON_LANGUAGE,
         languageName: 'Python',
         languageVersion: pythonVersion,

--- a/extensions/positron-python/src/test/positron/discoverer.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/discoverer.unit.test.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { assert } from 'chai';
+import { sortInterpreters } from '../../client/positron/discoverer';
+import { EnvironmentType, PythonEnvironment } from '../../client/pythonEnvironments/info';
+import { Architecture } from '../../client/common/utils/platform';
+
+function makeInterpreter(envType: EnvironmentType, version: string): PythonEnvironment {
+    const [major, minor, patch] = version.split('.').map(Number);
+    return {
+        id: `${envType}-${version}`,
+        path: `/envs/${envType}-${version}/bin/python`,
+        envType,
+        architecture: Architecture.x64,
+        sysPrefix: `/envs/${envType}-${version}`,
+        version: { major, minor, patch, raw: version, build: [], prerelease: [] },
+    };
+}
+
+/** Describe a sorted list as "<envType> <version>" pairs, which is what the ordering is about. */
+function describeOrder(interpreters: PythonEnvironment[]): string[] {
+    return interpreters.map((i) => `${i.envType} ${i.version?.raw}`);
+}
+
+suite('sortInterpreters', () => {
+    test('ranks environment types ahead of Python version, with system Pythons last', () => {
+        // The yield order here becomes the registration order in Positron, which in turn
+        // decides the order of the source separators in the interpreter picker. A newer
+        // system Python must not drag the System group above uv or venv.
+        const interpreters = [
+            makeInterpreter(EnvironmentType.System, '3.13.1'),
+            makeInterpreter(EnvironmentType.Conda, '3.11.9'),
+            makeInterpreter(EnvironmentType.Uv, '3.10.14'),
+            makeInterpreter(EnvironmentType.Venv, '3.12.7'),
+        ];
+
+        assert.deepEqual(describeOrder(sortInterpreters(interpreters, undefined)), [
+            'uv 3.10.14',
+            'Venv 3.12.7',
+            'Conda 3.11.9',
+            'System 3.13.1',
+        ]);
+    });
+
+    test('sorts by descending Python version within an environment type', () => {
+        const interpreters = [
+            makeInterpreter(EnvironmentType.Venv, '3.10.14'),
+            makeInterpreter(EnvironmentType.Venv, '3.13.1'),
+            makeInterpreter(EnvironmentType.Venv, '3.12.7'),
+        ];
+
+        assert.deepEqual(describeOrder(sortInterpreters(interpreters, undefined)), [
+            'Venv 3.13.1',
+            'Venv 3.12.7',
+            'Venv 3.10.14',
+        ]);
+    });
+
+    test('ranks deliberately provided interpreters ahead of system Pythons', () => {
+        // Custom means the interpreter was found in a directory the user added to
+        // python.interpreters.include, and Module means a site admin exposed it through
+        // environment modules; both outrank whatever else is on the system.
+        const interpreters = [
+            makeInterpreter(EnvironmentType.Global, '3.13.1'),
+            makeInterpreter(EnvironmentType.System, '3.13.1'),
+            makeInterpreter(EnvironmentType.Custom, '3.9.18'),
+            makeInterpreter(EnvironmentType.Module, '3.8.19'),
+        ];
+
+        assert.deepEqual(describeOrder(sortInterpreters(interpreters, undefined)), [
+            'Module 3.8.19',
+            'Custom 3.9.18',
+            'Global 3.13.1',
+            'System 3.13.1',
+        ]);
+    });
+
+    test('keeps the preferred interpreter first regardless of its environment type', () => {
+        // Positron uses the first registered runtime for a language as its last-resort
+        // preferred runtime, so the recommended interpreter has to stay at the front.
+        const preferred = makeInterpreter(EnvironmentType.System, '3.9.18');
+        const interpreters = [makeInterpreter(EnvironmentType.Uv, '3.13.1'), preferred];
+
+        assert.deepEqual(describeOrder(sortInterpreters(interpreters, preferred)), ['System 3.9.18', 'uv 3.13.1']);
+    });
+
+    test('ranks environment types missing from the priority list last', () => {
+        // indexOf returns -1 for an unlisted type; without a guard that would sort it
+        // ahead of everything else.
+        const interpreters = [
+            makeInterpreter(EnvironmentType.MicrosoftStore, '3.11.9'),
+            makeInterpreter('Brand New Env Type' as EnvironmentType, '3.13.1'),
+            makeInterpreter(EnvironmentType.Uv, '3.10.14'),
+        ];
+
+        assert.deepEqual(describeOrder(sortInterpreters(interpreters, undefined)), [
+            'uv 3.10.14',
+            'MicrosoftStore 3.11.9',
+            'Brand New Env Type 3.13.1',
+        ]);
+    });
+
+    test('does not mutate the input array', () => {
+        const interpreters = [
+            makeInterpreter(EnvironmentType.System, '3.13.1'),
+            makeInterpreter(EnvironmentType.Uv, '3.10.14'),
+        ];
+
+        sortInterpreters(interpreters, undefined);
+
+        assert.deepEqual(describeOrder(interpreters), ['System 3.13.1', 'uv 3.10.14']);
+    });
+});

--- a/extensions/positron-python/src/test/positron/discoverer.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/discoverer.unit.test.ts
@@ -27,9 +27,7 @@ function describeOrder(interpreters: PythonEnvironment[]): string[] {
 
 suite('sortInterpreters', () => {
     test('ranks environment types ahead of Python version, with system Pythons last', () => {
-        // The yield order here becomes the registration order in Positron, which in turn
-        // decides the order of the source separators in the interpreter picker. A newer
-        // system Python must not drag the System group above uv or venv.
+        // A newer system Python must not outrank a uv, venv or conda environment.
         const interpreters = [
             makeInterpreter(EnvironmentType.System, '3.13.1'),
             makeInterpreter(EnvironmentType.Conda, '3.11.9'),
@@ -79,7 +77,7 @@ suite('sortInterpreters', () => {
     });
 
     test('keeps the preferred interpreter first regardless of its environment type', () => {
-        // Positron uses the first registered runtime for a language as its last-resort
+        // Positron falls back to the first registered runtime for a language as its
         // preferred runtime, so the recommended interpreter has to stay at the front.
         const preferred = makeInterpreter(EnvironmentType.System, '3.9.18');
         const interpreters = [makeInterpreter(EnvironmentType.Uv, '3.13.1'), preferred];

--- a/extensions/positron-python/src/test/positron/runtime.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/runtime.unit.test.ts
@@ -5,6 +5,7 @@
 
 import { assert } from 'chai';
 import { getRuntimeSourceAndShortName } from '../../client/positron/runtime';
+import { getEnvironmentTypeRank } from '../../client/interpreter/configuration/environmentTypeComparer';
 import { EnvironmentType } from '../../client/pythonEnvironments/info';
 import { ModuleMetadata } from '../../client/pythonEnvironments/base/locators/lowLevel/moduleEnvironmentLocator';
 
@@ -31,8 +32,13 @@ suite('getRuntimeSourceAndShortName', () => {
 
         assert.deepEqual(result, {
             runtimeSource: EnvironmentType.Module,
+            runtimeSourceOrder: getEnvironmentTypeRank(EnvironmentType.Module),
             runtimeShortName: '3.12.8 (Module: Python-Leaves)',
         });
+
+        // The rank has to follow the module metadata too, or the picker would file the
+        // Module heading under Unknown's rank and list it last.
+        assert.isBelow(result.runtimeSourceOrder, getEnvironmentTypeRank(EnvironmentType.Unknown));
     });
 
     test('uses the parent project name for a .venv environment', () => {
@@ -46,6 +52,7 @@ suite('getRuntimeSourceAndShortName', () => {
 
         assert.deepEqual(result, {
             runtimeSource: EnvironmentType.Venv,
+            runtimeSourceOrder: getEnvironmentTypeRank(EnvironmentType.Venv),
             runtimeShortName: '3.10.17 (Venv: my-python-project)',
         });
     });
@@ -61,6 +68,7 @@ suite('getRuntimeSourceAndShortName', () => {
 
         assert.deepEqual(result, {
             runtimeSource: EnvironmentType.System,
+            runtimeSourceOrder: getEnvironmentTypeRank(EnvironmentType.System),
             runtimeShortName: '3.12.3 (System)',
         });
     });

--- a/extensions/positron-python/src/test/positron/runtime.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/runtime.unit.test.ts
@@ -72,4 +72,14 @@ suite('getRuntimeSourceAndShortName', () => {
             runtimeShortName: '3.12.3 (System)',
         });
     });
+
+    test('leaves room between the deliberate and machine-wide environment types', () => {
+        // positron-reticulate ranks its Python between these two, so it sorts below an
+        // interpreter the project provides but above anything merely installed on the
+        // machine. Renumbering these consecutively would leave it nowhere to go.
+        assert.isAbove(
+            getEnvironmentTypeRank(EnvironmentType.MicrosoftStore) - getEnvironmentTypeRank(EnvironmentType.Custom),
+            1,
+        );
+    });
 });

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -976,6 +976,10 @@ class ReticulateRuntimeMetadata implements positron.LanguageRuntimeMetadata {
 	runtimeShortName: string = 'Python (reticulate)';
 	runtimeVersion: string = '1.0';
 	runtimeSource: string = 'reticulate';
+	// This Python belongs to the R project the user already has open, so it outranks every
+	// interpreter merely installed on the machine, but not one the project itself provides.
+	// 135 falls between positron-python's Custom (130) and MicrosoftStore (140) ranks.
+	runtimeSourceOrder: number = 135;
 	languageVersion = '1.0';
 	startupBehavior: positron.LanguageRuntimeStartupBehavior = positron.LanguageRuntimeStartupBehavior.Manual;
 	sessionLocation: positron.LanguageRuntimeSessionLocation = positron.LanguageRuntimeSessionLocation.Workspace;

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -705,6 +705,8 @@ declare module 'positron' {
 		 * How useful this runtime's source is to the user, lowest first; used to
 		 * order the source headings in the interpreter picker. Sources left
 		 * unranked are listed after ranked ones.
+		 * The scale is shared by every extension that contributes runtimes for a
+		 * language, so ranking one source and not another mixes them up.
 		 */
 		runtimeSourceOrder?: number;
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -701,6 +701,13 @@ declare module 'positron' {
 		/** The runtime's source or origin; e.g. PyEnv, System, Homebrew, Conda, etc. */
 		runtimeSource: string;
 
+		/**
+		 * How useful this runtime's source is to the user, lowest first; used to
+		 * order the source headings in the interpreter picker. Sources left
+		 * unranked are listed after ranked ones.
+		 */
+		runtimeSourceOrder?: number;
+
 		/** The free-form, user-friendly name of the language this runtime can execute; e.g. "R" */
 		languageName: string;
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -660,11 +660,9 @@ export const selectNewLanguageRuntime = async (
 				envTypeOrder.set(envType, Math.min(envTypeOrder.get(envType) ?? order, order));
 			});
 
-			// Order the headings by the rank the extension gave each source, so that
-			// e.g. system Pythons come last. Registration order is not usable here:
-			// runtimes are registered one at a time as discovery finds them, and the
-			// order varies with discovery timing and the warm-start cache. Sources the
-			// extension didn't rank keep their registration order, after the ranked ones.
+			// Sort by the rank the extension gave each source, so e.g. system Pythons
+			// come last. Registration order is discovery order, which varies run to run.
+			// Unranked sources keep their registration order, after the ranked ones.
 			const envTypes = Array.from(runtimesByEnvType.keys())
 				.sort((a, b) => envTypeOrder.get(a)! - envTypeOrder.get(b)!);
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -646,6 +646,7 @@ export const selectNewLanguageRuntime = async (
 		interpreterGroups.forEach(group => {
 			// Group runtimes by environment type
 			const runtimesByEnvType = new Map<string, ILanguageRuntimeMetadata[]>();
+			const envTypeOrder = new Map<string, number>();
 			const allRuntimes = group.alternateRuntimes;
 
 			allRuntimes.forEach(runtime => {
@@ -655,12 +656,17 @@ export const selectNewLanguageRuntime = async (
 				}
 				runtimesByEnvType.get(envType)!.push(runtime);
 
+				const order = runtime.runtimeSourceOrder ?? Number.MAX_SAFE_INTEGER;
+				envTypeOrder.set(envType, Math.min(envTypeOrder.get(envType) ?? order, order));
 			});
 
-			// The environment type headings render in the order each type was first
-			// registered, so the extension that registers the runtimes owns their order
-			// (see sortInterpreters in positron-python's positron/discoverer.ts).
-			const envTypes = Array.from(runtimesByEnvType.keys());
+			// Order the headings by the rank the extension gave each source, so that
+			// e.g. system Pythons come last. Registration order is not usable here:
+			// runtimes are registered one at a time as discovery finds them, and the
+			// order varies with discovery timing and the warm-start cache. Sources the
+			// extension didn't rank keep their registration order, after the ranked ones.
+			const envTypes = Array.from(runtimesByEnvType.keys())
+				.sort((a, b) => envTypeOrder.get(a)! - envTypeOrder.get(b)!);
 
 			// Sort runtimes by version (decreasing), then alphabetically
 			envTypes.forEach(envType => {

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -657,6 +657,9 @@ export const selectNewLanguageRuntime = async (
 
 			});
 
+			// The environment type headings render in the order each type was first
+			// registered, so the extension that registers the runtimes owns their order
+			// (see sortInterpreters in positron-python's positron/discoverer.ts).
 			const envTypes = Array.from(runtimesByEnvType.keys());
 
 			// Sort runtimes by version (decreasing), then alphabetically

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -401,10 +401,9 @@ describe('selectNewLanguageRuntime', () => {
 		});
 
 		it('ranks a source by its best-ranked runtime when only some carry a rank', async () => {
-			// A discovery cache written before runtimeSourceOrder existed yields runtimes
-			// with no rank alongside freshly discovered ones that have it, in no
-			// guaranteed order. The source must follow the rank it does have rather than
-			// whichever runtime happened to be registered last.
+			// An extension can rank some of a source's runtimes and not others, and they
+			// register in no guaranteed order. The source must follow the rank it does
+			// have rather than whichever runtime happened to be registered last.
 			await registerRuntime(makeRuntime({ runtimeId: 'py-pref', runtimeSource: 'Pyenv' }));
 			await registerRuntime(makeRuntime({ runtimeId: 'py-sys-fresh', runtimeSource: 'System', runtimeSourceOrder: 30 }));
 			await registerRuntime(makeRuntime({ runtimeId: 'py-sys-cached', runtimeSource: 'System' }));

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -385,14 +385,34 @@ describe('selectNewLanguageRuntime', () => {
 		});
 
 		it('lists unranked environment types after ranked ones, in registration order', async () => {
+			// Registered Other before Mystery on purpose: that order is the reverse of
+			// alphabetical, so the assertion can only pass if the unranked sources kept
+			// their registration order rather than being sorted by label.
 			await registerRuntime(makeRuntime({ runtimeId: 'py-pref', runtimeSource: 'Pyenv' }));
-			await registerRuntime(makeRuntime({ runtimeId: 'py-mystery', runtimeSource: 'Mystery' }));
 			await registerRuntime(makeRuntime({ runtimeId: 'py-other', runtimeSource: 'Other' }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-mystery', runtimeSource: 'Mystery' }));
 			await registerRuntime(makeRuntime({ runtimeId: 'py-conda', runtimeSource: 'Conda', runtimeSourceOrder: 20 }));
 
 			const promise = runPicker();
 			await waitUntilOpened();
-			expect(separatorLabels()).toEqual(['Suggested', 'Conda', 'Mystery', 'Other']);
+			expect(separatorLabels()).toEqual(['Suggested', 'Conda', 'Other', 'Mystery']);
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('ranks a source by its best-ranked runtime when only some carry a rank', async () => {
+			// A discovery cache written before runtimeSourceOrder existed yields runtimes
+			// with no rank alongside freshly discovered ones that have it, in no
+			// guaranteed order. The source must follow the rank it does have rather than
+			// whichever runtime happened to be registered last.
+			await registerRuntime(makeRuntime({ runtimeId: 'py-pref', runtimeSource: 'Pyenv' }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-sys-fresh', runtimeSource: 'System', runtimeSourceOrder: 30 }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-sys-cached', runtimeSource: 'System' }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-global', runtimeSource: 'Global', runtimeSourceOrder: 40 }));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(separatorLabels()).toEqual(['Suggested', 'System', 'Global']);
 			pick.cancel(QuickInputHideReason.Gesture);
 			await promise;
 		});

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -187,6 +187,11 @@ describe('selectNewLanguageRuntime', () => {
 		return runtimeService.getRegisteredRuntime(metadata.runtimeId) ?? metadata;
 	}
 
+	/** The separator labels of the built picker, which are the environment type headings. */
+	function separatorLabels(): string[] {
+		return pick.items.filter(item => item.type === 'separator').map(item => item.label ?? '');
+	}
+
 	function pickItemById(id: string): IQuickPickItem | undefined {
 		return pick.items.find(
 			(item): item is IQuickPickItem => item.type !== 'separator' && item.id === id,
@@ -360,6 +365,34 @@ describe('selectNewLanguageRuntime', () => {
 			);
 			expect(item?.detail).toBe('/opt/python/bin/python3');
 			expect(pick.matchOnDetail).toBe(true);
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('orders the environment type headings by runtimeSourceOrder, not registration order', async () => {
+			// Registration order is discovery order, which varies run to run, so the
+			// extension ranks its sources instead and the picker sorts by that rank.
+			await registerRuntime(makeRuntime({ runtimeId: 'py-pref', runtimeSource: 'Pyenv' }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-system', runtimeSource: 'System', runtimeSourceOrder: 30 }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-conda', runtimeSource: 'Conda', runtimeSourceOrder: 20 }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-uv', runtimeSource: 'uv', runtimeSourceOrder: 10 }));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(separatorLabels()).toEqual(['Suggested', 'uv', 'Conda', 'System']);
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('lists unranked environment types after ranked ones, in registration order', async () => {
+			await registerRuntime(makeRuntime({ runtimeId: 'py-pref', runtimeSource: 'Pyenv' }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-mystery', runtimeSource: 'Mystery' }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-other', runtimeSource: 'Other' }));
+			await registerRuntime(makeRuntime({ runtimeId: 'py-conda', runtimeSource: 'Conda', runtimeSourceOrder: 20 }));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(separatorLabels()).toEqual(['Suggested', 'Conda', 'Mystery', 'Other']);
 			pick.cancel(QuickInputHideReason.Gesture);
 			await promise;
 		});

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -998,6 +998,13 @@ export interface ILanguageRuntimeMetadata {
 	/** The runtime's source or origin; e.g. PyEnv, System, Homebrew, Conda, etc. */
 	readonly runtimeSource: string;
 
+	/**
+	 * How useful this runtime's source is to the user, lowest first; used to order
+	 * the source headings in the interpreter picker. Sources left unranked are
+	 * listed after ranked ones.
+	 */
+	readonly runtimeSourceOrder?: number;
+
 	/** Whether the runtime should start up automatically or wait until explicitly requested */
 	readonly startupBehavior: LanguageRuntimeStartupBehavior;
 

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeService.ts
@@ -1002,6 +1002,8 @@ export interface ILanguageRuntimeMetadata {
 	 * How useful this runtime's source is to the user, lowest first; used to order
 	 * the source headings in the interpreter picker. Sources left unranked are
 	 * listed after ranked ones.
+	 * The scale is shared by every extension that contributes runtimes for a language,
+	 * so ranking one source and not another mixes them up.
 	 */
 	readonly runtimeSourceOrder?: number;
 

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeDiscoveryCacheService.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeDiscoveryCacheService.ts
@@ -66,8 +66,14 @@ export const RUNTIME_DISCOVERY_CACHE_REFRESH_INTERVAL_DAYS_DEFAULT = 1;
  * written by older builds may still carry a `~`-shortened `runtimePath` and
  * no `runtimeDisplayPath`; bumping the version forces those entries to be
  * discarded and rediscovered rather than replayed as-is.
+ *
+ * v4: entries carry `runtimeSourceOrder`, and earlier builds wrote it on a
+ * different numeric scale. The picker compares those numbers across entries,
+ * so a replayed entry from an older scale sorts against a freshly discovered
+ * one and both orderings are wrong. Changing an extension's rank values means
+ * bumping this version.
  */
-export const RUNTIME_DISCOVERY_CACHE_SCHEMA_VERSION = 3;
+export const RUNTIME_DISCOVERY_CACHE_SCHEMA_VERSION = 4;
 
 /**
  * Storage key under which all cache state is persisted. Embeds the schema


### PR DESCRIPTION
Fixes #14803

### Summary
The interpreter/session picker ordered its environment-type headings by runtime registration order, which is discovery order, so System Pythons could sit above a workspace venv. An extension can't control that order, so the rank now travels on the runtime metadata and the picker sorts at read time.

- Adds an optional `runtimeSourceOrder` to `LanguageRuntimeMetadata`, filled by positron-python from the same environment-type ranking that drives the Suggested entry.
- The picker sorts its headings by that rank; unranked sources (e.g. R) follow the ranked ones, sorted by label so they don't shuffle between runs.
- `positron-reticulate` ranks its Python too, or it would fall into the unranked bucket below `System`.
- Adds `Pixi` to the priority table, where it was missing and so outranked everything, and ranks `Module`/`Custom` above `Global`/`System`.
- Bumps the discovery cache schema to v4. The rank is persisted per entry, so a cache written on the old scale has to be discarded rather than replayed against freshly discovered runtimes.
- The New Folder Flow interpreter dropdown sorts by the same rank, so the two lists agree.
- The notebook kernel picker calls the same helper, so it inherits the fix.

Heading order, top to bottom. Ranks are spaced by 10 so another extension can slot a source between two of them; `positron-reticulate` takes 135.

| Rank | Source |
| --- | --- |
| 10 | `uv` |
| 20 | `Poetry` |
| 30 | `Pipenv` |
| 40 | `Pixi` |
| 50 | `VirtualEnvWrapper` |
| 60 | `Hatch` |
| 70 | `Venv` |
| 80 | `VirtualEnv` |
| 90 | `ActiveState` |
| 100 | `Conda` |
| 110 | `Pyenv` |
| 120 | `Module` |
| 130 | `Custom` |
| 135 | `reticulate` |
| 140 | `MicrosoftStore` |
| 150 | `Global` |
| 160 | `System` |
| 170 | `Unknown` |

Unchanged: the Suggested entry still comes from `getRecommended()`.

#### Session Picker
##### Before
https://github.com/user-attachments/assets/e02e04ca-a6cc-4abe-8d68-a227dbff3ea8

##### After
https://github.com/user-attachments/assets/e2f1fd83-8937-4926-8aa2-7a7d406a23a7

#### New Folder Flow

##### Before

<img width="732" height="771" alt="nff - before" src="https://github.com/user-attachments/assets/988aa13c-f948-4d4a-9cec-8017a209f6bd" />

##### After

<img width="726" height="742" alt="nff - after 2" src="https://github.com/user-attachments/assets/7015b30c-cbce-4a05-9489-852d98d4ccbc" />

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- System Pythons are now listed last in the interpreter and session pickers, below uv, venv, conda and pyenv environments (#14803)

### Validation Steps

@:interpreter @:sessions @:console @:new-folder-flow

1. Open a workspace that has its own `.venv`, on a machine with several system Pythons.
2. Run **Positron: Select Interpreter** (or start a new console session) and check the source headings: virtual-environment sources first, `Global` and `System` last.
3. Confirm the **Suggested** entry is still the workspace `.venv`.
4. In an R session, run `reticulate::repl_python()` so the reticulate runtime registers, then reopen the picker: `reticulate` sits below `Venv`/`Conda`/`Pyenv` and above `Global`/`System`.
5. Restart Positron and reopen the picker. The order must be the same on this warm start, when the discovery cache has already registered the system Pythons.
6. **New Folder** > **Python Project** > **Use an existing environment**: the interpreter dropdown has the same source order as the picker, with `System` last.


