### PR TITLE
Load database SDKs on first connect instead of at pane activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,6 @@ dist
 # deleting them in the background. Present while rebuild.sh runs, and left
 # behind if a run is interrupted before the deletion finishes.
 .rebuild-trash.*
+# Posit Assistant plans, which are local working notes rather than repo content
+.posit/assistant/plans/
 # --- End Positron ---

--- a/extensions/positron-catalog-explorer/src/catalogs/snowflake.ts
+++ b/extensions/positron-catalog-explorer/src/catalogs/snowflake.ts
@@ -42,7 +42,7 @@ let snowflakeSdk: typeof import('snowflake-sdk') | undefined;
  */
 async function loadSnowflakeSdk(context: vscode.ExtensionContext): Promise<typeof import('snowflake-sdk')> {
 	if (!snowflakeSdk) {
-		const sdk = await import('snowflake-sdk');
+		const sdk = (await import('snowflake-sdk')).default;
 		await configureSnowflakeLogging(context, sdk);
 		snowflakeSdk = sdk;
 	}

--- a/extensions/positron-data-driver-databricks/src/databricksClient.ts
+++ b/extensions/positron-data-driver-databricks/src/databricksClient.ts
@@ -20,8 +20,6 @@
 //      browsing a connection that sat idle recovers transparently. A genuine SQL error (unknown
 //      table, parse error) is never retried.
 
-import { DBSQLClient } from '@databricks/sql';
-
 /** How the connection authenticates. Each value maps to a distinct @databricks/sql auth config. */
 export type DatabricksAuthType =
 	/** Personal access token, supplied as a bearer token. */
@@ -100,15 +98,27 @@ export interface IDatabricksSdkClient {
 
 /**
  * Builds a fresh SDK client. Factored out (and overridable via the DatabricksClient constructor) so
- * tests can supply a fake client without a live workspace.
+ * tests can supply a fake client without a live workspace. Async because the real factory loads the
+ * SDK on demand.
  */
-export type DatabricksSdkClientFactory = () => IDatabricksSdkClient;
+export type DatabricksSdkClientFactory = () => Promise<IDatabricksSdkClient>;
 
-/** The real factory: a stock DBSQLClient. */
-const defaultClientFactory: DatabricksSdkClientFactory = () =>
+/**
+ * The real factory: a stock DBSQLClient.
+ *
+ * @databricks/sql is imported here rather than at the top of the module so that loading it is paid
+ * for by the first connection attempt, not by activating the extension. The Data Connections pane
+ * activates every driver at once, and a user who never opens a Databricks connection should never
+ * pay to load its SDK.
+ *
+ * Exported for unit tests, which assert the lazy import yields a constructible client.
+ */
+export const defaultClientFactory: DatabricksSdkClientFactory = async () => {
+	const { DBSQLClient } = await import('@databricks/sql');
 	// DBSQLClient's connect() takes a discriminated union of auth shapes that this file assembles
 	// dynamically (see connectionOptions), so the boundary is cast to the narrower local interface.
-	new DBSQLClient() as unknown as IDatabricksSdkClient;
+	return new DBSQLClient() as unknown as IDatabricksSdkClient;
+};
 
 /**
  * Translates normalized options into the @databricks/sql connect options for the chosen auth flow.
@@ -236,7 +246,7 @@ export class DatabricksClient {
 	 */
 	private async _open(): Promise<void> {
 		for (let attempt = 1; ; attempt++) {
-			const client = this._createClient();
+			const client = await this._createClient();
 			try {
 				await client.connect(connectionOptions(this._config));
 				this._session = await client.openSession({

--- a/extensions/positron-data-driver-databricks/src/test/databricksDriver.test.ts
+++ b/extensions/positron-data-driver-databricks/src/test/databricksDriver.test.ts
@@ -10,6 +10,7 @@ import {
 	connectionOptions,
 	DatabricksClient,
 	DatabricksSdkClientFactory,
+	defaultClientFactory,
 	IDatabricksOperation,
 	IDatabricksSdkClient,
 	IDatabricksSession,
@@ -562,7 +563,7 @@ suite('Databricks Client', () => {
 			closedOperations: [] as string[],
 			queries: [] as string[],
 		};
-		const factory: DatabricksSdkClientFactory = () => {
+		const factory: DatabricksSdkClientFactory = async () => {
 			const generation = ++state.clientsCreated;
 			// Both statements and metadata calls resolve to an operation, so one builder serves each; the
 			// metadata call is recorded under a synthetic label so tests can assert on it like a query.
@@ -930,5 +931,18 @@ suite('Databricks Connection Code', () => {
 		const generated = code('pat', 'python', { token: 'dapi"123', catalog: 'my"catalog' });
 		assert.match(generated, /access_token="dapi\\"123"/);
 		assert.match(generated, /catalog="my\\"catalog"/);
+	});
+});
+
+suite('Databricks Lazy SDK Loading', () => {
+	// The SDK is reached through a dynamic import() inside the default factory rather than a
+	// top-level import, so that opening the Data Connections pane does not pay to load it. That
+	// import is resolved at runtime against the real package, so an export the module namespace does
+	// not actually carry still type-checks and only fails at the user's first connect.
+	test('the default factory builds a real client from the deferred import', async () => {
+		const client = await defaultClientFactory();
+		assert.deepStrictEqual(
+			{ connect: typeof client.connect, openSession: typeof client.openSession },
+			{ connect: 'function', openSession: 'function' });
 	});
 });

--- a/extensions/positron-data-driver-postgresql/esbuild.mts
+++ b/extensions/positron-data-driver-postgresql/esbuild.mts
@@ -16,9 +16,15 @@ run({
 	srcDir,
 	outdir: outDir,
 	additionalOptions: {
+		// pg is externalized so the dynamic import() in postgresqlConnection stays
+		// a deferred load: opening the Data Connections pane activates this
+		// extension, and a user who never connects to PostgreSQL should not pay
+		// to parse pg. positron-data-driver-postgresql is registered in
+		// extensionsWithNpmDeps (build/lib/extensions.ts) so pg is packaged.
+		//
 		// pg-native is an optional native dependency of pg; leave it as an
 		// external so its require() at runtime can no-op gracefully when
 		// callers don't opt into pg.native.
-		external: ['vscode', 'positron', 'pg-native'],
+		external: ['vscode', 'positron', 'pg', 'pg-native'],
 	},
 }, process.argv);

--- a/extensions/positron-data-driver-postgresql/src/postgresqlClient.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlClient.ts
@@ -16,10 +16,13 @@
 // PostgreSQL connection creates clients several ways (a libpq connection string, discrete fields, and
 // per-database clients in server mode); the connection supplies the right builder for each.
 
-import { Client, QueryResult } from 'pg';
+import type { Client, QueryResult } from 'pg';
 
-/** Factory for the underlying pg Client. Overridable in tests to supply a fake. */
-export type PgClientFactory = () => Client;
+/**
+ * Factory for the underlying pg Client. Overridable in tests to supply a fake. Async because the
+ * real factory loads pg on demand.
+ */
+export type PgClientFactory = () => Promise<Client>;
 
 // Connect-retry budget. A server that is briefly unreachable on connect (a resuming instance, a
 // transient network blip) drops the first attempts with a transient connection error. The attempt
@@ -95,7 +98,7 @@ export class PostgreSQLClient {
 	 */
 	private async _open(): Promise<void> {
 		for (let attempt = 1; ; attempt++) {
-			const pg = this._createPgClient();
+			const pg = await this._createPgClient();
 			// When the socket dies while no query is in flight, the pg Client emits an asynchronous
 			// 'error' event. With no listener that becomes an unhandled 'error' and takes down the
 			// extension host, so absorb it here; the next query() observes the broken client and

--- a/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { readFileSync } from 'fs';
-import { Client } from 'pg';
+import type { Client } from 'pg';
 import * as positron from 'positron';
 import { ConnectionOptions } from 'tls';
 import { PostgreSQLClient } from './postgresqlClient.js';
@@ -127,6 +127,40 @@ function withConnectionStringDatabase(connectionString: string, database: string
  * never shown, because it can embed a password; a socket-directory host (or no host) means a
  * local-socket connection; otherwise the host:port is reported.
  */
+/**
+ * Builds the underlying pg client from the connection config, optionally scoped to a specific
+ * database. A connection string is parsed and applied by the pg client itself (including SSL);
+ * otherwise the client is built from the individual fields. TCP keepalive is enabled so an idle
+ * socket stays warm and a dead peer is detected quickly.
+ *
+ * pg is imported here rather than at the top of the module so that loading it is paid for by the
+ * first connection attempt, not by activating the extension. The Data Connections pane activates
+ * every driver at once, and a user who never opens a PostgreSQL connection should never pay to load
+ * pg.
+ *
+ * Exported for unit tests, which assert the lazy import yields a constructible client.
+ */
+export async function buildPgClient(config: PostgreSQLConnectionConfig, database?: string): Promise<Client> {
+	const { Client } = await import('pg');
+	// Keep the socket warm across idle gaps and let the OS detect a dead peer quickly.
+	const keepAlive = { keepAlive: true, keepAliveInitialDelayMillis: KEEP_ALIVE_INITIAL_DELAY_MS };
+	if (config.kind === 'connectionString') {
+		const connectionString = database !== undefined
+			? withConnectionStringDatabase(config.connectionString, database)
+			: config.connectionString;
+		return new Client({ connectionString, ...keepAlive });
+	}
+	return new Client({
+		host: config.host,
+		port: config.port,
+		user: config.user,
+		password: config.password,
+		database: database ?? config.database,
+		ssl: buildSslConfig(config),
+		...keepAlive,
+	});
+}
+
 export function connectionTarget(config: PostgreSQLConnectionConfig): string {
 	if (config.kind === 'connectionString') {
 		return 'the server in the connection string';
@@ -204,33 +238,7 @@ export class PostgreSQLConnection implements positron.DataConnection, IPostgresC
 	 * the same config on reconnect.
 	 */
 	private _buildClient(database?: string): PostgreSQLClient {
-		return new PostgreSQLClient(() => this._buildPgClient(database));
-	}
-
-	/**
-	 * Builds the underlying pg client from the connection config, optionally scoped to a specific
-	 * database. A connection string is parsed and applied by the pg client itself (including SSL);
-	 * otherwise the client is built from the individual fields. TCP keepalive is enabled so an idle
-	 * socket stays warm and a dead peer is detected quickly.
-	 */
-	private _buildPgClient(database?: string): Client {
-		// Keep the socket warm across idle gaps and let the OS detect a dead peer quickly.
-		const keepAlive = { keepAlive: true, keepAliveInitialDelayMillis: KEEP_ALIVE_INITIAL_DELAY_MS };
-		if (this._config.kind === 'connectionString') {
-			const connectionString = database !== undefined
-				? withConnectionStringDatabase(this._config.connectionString, database)
-				: this._config.connectionString;
-			return new Client({ connectionString, ...keepAlive });
-		}
-		return new Client({
-			host: this._config.host,
-			port: this._config.port,
-			user: this._config.user,
-			password: this._config.password,
-			database: database ?? this._config.database,
-			ssl: buildSslConfig(this._config),
-			...keepAlive,
-		});
+		return new PostgreSQLClient(() => buildPgClient(this._config, database));
 	}
 
 	/**

--- a/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
+++ b/extensions/positron-data-driver-postgresql/src/postgresqlConnection.ts
@@ -123,11 +123,6 @@ function withConnectionStringDatabase(connectionString: string, database: string
 }
 
 /**
- * Describes what a connection targets, for error messages and logging. A connection string is
- * never shown, because it can embed a password; a socket-directory host (or no host) means a
- * local-socket connection; otherwise the host:port is reported.
- */
-/**
  * Builds the underlying pg client from the connection config, optionally scoped to a specific
  * database. A connection string is parsed and applied by the pg client itself (including SSL);
  * otherwise the client is built from the individual fields. TCP keepalive is enabled so an idle
@@ -161,6 +156,11 @@ export async function buildPgClient(config: PostgreSQLConnectionConfig, database
 	});
 }
 
+/**
+ * Describes what a connection targets, for error messages and logging. A connection string is
+ * never shown, because it can embed a password; a socket-directory host (or no host) means a
+ * local-socket connection; otherwise the host:port is reported.
+ */
 export function connectionTarget(config: PostgreSQLConnectionConfig): string {
 	if (config.kind === 'connectionString') {
 		return 'the server in the connection string';

--- a/extensions/positron-data-driver-postgresql/src/test/postgresqlDriver.test.ts
+++ b/extensions/positron-data-driver-postgresql/src/test/postgresqlDriver.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as positron from 'positron';
 import { PostgreSQLClient } from '../postgresqlClient.js';
-import { connectionTarget, PostgreSQLConnection, PostgreSQLConnectionConfig } from '../postgresqlConnection.js';
+import { buildPgClient, connectionTarget, PostgreSQLConnection, PostgreSQLConnectionConfig } from '../postgresqlConnection.js';
 import { createSchemaNode } from '../postgresqlNodes.js';
 
 // Default config for tests -- not used to connect, just to construct.
@@ -635,7 +635,7 @@ suite('PostgreSQL Reconnecting Client', () => {
 	// created so far.
 	function makeClient(handlers: Array<(sql: string, params?: unknown[]) => { rows: unknown[] }>) {
 		const clients: FakeClient[] = [];
-		const client = new PostgreSQLClient(() => {
+		const client = new PostgreSQLClient(async () => {
 			const pg = new FakeClient(handlers[clients.length] ?? (() => ({ rows: [] })));
 			clients.push(pg);
 			// eslint-disable-next-line local/code-no-any-casts
@@ -703,7 +703,7 @@ suite('PostgreSQL Reconnecting Client', () => {
 	// count, and passes a no-op sleep so the backoff does not slow the test.
 	function connectClient(connectErrors: Array<Error | undefined>) {
 		const state = { attempts: 0 };
-		const client = new PostgreSQLClient(() => {
+		const client = new PostgreSQLClient(async () => {
 			const err = connectErrors[state.attempts];
 			state.attempts++;
 			// eslint-disable-next-line local/code-no-any-casts
@@ -730,5 +730,18 @@ suite('PostgreSQL Reconnecting Client', () => {
 
 		await assert.rejects(() => client.connect(), /password authentication failed/);
 		assert.strictEqual(state.attempts, 1, 'a bad password should fail fast, not retry');
+	});
+});
+
+suite('PostgreSQL Lazy pg Loading', () => {
+	// pg is reached through a dynamic import() inside buildPgClient rather than a top-level import,
+	// so that opening the Data Connections pane does not pay to load it. That import is resolved at
+	// runtime against the real package, so an export the module namespace does not actually carry
+	// still type-checks and only fails at the user's first connect.
+	test('buildPgClient builds a real client from the deferred import', async () => {
+		const client = await buildPgClient(TEST_CONFIG);
+		assert.deepStrictEqual(
+			{ connect: typeof client.connect, query: typeof client.query },
+			{ connect: 'function', query: 'function' });
 	});
 });

--- a/extensions/positron-data-driver-redshift/esbuild.mts
+++ b/extensions/positron-data-driver-redshift/esbuild.mts
@@ -16,9 +16,26 @@ run({
 	srcDir,
 	outdir: outDir,
 	additionalOptions: {
+		// pg and the AWS SDK are externalized so the dynamic import()s in
+		// redshiftClient and redshiftConnection stay deferred loads: opening the
+		// Data Connections pane activates this extension, and a user who never
+		// connects to Redshift should not pay to parse either. The AWS SDK is
+		// only reachable through the IAM auth mechanism, so even a Redshift user
+		// on password auth never loads it. positron-data-driver-redshift is
+		// registered in extensionsWithNpmDeps (build/lib/extensions.ts) so all of
+		// these are packaged.
+		//
 		// pg-native is an optional native dependency of pg; leave it as an
 		// external so its require() at runtime can no-op gracefully when
 		// callers don't opt into pg.native.
-		external: ['vscode', 'positron', 'pg-native'],
+		external: [
+			'vscode',
+			'positron',
+			'pg',
+			'pg-native',
+			'@aws-sdk/client-redshift',
+			'@aws-sdk/client-redshift-serverless',
+			'@aws-sdk/credential-providers',
+		],
 	},
 }, process.argv);

--- a/extensions/positron-data-driver-redshift/src/redshiftClient.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftClient.ts
@@ -19,9 +19,9 @@
 //      serverless workgroup can take tens of seconds to accept the new connection; the reconnect
 //      waits for it rather than imposing a shorter deadline of our own.)
 
-import { Client, QueryResult } from 'pg';
+import type { Client, QueryResult } from 'pg';
 import { ConnectionOptions } from 'tls';
-import { RedshiftCredentialProvider } from './redshiftIamCredentials.js';
+import type { RedshiftCredentialProvider } from './redshiftIamCredentials.js';
 
 /**
  * The discrete connection fields for a Redshift connection. Host, port, database, and user identify
@@ -85,10 +85,19 @@ function buildSslConfig(config: RedshiftFieldConfig): boolean | ConnectionOption
  * overridable via the RedshiftClient constructor) so tests can supply a fake pg client without a
  * live cluster.
  */
-export type PgClientFactory = (config: RedshiftFieldConfig) => Client;
+export type PgClientFactory = (config: RedshiftFieldConfig) => Promise<Client>;
 
-/** The real factory: a keepalive-enabled pg Client. */
-const defaultPgClientFactory: PgClientFactory = config => new Client({
+/**
+ * The real factory: a keepalive-enabled pg Client.
+ *
+ * pg is imported here rather than at the top of the module so that loading it is paid for by the
+ * first connection attempt, not by activating the extension. The Data Connections pane activates
+ * every driver at once, and a user who never opens a Redshift connection should never pay to load
+ * pg.
+ *
+ * Exported for unit tests, which assert the lazy import yields a constructible client.
+ */
+export const defaultPgClientFactory: PgClientFactory = async config => new (await import('pg')).Client({
 	host: config.host,
 	port: config.port,
 	user: config.user,
@@ -193,7 +202,7 @@ export class RedshiftClient {
 			// resuming serverless workgroup, so a set fetched once up front can expire before the
 			// attempt that finally succeeds uses it. Only the first attempt forces a re-mint; the
 			// later ones reuse what it fetched rather than calling AWS once per retry.
-			const pg = this._createPgClient(await this._resolveConfig(forceRefresh && attempt === 1));
+			const pg = await this._createPgClient(await this._resolveConfig(forceRefresh && attempt === 1));
 			// When the socket dies while no query is in flight, the pg Client emits an asynchronous
 			// 'error' event. With no listener that becomes an unhandled 'error' and takes down the
 			// extension host, so absorb it here; the next query() observes the broken client and

--- a/extensions/positron-data-driver-redshift/src/redshiftConnection.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftConnection.ts
@@ -12,7 +12,7 @@
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { isAuthenticationError, PgClientFactory, RedshiftClient, RedshiftFieldConfig } from './redshiftClient.js';
-import { createIamCredentialProvider, RedshiftCredentialFetcher, RedshiftIamConfig } from './redshiftIamCredentials.js';
+import type { RedshiftCredentialFetcher, RedshiftCredentialProvider, RedshiftIamConfig } from './redshiftIamCredentials.js';
 import { createDatabasesGroupNode, createSchemasGroupNode, IRedshiftPreviewHost } from './redshiftNodes.js';
 import { IRedshiftDataExplorerHost, REDSHIFT_DATA_EXPLORER_PROVIDER_ID } from './redshiftDataExplorerRpcHandler.js';
 
@@ -82,11 +82,35 @@ export class RedshiftConnection implements positron.DataConnection, IRedshiftPre
 			this._config.kind === 'iam'
 				? {
 					...this._config,
-					credentialProvider: createIamCredentialProvider(
-						this._config.iam, this._logger, this._options?.credentialFetcher),
+					credentialProvider: this._lazyIamCredentialProvider(this._config.iam),
 				}
 				: this._config,
 			this._options?.pgClientFactory);
+	}
+
+	/**
+	 * Wraps the IAM credential provider in one that loads redshiftIamCredentials on first use.
+	 *
+	 * That module statically imports the AWS SDK, so importing it from here would pull the SDK in at
+	 * activation. The Data Connections pane activates every driver at once, so the cost is paid by
+	 * every user, including one who never opens a Redshift connection (let alone an IAM one). The
+	 * real provider caches the credentials it mints, so it is created once and reused; only the
+	 * first call pays for the import.
+	 */
+	private _lazyIamCredentialProvider(iam: RedshiftIamConfig): RedshiftCredentialProvider {
+		let provider: Promise<RedshiftCredentialProvider> | undefined;
+		return async forceRefresh => {
+			if (!provider) {
+				const pending = import('./redshiftIamCredentials.js').then(
+					m => m.createIamCredentialProvider(iam, this._logger, this._options?.credentialFetcher));
+				// Drop a failed load rather than memoizing it. RedshiftClient re-resolves credentials on
+				// every connect attempt, so a cached rejection would spend the whole retry budget
+				// replaying one stale error, and leave the connection unable to ever reconnect.
+				pending.catch(() => { if (provider === pending) { provider = undefined; } });
+				provider = pending;
+			}
+			return (await provider)(forceRefresh);
+		};
 	}
 
 	/** Establishes the connection. Must be called before any other method. */

--- a/extensions/positron-data-driver-redshift/src/redshiftDriver.ts
+++ b/extensions/positron-data-driver-redshift/src/redshiftDriver.ts
@@ -16,7 +16,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { RedshiftConnection } from './redshiftConnection.js';
 import { RedshiftDataExplorerRpcHandler } from './redshiftDataExplorerRpcHandler.js';
-import { RedshiftIamConfig } from './redshiftIamCredentials.js';
+import type { RedshiftIamConfig } from './redshiftIamCredentials.js';
 
 /** The Redshift default port. */
 const DEFAULT_PORT = 5439;

--- a/extensions/positron-data-driver-redshift/src/test/redshiftDriver.test.ts
+++ b/extensions/positron-data-driver-redshift/src/test/redshiftDriver.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as positron from 'positron';
 import { RedshiftConnection, RedshiftConnectionConfig } from '../redshiftConnection.js';
-import { PgClientFactory, RedshiftClient, RedshiftFieldConfig } from '../redshiftClient.js';
+import { defaultPgClientFactory, PgClientFactory, RedshiftClient, RedshiftFieldConfig } from '../redshiftClient.js';
 import { createDatabaseNode, createSchemaNode } from '../redshiftNodes.js';
 import {
 	describeRedshiftEndpoint,
@@ -806,5 +806,19 @@ suite('Redshift IAM Connection Code', () => {
 		assert.match(code, /ClusterIdentifier = "my-cluster"/);
 		assert.match(code, /user = creds\$DbUser/);
 		assert.match(code, /password = creds\$DbPassword/);
+	});
+});
+
+suite('Redshift Lazy pg Loading', () => {
+	// pg is reached through a dynamic import() inside the default factory rather than a top-level
+	// import, so that opening the Data Connections pane does not pay to load it. That import is
+	// resolved at runtime against the real package, so an export the module namespace does not
+	// actually carry still type-checks and only fails at the user's first connect. The AWS SDK is
+	// deferred the same way, one level up, and is covered by the IAM connection-wiring test.
+	test('the default factory builds a real client from the deferred import', async () => {
+		const client = await defaultPgClientFactory(TEST_CONFIG);
+		assert.deepStrictEqual(
+			{ connect: typeof client.connect, query: typeof client.query },
+			{ connect: 'function', query: 'function' });
 	});
 });

--- a/extensions/positron-data-driver-snowflake/src/snowflakeClient.ts
+++ b/extensions/positron-data-driver-snowflake/src/snowflakeClient.ts
@@ -17,8 +17,6 @@
 //      rebuilds the connection once before retrying, so browsing a connection that sat idle recovers
 //      transparently. A genuine SQL error (bad identifier, compilation error) is never retried.
 
-import * as snowflake from 'snowflake-sdk';
-
 /**
  * Normalized Snowflake connection options, independent of any single auth mechanism. Built by the
  * driver from the mechanism's parameter values and passed straight to snowflake-sdk's
@@ -100,8 +98,9 @@ export interface SnowflakeQueryResult {
 /**
  * Builds a fresh snowflake-sdk Connection for the given options. Factored out (and overridable via
  * the SnowflakeClient constructor) so tests can supply a fake connection without a live account.
+ * Async because the real factory loads the SDK on demand.
  */
-export type SnowflakeConnectionFactory = (options: SnowflakeConnectionOptions) => ISnowflakeSdkConnection;
+export type SnowflakeConnectionFactory = (options: SnowflakeConnectionOptions) => Promise<ISnowflakeSdkConnection>;
 
 /**
  * Authenticators whose connect performs an asynchronous step (an OAuth token exchange or a browser
@@ -109,8 +108,22 @@ export type SnowflakeConnectionFactory = (options: SnowflakeConnectionOptions) =
  */
 const ASYNC_AUTHENTICATORS = new Set(['OAUTH_CLIENT_CREDENTIALS', 'OAUTH_AUTHORIZATION_CODE', 'EXTERNALBROWSER']);
 
-/** The real factory: a keepalive-enabled snowflake-sdk Connection. */
-const defaultConnectionFactory: SnowflakeConnectionFactory = options => {
+/**
+ * The real factory: a keepalive-enabled snowflake-sdk Connection.
+ *
+ * snowflake-sdk is imported here rather than at the top of the module so that loading it is paid
+ * for by the first connection attempt, not by activating the extension. The Data Connections pane
+ * activates every driver at once, and a user who never opens a Snowflake connection should never
+ * pay to load its SDK.
+ *
+ * Exported for unit tests, which assert the lazy import yields a constructible connection.
+ */
+export const defaultConnectionFactory: SnowflakeConnectionFactory = async options => {
+	// snowflake-sdk is CommonJS with no `exports` map, so Node's ESM loader cannot detect its named
+	// exports: the namespace a dynamic import() yields carries the module object on `default` and
+	// nothing else. @types/snowflake-sdk declares the package ESM-shaped, so reaching for
+	// `createConnection` on the namespace type-checks but is undefined at runtime.
+	const snowflake = (await import('snowflake-sdk')).default;
 	// createConnection returns @types/snowflake-sdk's Connection, whose execute signature is narrower
 	// than the simplified ISnowflakeSdkConnection this file declares (see that interface's comment).
 	// Cast at the SDK boundary since the two execute shapes aren't structurally assignable.
@@ -217,7 +230,7 @@ export class SnowflakeClient {
 	 */
 	private async _open(): Promise<void> {
 		for (let attempt = 1; ; attempt++) {
-			const conn = this._createConnection(this._config);
+			const conn = await this._createConnection(this._config);
 			try {
 				await this._connectOnce(conn);
 				this._conn = conn;

--- a/extensions/positron-data-driver-snowflake/src/test/snowflakeDriver.test.ts
+++ b/extensions/positron-data-driver-snowflake/src/test/snowflakeDriver.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import * as positron from 'positron';
 import { SnowflakeConnection, SnowflakeConnectionConfig } from '../snowflakeConnection.js';
-import { SnowflakeConnectionFactory, SnowflakeClient, SnowflakeConnectionOptions } from '../snowflakeClient.js';
+import { defaultConnectionFactory, SnowflakeConnectionFactory, SnowflakeClient, SnowflakeConnectionOptions } from '../snowflakeClient.js';
 import { createDatabaseNode, createSchemaNode } from '../snowflakeNodes.js';
 import { parseSnowflakeAccount } from '../snowflakeDriver.js';
 
@@ -418,7 +418,7 @@ suite('Snowflake Reconnecting Client', () => {
 	// nth handler backs the nth connection built), plus the list of connections created so far.
 	function makeFactory(handlers: Array<(sql: string, binds?: unknown[]) => { rows: unknown[] }>) {
 		const connections: FakeConnection[] = [];
-		const factory: SnowflakeConnectionFactory = () => {
+		const factory: SnowflakeConnectionFactory = async () => {
 			const conn = new FakeConnection(handlers[connections.length] ?? (() => ({ rows: [] })));
 			connections.push(conn);
 			// eslint-disable-next-line local/code-no-any-casts
@@ -489,7 +489,7 @@ suite('Snowflake Reconnecting Client', () => {
 	// a transient connect sequence can be simulated. Records the attempt count.
 	function connectFactory(connectErrors: Array<Error | undefined>) {
 		const state = { attempts: 0 };
-		const factory: SnowflakeConnectionFactory = () => {
+		const factory: SnowflakeConnectionFactory = async () => {
 			// eslint-disable-next-line local/code-no-any-casts
 			return {
 				connect: (cb: (err: any, conn: any) => void) => { const err = connectErrors[state.attempts]; state.attempts++; cb(err, undefined); },
@@ -523,7 +523,7 @@ suite('Snowflake Reconnecting Client', () => {
 		// the browser-SSO / OAuth failure paths can. Callback-only wiring would wait for the SDK's
 		// internal timeout; consuming the returned promise rejects promptly.
 		const authError = Object.assign(new Error('Incorrect username or password was specified'), { code: '390100' });
-		const factory: SnowflakeConnectionFactory = () => {
+		const factory: SnowflakeConnectionFactory = async () => {
 			// eslint-disable-next-line local/code-no-any-casts
 			return {
 				connect: (cb: (err: any, conn: any) => void) => cb(authError, undefined),
@@ -567,7 +567,7 @@ suite('Snowflake Reconnecting Client', () => {
 		const built = [first, replacement];
 		let n = 0;
 		// eslint-disable-next-line local/code-no-any-casts
-		const factory: SnowflakeConnectionFactory = () => built[n++].conn as any;
+		const factory: SnowflakeConnectionFactory = async () => built[n++].conn as any;
 		const client = new SnowflakeClient(OPTIONS, factory, async () => { });
 		await client.connect();
 
@@ -591,7 +591,7 @@ suite('Snowflake Reconnecting Client', () => {
 		const built = [first, replacement];
 		let n = 0;
 		// eslint-disable-next-line local/code-no-any-casts
-		const factory: SnowflakeConnectionFactory = () => built[n++].conn as any;
+		const factory: SnowflakeConnectionFactory = async () => built[n++].conn as any;
 		const client = new SnowflakeClient(OPTIONS, factory, async () => { });
 		await client.connect();
 
@@ -643,5 +643,24 @@ suite('Snowflake Account Parsing', () => {
 			parseSnowflakeAccount('https://app.snowflake.com/duloftf/posit_software_pbc_dev/'),
 			'DULOFTF-POSIT_SOFTWARE_PBC_DEV'
 		);
+	});
+});
+
+suite('Snowflake Lazy SDK Loading', () => {
+	// The SDK is reached through a dynamic import() inside the default factory rather than a
+	// top-level import, so that opening the Data Connections pane does not pay to load it. That
+	// import is resolved at runtime against the real package, so an export the module namespace does
+	// not actually carry still type-checks and only fails at the user's first connect. snowflake-sdk
+	// is CommonJS with no `exports` map, which is exactly that case: its named exports are invisible
+	// to Node's ESM loader and only reachable through the namespace's `default`.
+	test('the default factory builds a real connection from the deferred import', async () => {
+		const conn = await defaultConnectionFactory({
+			account: 'myorg-myacct',
+			username: 'testuser',
+			password: 'testpass',
+		});
+		assert.deepStrictEqual(
+			{ execute: typeof conn.execute, connectAsync: typeof conn.connectAsync },
+			{ execute: 'function', connectAsync: 'function' });
 	});
 });


### PR DESCRIPTION
Fixes #15442

Currently, all seven `positron-data-driver-*` extensions activate together on the `onView:workbench.panel.positronDataConnections` event. Four of them (Databricks, Snowflake, PostgreSQL, and Redshift) imported their database SDK at the top of a client module. The `activate()` function reaches that module synchronously, so the pane therefore loaded `@databricks/sql`, `snowflake-sdk`, `pg`, and three `@aws-sdk` packages at activation. A user who, for example, only opens SQLite connections paid this cost too.

This PR moves each SDK behind a dynamic `import()` in the client factory. The cost now moves from pane activation to the first connection attempt, which I think is better. SQLite, DuckDB, and ODBC do not have this problem, because they keep their native module in a worker process.

The linked issue outlines two possible fixes, and this PR takes the first approach. All seven extensions still activate, but activation now costs only the registration of a metadata object. I think it solves the problem sufficiently that we don't need to do anything else for now.

### Performance

The table below gives the time to load each driver bundle. I measured it on the packaged macOS arm64 build, with `vscode` and `positron` stubbed. This is that "extra"  cost the extension host pays at activation.

| Driver | Before | After | Deferred to first connect |
|---|---|---|---|
| Databricks | 79 ms | 1.2 ms | 83 ms |
| Snowflake | 143 ms | 2.0 ms | 144 ms |
| PostgreSQL | 6.5 ms | 1.2 ms | 12 ms |
| Redshift | 19 ms | 1.2 ms | 10 ms, plus the AWS SDK on IAM connections |
| **Total** | **248 ms** | **5.6 ms** | |

The last column shows that the cost is just moved, but now a user who never opens a Redshift connection never loads the AWS SDK and a Redshift user with password authentication does not ever load it either.

`pg` and the AWS SDK are now esbuild externals, so they load from `node_modules` on demand. Before this change they were bundled and also shipped in `node_modules`. Removing that duplicate copy makes the PostgreSQL bundle 81 KB smaller and the Redshift bundle 451 KB smaller.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- The Data Connections pane opens faster, because each database SDK now waits to load on the first connection (#15442)

### Validation Steps

@:connections

The E2E suite covers all four drivers in `test/e2e/tests/data-connections/`. Each driver also has a new unit test for its real client factory. That test fails if a lazy import does not give the expected export.

It would be best to do these steps on a release build and not a dev build:

1. Open the Data Connections pane. Make sure that all seven drivers appear in the Add Connection dialog.
2. Generate a connection code snippet for the drivers, without a connection.
3. Run _Developer: Show Running Extensions_ with the pane open. Each of the four drivers should activate in 1 ms to 5 ms.
4. Connect to Snowflake and run a query. This is the most important manual validation, because the compiler cannot catch an error in it.
5. Connect to Databricks and run a query.
6. Connect to PostgreSQL in single-database mode. Then connect again in server mode, which uses a second factory path.
7. Connect to Redshift with password authentication.
8. Connect to Redshift with IAM authentication. This is the only path that loads the AWS SDK.
9. Connect to PostgreSQL. Restart the server. Then run a query. The connection must recover without an error.

Step 8 matters most, because the Redshift IAM path holds the only new code in this PR and I have not run that myself yet.
