### PR TITLE
Update dev fallback versions in product.ts

### DIFF
--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -93,12 +93,12 @@ else {
 	// Running out of sources
 	if (Object.keys(product).length === 0) {
 		Object.assign(product, {
-			version: '1.111.0-dev',
+			version: '1.134.0-dev',
 			// --- Start Positron ---
 			// This only applies to dev builds where it is not possible to read the
 			// product configuration. Release builds replace the product configuration
 			// during the build. See INSERT_PRODUCT_CONFIGURATION above.
-			positronVersion: '2026.09.0',
+			positronVersion: '2026.10.0',
 			positronBuildNumber: '0',
 			date: new Date().toISOString(),
 			nameShort: 'Positron Dev',


### PR DESCRIPTION
### Summary

The sources-only fallback block in `product.ts` (used when running from source, where the product configuration cannot be read) was missed during the 1.134.0 upstream merge. It still reported `1.111.0-dev` / `2026.09.0`.

This brings it in line with the real version sources:
- `version`: `1.111.0-dev` -> `1.134.0-dev` (matches `package.json` `1.134.0`)
- `positronVersion`: `2026.09.0` -> `2026.10.0` (matches `product.json`)

### QA Notes

Dev-build only; release builds replace the product configuration at build time, so packaged builds were unaffected. To verify, run Positron from source and check Help > About shows 2026.10.0 / 1.134.0.

@:nowatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)