### PR TITLE
fix(e2e): dismiss toasts before New Folder Flow modal clicks

### DIFF
--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -133,7 +133,7 @@ export class Workbench {
 		this.explorer = new Explorer(code, this.quickaccess);
 		this.connections = new Connections(code, this.quickaccess);
 		this.dataConnections = new DataConnections(code, this.quickaccess);
-		this.newFolderFlow = new NewFolderFlow(code, this.quickaccess);
+		this.newFolderFlow = new NewFolderFlow(code, this.quickaccess, this.toasts);
 		this.output = new Output(code, this.quickaccess, this.quickInput);
 		this.console = new Console(code, this.quickInput, this.hotKeys, this.contextMenu);
 		this.modals = new Modals(code, this.toasts);

--- a/test/e2e/pages/dialog-toasts.ts
+++ b/test/e2e/pages/dialog-toasts.ts
@@ -113,13 +113,16 @@ export class Toasts {
 	}
 
 	async closeAll() {
-		const count = await this.toastNotification.count();
-		for (let i = 0; i < count; i++) {
+		// Always close index 0: closing a toast shifts the remaining ones up, so
+		// re-checking count() each pass (rather than iterating a snapshot of it)
+		// avoids skipping over the toast that just moved into a lower index.
+		while (await this.toastNotification.count() > 0) {
 			try {
-				await this.toastNotification.nth(i).hover({ timeout: 5000 });
-				await this.closeButton.nth(i).click({ timeout: 5000 });
+				await this.toastNotification.first().hover({ timeout: 5000 });
+				await this.closeButton.first().click({ timeout: 5000 });
 			} catch {
-				this.code.logger.log(`Toast ${i} already closed`);
+				this.code.logger.log('Toast already closed');
+				break;
 			}
 		}
 	}

--- a/test/e2e/pages/newFolderFlow.ts
+++ b/test/e2e/pages/newFolderFlow.ts
@@ -6,6 +6,7 @@
 import test, { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
+import { Toasts } from './dialog-toasts';
 
 export class NewFolderFlow {
 	// Dynamic modal dialogs render into an overlay with this same testid, so two on screen at once
@@ -28,7 +29,7 @@ export class NewFolderFlow {
 	private get interpreterDropdown(): Locator { return this.code.driver.currentPage.locator('#flow-sub-step-pythonenvironment-interpreterorversion').locator('button'); }
 	private get interpreterDropdownSubtitle(): Locator { return this.interpreterDropdown.locator('.dropdown-entry-subtitle'); }
 
-	constructor(private code: Code, private quickaccess: QuickAccess) { }
+	constructor(private code: Code, private quickaccess: QuickAccess, private toasts: Toasts) { }
 
 	/**
 	 * NEW FOLDER FLOW:
@@ -157,6 +158,9 @@ export class NewFolderFlow {
 			throw new Error(`Invalid flow button action: ${action}`);
 		}
 
+		// A background session's toast (e.g. a forwarded-port notice) can render over this
+		// modal and intercept the click for the full timeout.
+		await this.toasts.closeAll();
 		await button.click();
 	}
 


### PR DESCRIPTION
### Summary
Fixes a flaky "New env: uv environment" e2e failure where a background session's notification toast (e.g. a forwarded-port notice) renders over the New Folder Flow modal and intercepts clicks for the full timeout.
- `NewFolderFlow.clickFlowButton` now dismisses open toasts before clicking any flow button
- Reuses the existing `Toasts` helper via constructor injection, matching the pattern already used by `Modals`, `Assistant`, `ModelProviderModal`, and `Packages`
- Also fixes an indexing bug in `Toasts.closeAll()` itself: it snapshotted the toast count once and closed by position, so closing one toast could shift a later one out from under the next index, skipping it when multiple toasts were open at once. `closeAll()` is shared by several other suites (packages pane, notebooks, plots, assistant), so this PR tags those areas too as a sanity check on the shared helper.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:new-folder-flow @:modal @:packages-pane @:positron-notebooks @:plots @:assistant

### E2E Triage Diagnosis

<details>
<summary>🟢 <b>High confidence</b> -- clickFlowButton(CREATE) times out because a background notification toast (forwarded-port info alert from an earlier subtest session in the same window) overlaps the New Folder Flow modal and intercepts pointer events on the Create button for the full 30s.</summary>

- **Test:** [New Folder Flow: Python Project > New env: uv environment](https://connect.posit.it/e2e-test-insights/?tab=test_health&repo=positron&test=New%20Folder%20Flow%3A%20Python%20Project%20%3E%20New%20env%3A%20uv%20environment%7C%7C%7Ctest%2Fe2e%2Ftests%2Fnew-folder-flow%2Fnew-folder-flow-python.test.ts)
- **Targeted failure:** locator.click: Timeout 30000ms exceeded on the New Folder Flow Create button
- **Signal:** Playwright call log shows every retry blocked by ".notification-toast-container" / ".notifications-toasts bottom-right visible" intercepting pointer events; page snapshot at failure shows the open toast ("Your application running on port 5877 is available") plus 16 accumulated forwarded ports from prior New env subtests in the same window, while the modal Create button itself is visible/enabled/stable throughout.
- **Frequency:** 2/116 runs (1.7%) on main, ubuntu/chromium
- **Hypothesis:** distinct from PR #15029 (dropped CREATED_VENV marker, no console start) despite git-ancestry flagging this occurrence as postdating that fix -- console/session here started fine; the blocker is a stray toast, a timing coincidence between a background session's port-forward notification and this test's modal click, not a recurrence of the marker race

</details>
