### PR TITLE
Disable Playwright snapshots in performance tests

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -200,6 +200,17 @@ export class Console {
 		}).toPass({ timeout });
 	}
 
+	/**
+	 * Checks whether the prompt is ready without moving focus.
+	 *
+	 * Use in timed paths. `waitForReady()` sends the `Cmd+K F` chord through CDP,
+	 * whose keypresses must stay outside the measurement.
+	 */
+	async expectPromptReady(prompt: string, timeout = 30000): Promise<void> {
+		const activeLine = this.code.driver.currentPage.locator(`${ACTIVE_CONSOLE_INSTANCE} .active-line-number`);
+		await expect(activeLine).toHaveText(prompt, { timeout });
+	}
+
 	async waitForReadyAndStarted(prompt: string, timeout = 30000, expectedCount = 1): Promise<void> {
 		await test.step('Wait for console to be ready and started', async () => {
 			// Only click the console tab if it's visible

--- a/test/e2e/tests/console/performance/console-code-execution.test.ts
+++ b/test/e2e/tests/console/performance/console-code-execution.test.ts
@@ -6,7 +6,10 @@
 import { expect, test, tags } from '../../_test.setup';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// Disable snapshots because document-wide capture includes a previous session's
+	// console at `z-index: -1` and attributes its output to this sample.
+	snapshots: false
 });
 
 const LANGUAGES = [
@@ -66,21 +69,23 @@ test.describe('Console Performance: Code Execution', {
 					const { console: positronConsole } = app.workbench;
 					await sessions.start(runtime, { reuse: true });
 
-					// Pre-timer setup: ensure console is focused and idle, then stage the code.
-					// pasteCodeToConsole dispatches a ClipboardEvent directly to the input
-					// element so it doesn't need keyboard focus.
+					// Pre-timer setup: Clear output so the wait can match only this
+					// submission. `waitForReady()` establishes focus outside the timer,
+					// and `pasteCodeToConsole()` preserves it.
+					await positronConsole.clearButton.click();
 					await positronConsole.waitForReady(prompt);
 					await positronConsole.pasteCodeToConsole(code);
 					await page.waitForTimeout(200);
 
 					// Metric: Enter keypress → output appears → prompt returns.
-					// waitForConsoleContents guards against Enter missing the console —
-					// if focus was lost, no output appears and the test fails rather than
-					// recording a false near-0ms result from an already-idle prompt.
+					// Keep focus restoration outside the measurement. `waitForReady()`
+					// sends `Cmd+K F` and those keypresses slow as the console DOM grows.
+					// `waitForConsoleContents()` fails if Enter misses the console,
+					// preventing an idle prompt from producing a near-zero duration.
 					const { duration_ms } = await metric.console.executeCode(async () => {
 						await page.keyboard.press('Enter');
 						await positronConsole.waitForConsoleContents(scenario.output, { timeout: 60000 });
-						await positronConsole.waitForReady(prompt, 60000);
+						await positronConsole.expectPromptReady(prompt, 60000);
 					}, target, {
 						language: lang,
 						description: `${lang}: ${scenario.name}`,


### PR DESCRIPTION
Part of https://github.com/posit-dev/positron/issues/15466

The difference between R and Python came from this interaction:

- The R test runs after the Python trim test, after which the console contains thousands of lines.
- Playwright snapshoting captures the DOM, which now contains those python lines

Disabling snapshots drastically reduced the difference in local tests.

This doesn't explain the end of July step in R timings, but it should make measurements easier to interpret.

Other change: `expectPromptReady()` removes an unnecessary key chord from the measured test. Claude thinks this could pollute measurements as well.


<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: e2e feature tags are auto-added based on your changed
  files, so tests run automatically when you open this pull request. Add tags
  here yourself to run more.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
