### PR TITLE
Use bundled ipykernel for reticulate sessions

### DIFF
--- a/extensions/positron-python/src/client/common/process/internal/scripts/architecture.ts
+++ b/extensions/positron-python/src/client/common/process/internal/scripts/architecture.ts
@@ -15,7 +15,9 @@ import { InterpreterInfoJson } from '.';
  * - Windows: 'AMD64' or 'ARM64' (normalized to lowercase)
  * - Linux: 'aarch64' or 'x86_64'
  */
-export function getArchitectureFromInfo(raw: InterpreterInfoJson): Architecture {
+export function getArchitectureFromInfo(
+    raw: Partial<Pick<InterpreterInfoJson, 'architecture' | 'is64Bit'>>,
+): Architecture {
     if (raw.architecture) {
         const normalized = raw.architecture.toLowerCase();
         if (normalized === 'arm64' || normalized === 'aarch64') {
@@ -27,6 +29,10 @@ export function getArchitectureFromInfo(raw: InterpreterInfoJson): Architecture 
         if (normalized === 'x86' || normalized === 'i386' || normalized === 'i686') {
             return Architecture.x86;
         }
+    }
+    // Embedded interpreters omit bitness, so leave an unrecognized architecture unknown.
+    if (raw.is64Bit === undefined) {
+        return Architecture.Unknown;
     }
     // Fall back to is64Bit for backward compatibility
     return raw.is64Bit ? Architecture.x64 : Architecture.x86;

--- a/extensions/positron-python/src/client/positron/ipykernel.ts
+++ b/extensions/positron-python/src/client/positron/ipykernel.ts
@@ -11,6 +11,7 @@ import { IServiceContainer } from '../ioc/types';
 import { PythonEnvironment } from '../pythonEnvironments/info';
 import { IWorkspaceService } from '../common/application/types';
 import { IPythonExecutionFactory } from '../common/process/types';
+import { getArchitectureFromInfo } from '../common/process/internal/scripts/architecture';
 import { traceWarn } from '../logging';
 import { EXTENSION_ROOT_DIR } from '../constants';
 import { Architecture } from '../common/utils/platform';
@@ -45,11 +46,18 @@ export interface IpykernelBundle {
     /** If bundling is disabled, the reason for it. */
     disabledReason?: string;
 
-    /** Paths to be appended to the PYTHONPATH environment variable in this order, if bundling is enabled. */
+    /** Paths to be added to Python's import path in this order, if bundling is enabled. */
     paths?: string[];
 
     /** The detected interpreter architecture (freshly queried on ARM64 systems). */
     architecture?: Architecture;
+}
+
+/** Interpreter information supplied by a host embedding Python, such as reticulate. */
+export interface EmbeddedPythonInterpreter {
+    version: { major: number; minor: number };
+    implementation: string;
+    architecture: string;
 }
 
 /**
@@ -58,15 +66,16 @@ export interface IpykernelBundle {
  * @param interpreter The interpreter to check.
  * @param serviceContainer The service container to use for dependency injection.
  * @param resource The resource to scope setting to.
+ * @param embeddedInterpreter Information from the host process instead of a separately launched Python.
  */
 export async function getIpykernelBundle(
     interpreter: PythonEnvironment,
     serviceContainer: IServiceContainer,
     resource?: vscode.Uri,
+    embeddedInterpreter?: EmbeddedPythonInterpreter,
 ): Promise<IpykernelBundle> {
     // Get the required services.
     const workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
-    const pythonExecutionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
 
     // Check if bundling ipykernel is enabled for the resource.
     const useBundledIpykernel = workspaceService
@@ -78,8 +87,12 @@ export async function getIpykernelBundle(
 
     // Check if ipykernel is bundled for the interpreter version.
     // (defined in scripts/pip-compile-ipykernel.py).
-    if (interpreter.version?.major !== 3 || ![9, 10, 11, 12, 13, 14].includes(interpreter.version?.minor)) {
-        return { disabledReason: `unsupported interpreter version: ${interpreter.version?.raw}` };
+    const { version } = embeddedInterpreter ?? interpreter;
+    if (version?.major !== 3 || ![9, 10, 11, 12, 13, 14].includes(version?.minor)) {
+        const rawVersion = embeddedInterpreter
+            ? `${embeddedInterpreter.version.major}.${embeddedInterpreter.version.minor}`
+            : interpreter.version?.raw;
+        return { disabledReason: `unsupported interpreter version: ${rawVersion}` };
     }
 
     // Get fresh interpreter information if implementation or architecture is not available.
@@ -92,7 +105,17 @@ export async function getIpykernelBundle(
     let { implementation, architecture } = interpreter;
     const systemArch = os.arch();
     const architectureMismatchPossible = systemArch === 'arm64';
-    if (
+    if (embeddedInterpreter) {
+        // Embedded Python must use the host architecture. A separate launch of
+        // a universal2 executable can select a different architecture.
+        implementation = embeddedInterpreter.implementation;
+        architecture = getArchitectureFromInfo(embeddedInterpreter);
+        if (architecture !== Architecture.arm64 && architecture !== Architecture.x64) {
+            return {
+                disabledReason: `unsupported embedded interpreter architecture: ${embeddedInterpreter.architecture}`,
+            };
+        }
+    } else if (
         implementation === undefined ||
         architecture === undefined ||
         architecture === Architecture.Unknown ||
@@ -102,6 +125,7 @@ export async function getIpykernelBundle(
         // the interpreter runs correctly, so probe them through the activated
         // environment (which applies the module startup command); other
         // interpreters can be probed directly.
+        const pythonExecutionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
         const pythonExecutionService = moduleMetadataMap.has(interpreter.path)
             ? await pythonExecutionFactory.createActivatedEnvironment({
                   resource,
@@ -122,10 +146,9 @@ export async function getIpykernelBundle(
         return { disabledReason: `unsupported interpreter implementation: ${implementation}` };
     }
 
-    // Append the bundle paths (defined in gulpfile.js) to the PYTHONPATH environment variable.
-    // Use the interpreter's architecture, not the system architecture, to select the correct bundle.
+    // Select bundle paths (defined in gulpfile.js) for the interpreter's architecture.
     const arch = getArchString(architecture, interpreter.path);
-    const cpxSpecifier = `cp${interpreter.version.major}${interpreter.version.minor}`;
+    const cpxSpecifier = `cp${version.major}${version.minor}`;
 
     // On macOS, packages have different wheel availability:
     // - cpx packages (pyzmq): Only have universal2 wheels, stored in universal2/cpXX

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -20,7 +20,7 @@ import {
     getEnvLocationHeuristic,
     isVersionSupported,
 } from '../interpreter/configuration/environmentTypeComparer';
-import { getIpykernelBundle, IpykernelBundle } from './ipykernel';
+import { EmbeddedPythonInterpreter, getIpykernelBundle, IpykernelBundle } from './ipykernel';
 import {
     ModuleMetadata,
     moduleMetadataMap,
@@ -44,6 +44,8 @@ export interface PythonRuntimeExtraData {
     pythonPath: string;
     ipykernelBundle?: IpykernelBundle;
     externallyManaged?: boolean;
+    /** The interpreter already loaded in the host process. */
+    embeddedInterpreter?: EmbeddedPythonInterpreter;
     supported?: boolean;
     /** Module metadata for interpreters discovered via environment modules */
     moduleMetadata?: PythonModuleMetadata;

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -412,7 +412,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         // Use the bundled ipykernel if requested.
         const didUseBundledIpykernel = await this._addBundledIpykernelToPythonPath(interpreter, kernelSpec);
 
-        // If the bundled ipykernel was not used, proceed to install ipykernel for the interpreter.
+        // If the bundle was not used, check ipykernel in the selected environment.
         if (!didUseBundledIpykernel) {
             await this._installIpykernel(interpreter);
         }
@@ -422,14 +422,22 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         interpreter: PythonEnvironment,
         kernelSpec: JupyterKernelSpec,
     ): Promise<boolean> {
-        // Re-evaluate the ipykernel bundle paths for this interpreter at runtime.
-        // This ensures we use the correct paths based on the interpreter's actual architecture,
-        // rather than relying on potentially stale cached metadata (which may have been created
-        // with different bundle paths before an update).
-        const ipykernelBundle = await getIpykernelBundle(interpreter, this.serviceContainer);
+        const extraData = this.runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData;
+        // Select a fresh bundle for this launch. Older hosts cannot consume bundle paths.
+        const ipykernelBundle: IpykernelBundle =
+            kernelSpec.startKernel && !extraData.embeddedInterpreter
+                ? { disabledReason: 'The host does not support bundled ipykernel' }
+                : await getIpykernelBundle(
+                      interpreter,
+                      this.serviceContainer,
+                      undefined,
+                      extraData.embeddedInterpreter,
+                  );
 
         // Update the cached bundle for use by other methods (e.g., _isUninstallBundledPackageCommand)
         this._ipykernelBundle = ipykernelBundle;
+        // Persist the selection so restored sessions also recognize bundled packages.
+        extraData.ipykernelBundle = ipykernelBundle;
 
         if (ipykernelBundle.disabledReason || !ipykernelBundle.paths) {
             traceInfo(`Not using bundled ipykernel. Reason: ${ipykernelBundle.disabledReason}`);

--- a/extensions/positron-python/src/test/positron/ipykernel.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/ipykernel.unit.test.ts
@@ -27,8 +27,10 @@ suite('Ipykernel', () => {
     let pythonExecutionFactory: IPythonExecutionFactory;
     let workspaceConfiguration: vscode.WorkspaceConfiguration;
     let serviceContainer: IServiceContainer;
+    let pathExists: sinon.SinonStub;
 
     setup(() => {
+        pathExists = sinon.stub(fs, 'pathExists').resolves(true);
         // Default to x64 architecture and cpython implementation for tests
         interpreter = mock<PythonEnvironment>({
             id: 'pythonEnvironmentId',
@@ -102,8 +104,6 @@ suite('Ipykernel', () => {
     test('should use interpreter architecture for arm64 interpreter', async () => {
         // Set interpreter to arm64 architecture
         sinon.stub(interpreter, 'architecture').get(() => Architecture.arm64);
-        // Stub fs.pathExists to return true so tests pass on CI where arm64 bundles may not exist
-        sinon.stub(fs, 'pathExists').resolves(true);
 
         const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
 
@@ -130,8 +130,6 @@ suite('Ipykernel', () => {
                 architecture: Architecture.arm64,
             }),
         );
-        // Stub fs.pathExists to return true so tests pass on CI where arm64 bundles may not exist
-        sinon.stub(fs, 'pathExists').resolves(true);
 
         const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
 
@@ -151,7 +149,6 @@ suite('Ipykernel', () => {
     test('should probe module interpreters through the activated environment', async () => {
         // Force the fresh interpreter-info probe to run.
         sinon.stub(interpreter, 'architecture').get(() => Architecture.Unknown);
-        sinon.stub(fs, 'pathExists').resolves(true);
         moduleMetadataMap.set(interpreter.path, {
             type: 'module',
             environmentName: 'python/3.9',
@@ -239,7 +236,7 @@ suite('Ipykernel', () => {
 
     test('should not bundle ipykernel if bundle path does not exist', async () => {
         // Simulate the bundle paths not existing.
-        sinon.stub(fs, 'pathExists').resolves(false);
+        pathExists.resolves(false);
 
         const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
 

--- a/extensions/positron-python/src/test/positron/ipykernel.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/ipykernel.unit.test.ts
@@ -27,10 +27,8 @@ suite('Ipykernel', () => {
     let pythonExecutionFactory: IPythonExecutionFactory;
     let workspaceConfiguration: vscode.WorkspaceConfiguration;
     let serviceContainer: IServiceContainer;
-    let pathExists: sinon.SinonStub;
 
     setup(() => {
-        pathExists = sinon.stub(fs, 'pathExists').resolves(true);
         // Default to x64 architecture and cpython implementation for tests
         interpreter = mock<PythonEnvironment>({
             id: 'pythonEnvironmentId',
@@ -104,6 +102,8 @@ suite('Ipykernel', () => {
     test('should use interpreter architecture for arm64 interpreter', async () => {
         // Set interpreter to arm64 architecture
         sinon.stub(interpreter, 'architecture').get(() => Architecture.arm64);
+        // Stub fs.pathExists to return true so tests pass on CI where arm64 bundles may not exist
+        sinon.stub(fs, 'pathExists').resolves(true);
 
         const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
 
@@ -130,6 +130,8 @@ suite('Ipykernel', () => {
                 architecture: Architecture.arm64,
             }),
         );
+        // Stub fs.pathExists to return true so tests pass on CI where arm64 bundles may not exist
+        sinon.stub(fs, 'pathExists').resolves(true);
 
         const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
 
@@ -149,6 +151,7 @@ suite('Ipykernel', () => {
     test('should probe module interpreters through the activated environment', async () => {
         // Force the fresh interpreter-info probe to run.
         sinon.stub(interpreter, 'architecture').get(() => Architecture.Unknown);
+        sinon.stub(fs, 'pathExists').resolves(true);
         moduleMetadataMap.set(interpreter.path, {
             type: 'module',
             environmentName: 'python/3.9',
@@ -236,7 +239,7 @@ suite('Ipykernel', () => {
 
     test('should not bundle ipykernel if bundle path does not exist', async () => {
         // Simulate the bundle paths not existing.
-        pathExists.resolves(false);
+        sinon.stub(fs, 'pathExists').resolves(false);
 
         const ipykernelBundle = await getIpykernelBundle(interpreter, serviceContainer);
 

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -11,7 +11,6 @@ import { interfaces } from 'inversify';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import * as sinon from 'sinon';
-import { anything, reset, when } from 'ts-mockito';
 import * as vscode from 'vscode';
 import * as fs from '../../client/common/platform/fs-paths';
 import { ILanguageServerOutputChannel } from '../../client/activation/types';
@@ -27,7 +26,6 @@ import {
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../client/common/process/types';
 import { InterpreterInformation } from '../../client/pythonEnvironments/info';
 import { Architecture } from '../../client/common/utils/platform';
-import { createDeferred } from '../../client/common/utils/async';
 import { IEnvironmentVariablesProvider, IEnvironmentVariablesService } from '../../client/common/variables/types';
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
@@ -35,16 +33,12 @@ import {
     PositronSupervisorApi,
     JupyterKernelSpec,
     JupyterLanguageRuntimeSession,
-    JupyterSession,
-    JupyterKernel,
 } from '../../client/positron-supervisor.d';
 import { PythonRuntimeSession } from '../../client/positron/session';
 import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 import { PythonVersion } from '../../client/pythonEnvironments/info/pythonVersion';
 import { mock } from './utils';
 import { IpykernelBundle } from '../../client/positron/ipykernel';
-import { MockMemento } from '../mocks/mementos';
-import { mockedPositronNamespaces, mockedVSCodeNamespaces } from '../vscode-mock';
 
 suite('Python Runtime Session', () => {
     let disposables: vscode.Disposable[];
@@ -58,12 +52,9 @@ suite('Python Runtime Session', () => {
     let kernelSpec: JupyterKernelSpec;
     let kernel: JupyterLanguageRuntimeSession;
     let pathExistsStub: sinon.SinonStub;
-    let executionFactorySpy: sinon.SinonSpiedInstance<IPythonExecutionFactory>;
-    let useBundledIpykernel: boolean;
 
     setup(() => {
         disposables = [];
-        useBundledIpykernel = true;
 
         applicationShell = mock<IApplicationShell>({
             showErrorMessage: () => Promise.resolve(undefined),
@@ -97,7 +88,7 @@ suite('Python Runtime Session', () => {
 
         // Mock workspace configuration for getIpykernelBundle
         const workspaceConfiguration = mock<vscode.WorkspaceConfiguration>({
-            get: (section: string) => (section === 'useBundledIpykernel' ? useBundledIpykernel : undefined),
+            get: (section: string) => (section === 'useBundledIpykernel' ? true : undefined),
         });
         const workspaceService = mock<IWorkspaceService>({
             workspaceFolders: undefined,
@@ -119,7 +110,6 @@ suite('Python Runtime Session', () => {
         const pythonExecutionFactory = mock<IPythonExecutionFactory>({
             create: () => Promise.resolve(pythonExecutionService),
         });
-        executionFactorySpy = sinon.spy(pythonExecutionFactory);
 
         const pythonSettings = mock<IPythonSettings>({
             autoComplete: { extraPaths: [] },
@@ -180,7 +170,6 @@ suite('Python Runtime Session', () => {
 
         const adapterApi = mock<PositronSupervisorApi>({
             createSession: sinon.stub().resolves(kernel),
-            restoreSession: sinon.stub().resolves(kernel),
         });
 
         sinon.stub(vscode.extensions, 'getExtension').callsFake((extensionId) => {
@@ -286,194 +275,25 @@ suite('Python Runtime Session', () => {
         sinon.assert.calledOnce(installerSpy.isProductVersionCompatible);
     });
 
-    for (const { enabled, minor, architecture, expectedArchitecture } of [
-        { enabled: true, minor: 14, architecture: 'arm64', expectedArchitecture: Architecture.arm64 },
-        { enabled: true, minor: 12, architecture: 'x64', expectedArchitecture: Architecture.x64 },
-        { enabled: false, minor: 14, architecture: 'arm64', expectedArchitecture: undefined },
-        { enabled: true, minor: 15, architecture: 'arm64', expectedArchitecture: undefined },
-        { enabled: true, minor: 14, architecture: 'i686', expectedArchitecture: undefined },
-    ]) {
-        test(`Start: embedded Python 3.${minor} ${architecture}, bundle enabled=${enabled}`, async () => {
-            useBundledIpykernel = enabled;
-            kernelSpec.startKernel = async () => {};
-            const session = createSession(positron.LanguageRuntimeSessionMode.Console);
-            session.runtimeMetadata.extraRuntimeData.embeddedInterpreter = {
-                version: { major: 3, minor },
-                implementation: 'cpython',
-                architecture,
-            };
-            await session.start();
+    test('Start: selects the bundle for Python embedded in a host', async () => {
+        kernelSpec.startKernel = async () => {};
+        const executionFactory = sinon.spy(serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory));
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console);
+        session.runtimeMetadata.extraRuntimeData.embeddedInterpreter = {
+            version: { major: 3, minor: 14 },
+            implementation: 'cpython',
+            architecture: 'arm64',
+        };
+        await session.start();
 
-            const bundle = session.runtimeMetadata.extraRuntimeData.ipykernelBundle;
-            const bundled = expectedArchitecture !== undefined;
-            assert.deepStrictEqual(
-                {
-                    architecture: bundle.architecture,
-                    version: bundle.paths && path.basename(bundle.paths[0]),
-                    appendedPaths: envVarsServiceSpy.appendPythonPath.callCount,
-                    checkedProjectKernel: installerSpy.isProductVersionCompatible.callCount,
-                },
-                {
-                    architecture: expectedArchitecture,
-                    version: bundled ? `cp3${minor}` : undefined,
-                    appendedPaths: bundled ? 3 : 0,
-                    checkedProjectKernel: bundled ? 0 : 1,
-                },
-            );
-            sinon.assert.notCalled(installerSpy.promptToInstall);
-            sinon.assert.notCalled(executionFactorySpy.create);
-        });
-    }
-
-    suite('Reticulate runtime manager', () => {
-        teardown(() => {
-            reset(mockedVSCodeNamespaces.window);
-            reset(mockedVSCodeNamespaces.workspace);
-            reset(mockedPositronNamespaces.window);
-        });
-
-        test('forwards bundle paths and refreshes interpreter metadata on restart', async () => {
-            const rState = new vscode.EventEmitter<positron.RuntimeState>();
-            const pythonState = new vscode.EventEmitter<positron.RuntimeState>();
-            const pythonExit = new vscode.EventEmitter<positron.LanguageRuntimeExit>();
-            disposables.push(rState, pythonState, pythonExit);
-            const firstInterpreter = {
-                version: { major: 3, minor: 14 },
-                implementation: 'cpython',
-                architecture: 'arm64',
-            };
-            const nextInterpreter = {
-                version: { major: 3, minor: 12 },
-                implementation: 'cpython',
-                architecture: 'x86_64',
-            };
-            const callMethod = sinon.stub();
-            callMethod.withArgs('reticulate_id').resolves('reticulate-id');
-            callMethod.withArgs('is_installed').resolves(true);
-            callMethod
-                .withArgs('reticulate_check_prerequisites')
-                .onFirstCall()
-                .resolves({
-                    python: '/project/python',
-                    venv: '/project',
-                    embeddedInterpreter: firstInterpreter,
-                })
-                .onSecondCall()
-                .resolves({
-                    python: '/other/python',
-                    venv: '/other',
-                    embeddedInterpreter: nextInterpreter,
-                });
-            callMethod.withArgs('reticulate_start_kernel').resolves('');
-            const rSession = mock<positron.LanguageRuntimeSession>({
-                runtimeMetadata: mock<positron.LanguageRuntimeMetadata>({ languageId: 'r' }),
-                metadata: mock<positron.RuntimeSessionMetadata>({ sessionId: 'r-session' }),
-                callMethod,
-                onDidChangeRuntimeState: rState.event,
-                restart: async () => {
-                    rState.fire(positron.RuntimeState.Ready);
-                },
-            });
-            const registration = { dispose() {} };
-            sinon
-                .stub(require('positron'), 'runtime')
-                .value(Object.assign(Object.create(positron.runtime), { getActiveSessions: async () => [rSession] }));
-            when(mockedVSCodeNamespaces.workspace!.onDidChangeConfiguration(anything())).thenReturn(registration);
-            when(mockedVSCodeNamespaces.window!.createOutputChannel(anything(), anything())).thenReturn(
-                mock<vscode.LogOutputChannel>({ info() {} }),
-            );
-            when(mockedVSCodeNamespaces.window!.withProgress(anything(), anything())).thenCall((_options, task) =>
-                task({ report() {} }, {}),
-            );
-            const prompts = mockedPositronNamespaces.window!;
-            when(prompts.showSimpleModalDialogPrompt(anything(), anything(), anything(), anything())).thenReturn(
-                Promise.resolve(true),
-            );
-
-            const connection = mock<JupyterSession>({
-                state: { connectionFile: '/connection.json', logFile: '/kernel.log' } as JupyterSession['state'],
-            });
-            const connect = sinon.stub().resolves();
-            const jupyterKernel = mock<JupyterKernel>({ log() {}, connectToSession: connect });
-            let bundlePaths = ['/bundle/cp314', '/bundle/arm64/cp3', '/bundle/py3'];
-            let started = createDeferred();
-            const createPythonSession = sinon.spy(
-                (
-                    runtimeMetadata: positron.LanguageRuntimeMetadata,
-                    metadata: positron.RuntimeSessionMetadata,
-                    spec: JupyterKernelSpec,
-                ) =>
-                    mock<positron.LanguageRuntimeSession>({
-                        runtimeMetadata,
-                        metadata,
-                        onDidChangeRuntimeState: pythonState.event,
-                        onDidReceiveRuntimeMessage: () => registration,
-                        onDidEndSession: pythonExit.event,
-                        onDidUpdateResourceUsage: () => registration,
-                        start: async () => {
-                            runtimeMetadata.extraRuntimeData.ipykernelBundle = { paths: bundlePaths };
-                            await spec.startKernel!(connection, jupyterKernel);
-                            pythonState.fire(positron.RuntimeState.Ready);
-                            started.resolve();
-                            return mock<positron.LanguageRuntimeInfo>({});
-                        },
-                        shutdown: async () => {
-                            pythonExit.fire(mock<positron.LanguageRuntimeExit>({}));
-                        },
-                    }),
-            );
-            (vscode.extensions.getExtension as sinon.SinonStub).withArgs('ms-python.python').returns({
-                isActive: true,
-                exports: { positron: { createPythonRuntimeSession: createPythonSession } },
-            });
-            // The reticulate extension is outside the Python extension's compilation tree.
-            require('ts-node').register({
-                project: path.join(__dirname, '../../../../positron-reticulate/tsconfig.json'),
-                transpileOnly: true,
-                scope: true,
-            });
-            const { ReticulateRuntimeManager } = require('../../../../positron-reticulate/src/extension');
-            const manager: positron.LanguageRuntimeManager = new ReticulateRuntimeManager(
-                mock<vscode.ExtensionContext>({
-                    subscriptions: disposables,
-                    workspaceState: new MockMemento(),
-                }),
-            );
-            const session: positron.LanguageRuntimeSession = await manager.createSession(
-                mock<positron.LanguageRuntimeMetadata>({
-                    extraRuntimeData: { ipykernelBundle: {}, externallyManaged: true },
-                }),
-                mock<positron.RuntimeSessionMetadata>({ sessionId: 'python-session' }),
-            );
-            await session.start();
-            const firstPaths = bundlePaths;
-            bundlePaths = [];
-            started = createDeferred();
-            await session.restart(undefined);
-            await started.promise;
-
-            assert.deepStrictEqual(
-                createPythonSession.args.map(([metadata]) => [
-                    metadata.runtimePath,
-                    metadata.extraRuntimeData.pythonPath,
-                    metadata.extraRuntimeData.embeddedInterpreter,
-                ]),
-                [
-                    ['/project/python', '/project/python', firstInterpreter],
-                    ['/other/python', '/other/python', nextInterpreter],
-                ],
-            );
-            assert.deepStrictEqual(
-                callMethod
-                    .withArgs('reticulate_start_kernel')
-                    .args.map((args) => [path.basename(args[1]), ...args.slice(2)]),
-                [
-                    ['positron_language_server.py', '/connection.json', '/kernel.log', 'debug', firstPaths],
-                    ['positron_language_server.py', '/connection.json', '/kernel.log', 'debug'],
-                ],
-            );
-            sinon.assert.calledTwice(connect);
-        });
+        const bundle = session.runtimeMetadata.extraRuntimeData.ipykernelBundle;
+        assert.deepStrictEqual(
+            { architecture: bundle.architecture, version: path.basename(bundle.paths[0]) },
+            { architecture: Architecture.arm64, version: 'cp314' },
+        );
+        sinon.assert.callCount(envVarsServiceSpy.appendPythonPath, 3);
+        sinon.assert.notCalled(installerSpy.isProductVersionCompatible);
+        sinon.assert.notCalled(executionFactory.create);
     });
 
     test('Start: retries interpreter resolution after a refresh when the first resolve fails', async () => {
@@ -531,24 +351,6 @@ suite('Python Runtime Session', () => {
         assert.strictEqual(messages[1].type, positron.LanguageRuntimeMessageType.State);
         const state = messages[1] as positron.LanguageRuntimeState;
         assert.strictEqual(state.state, positron.RuntimeOnlineState.Idle);
-    });
-
-    test('Restore: keeps bundled packages protected from uninstall commands', async () => {
-        sinon.stub(fs, 'readdirSync').returns(['ipykernel']);
-        const original = createSession(positron.LanguageRuntimeSessionMode.Console);
-        await original.start();
-
-        const savedMetadata = JSON.parse(JSON.stringify(original.runtimeMetadata));
-        const restored = new PythonRuntimeSession(savedMetadata, original.metadata, serviceContainer);
-        await restored.start();
-        const execute = sinon.spy(kernel, 'execute');
-        restored.execute(
-            'pip uninstall ipykernel',
-            'uninstall-after-restore',
-            positron.RuntimeCodeExecutionMode.Interactive,
-            positron.RuntimeErrorBehavior.Stop,
-        );
-        sinon.assert.notCalled(execute);
     });
 
     test('Execute: propagates the kernel execute promise (e.g. incomplete code)', async () => {

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -6,10 +6,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import * as path from 'path';
 import { interfaces } from 'inversify';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import * as sinon from 'sinon';
+import { anything, reset, when } from 'ts-mockito';
 import * as vscode from 'vscode';
 import * as fs from '../../client/common/platform/fs-paths';
 import { ILanguageServerOutputChannel } from '../../client/activation/types';
@@ -25,6 +27,7 @@ import {
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../client/common/process/types';
 import { InterpreterInformation } from '../../client/pythonEnvironments/info';
 import { Architecture } from '../../client/common/utils/platform';
+import { createDeferred } from '../../client/common/utils/async';
 import { IEnvironmentVariablesProvider, IEnvironmentVariablesService } from '../../client/common/variables/types';
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
@@ -32,12 +35,16 @@ import {
     PositronSupervisorApi,
     JupyterKernelSpec,
     JupyterLanguageRuntimeSession,
+    JupyterSession,
+    JupyterKernel,
 } from '../../client/positron-supervisor.d';
 import { PythonRuntimeSession } from '../../client/positron/session';
 import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 import { PythonVersion } from '../../client/pythonEnvironments/info/pythonVersion';
 import { mock } from './utils';
 import { IpykernelBundle } from '../../client/positron/ipykernel';
+import { MockMemento } from '../mocks/mementos';
+import { mockedPositronNamespaces, mockedVSCodeNamespaces } from '../vscode-mock';
 
 suite('Python Runtime Session', () => {
     let disposables: vscode.Disposable[];
@@ -51,9 +58,12 @@ suite('Python Runtime Session', () => {
     let kernelSpec: JupyterKernelSpec;
     let kernel: JupyterLanguageRuntimeSession;
     let pathExistsStub: sinon.SinonStub;
+    let executionFactorySpy: sinon.SinonSpiedInstance<IPythonExecutionFactory>;
+    let useBundledIpykernel: boolean;
 
     setup(() => {
         disposables = [];
+        useBundledIpykernel = true;
 
         applicationShell = mock<IApplicationShell>({
             showErrorMessage: () => Promise.resolve(undefined),
@@ -87,7 +97,7 @@ suite('Python Runtime Session', () => {
 
         // Mock workspace configuration for getIpykernelBundle
         const workspaceConfiguration = mock<vscode.WorkspaceConfiguration>({
-            get: (section: string) => (section === 'useBundledIpykernel' ? true : undefined),
+            get: (section: string) => (section === 'useBundledIpykernel' ? useBundledIpykernel : undefined),
         });
         const workspaceService = mock<IWorkspaceService>({
             workspaceFolders: undefined,
@@ -109,6 +119,7 @@ suite('Python Runtime Session', () => {
         const pythonExecutionFactory = mock<IPythonExecutionFactory>({
             create: () => Promise.resolve(pythonExecutionService),
         });
+        executionFactorySpy = sinon.spy(pythonExecutionFactory);
 
         const pythonSettings = mock<IPythonSettings>({
             autoComplete: { extraPaths: [] },
@@ -169,6 +180,7 @@ suite('Python Runtime Session', () => {
 
         const adapterApi = mock<PositronSupervisorApi>({
             createSession: sinon.stub().resolves(kernel),
+            restoreSession: sinon.stub().resolves(kernel),
         });
 
         sinon.stub(vscode.extensions, 'getExtension').callsFake((extensionId) => {
@@ -265,6 +277,205 @@ suite('Python Runtime Session', () => {
         sinon.assert.called(installerSpy.isProductVersionCompatible);
     });
 
+    test('Start: custom launchers without embedded interpreter information use the project kernel', async () => {
+        kernelSpec.startKernel = async () => {};
+        const session = createSession(positron.LanguageRuntimeSessionMode.Console, { paths: ['/previous/bundle'] });
+        await session.start();
+        assert.strictEqual(session.runtimeMetadata.extraRuntimeData.ipykernelBundle.paths, undefined);
+        sinon.assert.notCalled(envVarsServiceSpy.appendPythonPath);
+        sinon.assert.calledOnce(installerSpy.isProductVersionCompatible);
+    });
+
+    for (const { enabled, minor, architecture, expectedArchitecture } of [
+        { enabled: true, minor: 14, architecture: 'arm64', expectedArchitecture: Architecture.arm64 },
+        { enabled: true, minor: 12, architecture: 'x64', expectedArchitecture: Architecture.x64 },
+        { enabled: false, minor: 14, architecture: 'arm64', expectedArchitecture: undefined },
+        { enabled: true, minor: 15, architecture: 'arm64', expectedArchitecture: undefined },
+        { enabled: true, minor: 14, architecture: 'i686', expectedArchitecture: undefined },
+    ]) {
+        test(`Start: embedded Python 3.${minor} ${architecture}, bundle enabled=${enabled}`, async () => {
+            useBundledIpykernel = enabled;
+            kernelSpec.startKernel = async () => {};
+            const session = createSession(positron.LanguageRuntimeSessionMode.Console);
+            session.runtimeMetadata.extraRuntimeData.embeddedInterpreter = {
+                version: { major: 3, minor },
+                implementation: 'cpython',
+                architecture,
+            };
+            await session.start();
+
+            const bundle = session.runtimeMetadata.extraRuntimeData.ipykernelBundle;
+            const bundled = expectedArchitecture !== undefined;
+            assert.deepStrictEqual(
+                {
+                    architecture: bundle.architecture,
+                    version: bundle.paths && path.basename(bundle.paths[0]),
+                    appendedPaths: envVarsServiceSpy.appendPythonPath.callCount,
+                    checkedProjectKernel: installerSpy.isProductVersionCompatible.callCount,
+                },
+                {
+                    architecture: expectedArchitecture,
+                    version: bundled ? `cp3${minor}` : undefined,
+                    appendedPaths: bundled ? 3 : 0,
+                    checkedProjectKernel: bundled ? 0 : 1,
+                },
+            );
+            sinon.assert.notCalled(installerSpy.promptToInstall);
+            sinon.assert.notCalled(executionFactorySpy.create);
+        });
+    }
+
+    suite('Reticulate runtime manager', () => {
+        teardown(() => {
+            reset(mockedVSCodeNamespaces.window);
+            reset(mockedVSCodeNamespaces.workspace);
+            reset(mockedPositronNamespaces.window);
+        });
+
+        test('forwards bundle paths and refreshes interpreter metadata on restart', async () => {
+            const rState = new vscode.EventEmitter<positron.RuntimeState>();
+            const pythonState = new vscode.EventEmitter<positron.RuntimeState>();
+            const pythonExit = new vscode.EventEmitter<positron.LanguageRuntimeExit>();
+            disposables.push(rState, pythonState, pythonExit);
+            const firstInterpreter = {
+                version: { major: 3, minor: 14 },
+                implementation: 'cpython',
+                architecture: 'arm64',
+            };
+            const nextInterpreter = {
+                version: { major: 3, minor: 12 },
+                implementation: 'cpython',
+                architecture: 'x86_64',
+            };
+            const callMethod = sinon.stub();
+            callMethod.withArgs('reticulate_id').resolves('reticulate-id');
+            callMethod.withArgs('is_installed').resolves(true);
+            callMethod
+                .withArgs('reticulate_check_prerequisites')
+                .onFirstCall()
+                .resolves({
+                    python: '/project/python',
+                    venv: '/project',
+                    embeddedInterpreter: firstInterpreter,
+                })
+                .onSecondCall()
+                .resolves({
+                    python: '/other/python',
+                    venv: '/other',
+                    embeddedInterpreter: nextInterpreter,
+                });
+            callMethod.withArgs('reticulate_start_kernel').resolves('');
+            const rSession = mock<positron.LanguageRuntimeSession>({
+                runtimeMetadata: mock<positron.LanguageRuntimeMetadata>({ languageId: 'r' }),
+                metadata: mock<positron.RuntimeSessionMetadata>({ sessionId: 'r-session' }),
+                callMethod,
+                onDidChangeRuntimeState: rState.event,
+                restart: async () => {
+                    rState.fire(positron.RuntimeState.Ready);
+                },
+            });
+            const registration = { dispose() {} };
+            sinon
+                .stub(require('positron'), 'runtime')
+                .value(Object.assign(Object.create(positron.runtime), { getActiveSessions: async () => [rSession] }));
+            when(mockedVSCodeNamespaces.workspace!.onDidChangeConfiguration(anything())).thenReturn(registration);
+            when(mockedVSCodeNamespaces.window!.createOutputChannel(anything(), anything())).thenReturn(
+                mock<vscode.LogOutputChannel>({ info() {} }),
+            );
+            when(mockedVSCodeNamespaces.window!.withProgress(anything(), anything())).thenCall((_options, task) =>
+                task({ report() {} }, {}),
+            );
+            const prompts = mockedPositronNamespaces.window!;
+            when(prompts.showSimpleModalDialogPrompt(anything(), anything(), anything(), anything())).thenReturn(
+                Promise.resolve(true),
+            );
+
+            const connection = mock<JupyterSession>({
+                state: { connectionFile: '/connection.json', logFile: '/kernel.log' } as JupyterSession['state'],
+            });
+            const connect = sinon.stub().resolves();
+            const jupyterKernel = mock<JupyterKernel>({ log() {}, connectToSession: connect });
+            let bundlePaths = ['/bundle/cp314', '/bundle/arm64/cp3', '/bundle/py3'];
+            let started = createDeferred();
+            const createPythonSession = sinon.spy(
+                (
+                    runtimeMetadata: positron.LanguageRuntimeMetadata,
+                    metadata: positron.RuntimeSessionMetadata,
+                    spec: JupyterKernelSpec,
+                ) =>
+                    mock<positron.LanguageRuntimeSession>({
+                        runtimeMetadata,
+                        metadata,
+                        onDidChangeRuntimeState: pythonState.event,
+                        onDidReceiveRuntimeMessage: () => registration,
+                        onDidEndSession: pythonExit.event,
+                        onDidUpdateResourceUsage: () => registration,
+                        start: async () => {
+                            runtimeMetadata.extraRuntimeData.ipykernelBundle = { paths: bundlePaths };
+                            await spec.startKernel!(connection, jupyterKernel);
+                            pythonState.fire(positron.RuntimeState.Ready);
+                            started.resolve();
+                            return mock<positron.LanguageRuntimeInfo>({});
+                        },
+                        shutdown: async () => {
+                            pythonExit.fire(mock<positron.LanguageRuntimeExit>({}));
+                        },
+                    }),
+            );
+            (vscode.extensions.getExtension as sinon.SinonStub).withArgs('ms-python.python').returns({
+                isActive: true,
+                exports: { positron: { createPythonRuntimeSession: createPythonSession } },
+            });
+            // The reticulate extension is outside the Python extension's compilation tree.
+            require('ts-node').register({
+                project: path.join(__dirname, '../../../../positron-reticulate/tsconfig.json'),
+                transpileOnly: true,
+                scope: true,
+            });
+            const { ReticulateRuntimeManager } = require('../../../../positron-reticulate/src/extension');
+            const manager: positron.LanguageRuntimeManager = new ReticulateRuntimeManager(
+                mock<vscode.ExtensionContext>({
+                    subscriptions: disposables,
+                    workspaceState: new MockMemento(),
+                }),
+            );
+            const session: positron.LanguageRuntimeSession = await manager.createSession(
+                mock<positron.LanguageRuntimeMetadata>({
+                    extraRuntimeData: { ipykernelBundle: {}, externallyManaged: true },
+                }),
+                mock<positron.RuntimeSessionMetadata>({ sessionId: 'python-session' }),
+            );
+            await session.start();
+            const firstPaths = bundlePaths;
+            bundlePaths = [];
+            started = createDeferred();
+            await session.restart(undefined);
+            await started.promise;
+
+            assert.deepStrictEqual(
+                createPythonSession.args.map(([metadata]) => [
+                    metadata.runtimePath,
+                    metadata.extraRuntimeData.pythonPath,
+                    metadata.extraRuntimeData.embeddedInterpreter,
+                ]),
+                [
+                    ['/project/python', '/project/python', firstInterpreter],
+                    ['/other/python', '/other/python', nextInterpreter],
+                ],
+            );
+            assert.deepStrictEqual(
+                callMethod
+                    .withArgs('reticulate_start_kernel')
+                    .args.map((args) => [path.basename(args[1]), ...args.slice(2)]),
+                [
+                    ['positron_language_server.py', '/connection.json', '/kernel.log', 'debug', firstPaths],
+                    ['positron_language_server.py', '/connection.json', '/kernel.log', 'debug'],
+                ],
+            );
+            sinon.assert.calledTwice(connect);
+        });
+    });
+
     test('Start: retries interpreter resolution after a refresh when the first resolve fails', async () => {
         const getDetails = sinon.stub(interpreterService, 'getInterpreterDetails');
         getDetails.onFirstCall().resolves(undefined);
@@ -320,6 +531,24 @@ suite('Python Runtime Session', () => {
         assert.strictEqual(messages[1].type, positron.LanguageRuntimeMessageType.State);
         const state = messages[1] as positron.LanguageRuntimeState;
         assert.strictEqual(state.state, positron.RuntimeOnlineState.Idle);
+    });
+
+    test('Restore: keeps bundled packages protected from uninstall commands', async () => {
+        sinon.stub(fs, 'readdirSync').returns(['ipykernel']);
+        const original = createSession(positron.LanguageRuntimeSessionMode.Console);
+        await original.start();
+
+        const savedMetadata = JSON.parse(JSON.stringify(original.runtimeMetadata));
+        const restored = new PythonRuntimeSession(savedMetadata, original.metadata, serviceContainer);
+        await restored.start();
+        const execute = sinon.spy(kernel, 'execute');
+        restored.execute(
+            'pip uninstall ipykernel',
+            'uninstall-after-restore',
+            positron.RuntimeCodeExecutionMode.Interactive,
+            positron.RuntimeErrorBehavior.Stop,
+        );
+        sinon.assert.notCalled(execute);
     });
 
     test('Execute: propagates the kernel execute promise (e.g. incomplete code)', async () => {

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -66,7 +66,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 
 		switch (option) {
 			case 'auto':
-				const val = CONTEXT.workspaceState.get(autoEnabledStorageKey, false);
+				const val = this._context.workspaceState.get(autoEnabledStorageKey, false);
 				return val;
 			case 'never':
 				return false;
@@ -220,12 +220,12 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 
 	setSessions(hostRSessionId: string, reticulateId: string, session: positron.LanguageRuntimeSession) {
 		let sessionsMap: ReticulateSessionInfo[] =
-			CONTEXT.workspaceState.get('reticulate-sessions-map', []);
+			this._context.workspaceState.get('reticulate-sessions-map', []);
 
 		session.onDidEndSession(() => {
 			// Remove the session from the map when it ends.
 			sessionsMap = sessionsMap.filter((pair) => pair.reticulateSessionId !== session.metadata.sessionId);
-			CONTEXT.workspaceState.update('reticulate-sessions-map', sessionsMap);
+			this._context.workspaceState.update('reticulate-sessions-map', sessionsMap);
 			this._sessions.delete(session.metadata.sessionId);
 		});
 
@@ -241,11 +241,11 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 		}
 
 		this._sessions.set(session.metadata.sessionId, session);
-		CONTEXT.workspaceState.update('reticulate-sessions-map', sessionsMap);
+		this._context.workspaceState.update('reticulate-sessions-map', sessionsMap);
 	}
 
 	getSessions(): Array<ReticulateSessionInfo> {
-		const sessionsMap = CONTEXT.workspaceState.get('reticulate-sessions-map', []);
+		const sessionsMap = this._context.workspaceState.get('reticulate-sessions-map', []);
 		return sessionsMap as Array<ReticulateSessionInfo>;
 	}
 
@@ -356,7 +356,11 @@ enum ReticulateRuntimeSessionType {
 class ReticulateConfig {
 	python?: string;
 	venv?: string;
-	ipykernel?: boolean;
+	embeddedInterpreter?: {
+		version: { major: number; minor: number };
+		implementation: string;
+		architecture: string;
+	};
 	error?: string;
 }
 
@@ -428,7 +432,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 			config.finally(() => clearTimeout(timeout));
 		}
 
-		const metadata = await ReticulateRuntimeSession.fixInterpreterPath(runtimeMetadata, (await config).python);
+		const metadata = ReticulateRuntimeSession.applyConfig(runtimeMetadata, await config);
 
 		// Create the session itself.
 		const session = new ReticulateRuntimeSession(
@@ -451,7 +455,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		// Make sure the R session has the necessary packages installed.
 		progress.report({ increment: 10, message: vscode.l10n.t('Checking prerequisites') });
 		const config = await ReticulateRuntimeSession.checkRSession(rSession);
-		const metadata = await ReticulateRuntimeSession.fixInterpreterPath(runtimeMetadata, config.python);
+		const metadata = ReticulateRuntimeSession.applyConfig(runtimeMetadata, config);
 
 		// Create the session itself.
 		const session = new ReticulateRuntimeSession(
@@ -465,7 +469,7 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 		return session;
 	}
 
-	static async checkRSession(rSession: positron.LanguageRuntimeSession): Promise<{ python: string }> {
+	static async checkRSession(rSession: positron.LanguageRuntimeSession): Promise<ReticulateConfig & { python: string }> {
 		// Check that we have a minimum version of reticulate.
 		if (!await rSession.callMethod?.('is_installed', 'reticulate', '1.39')) {
 			// Offer to install reticulate
@@ -579,19 +583,23 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 			informCreateVirtualEenv();
 		}
 
-		return { python: config.python };
+		return { ...config, python: config.python };
 	}
 
-	static async fixInterpreterPath(
+	static applyConfig(
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
-		interpreterPath: string
-	): Promise<positron.LanguageRuntimeMetadata> {
+		config: ReticulateConfig & { python: string }
+	): positron.LanguageRuntimeMetadata {
 
-		const output = runtimeMetadata;
-		output.runtimePath = interpreterPath;
-		output.extraRuntimeData.pythonPath = interpreterPath;
-
-		return output;
+		return {
+			...runtimeMetadata,
+			runtimePath: config.python,
+			extraRuntimeData: {
+				...runtimeMetadata.extraRuntimeData,
+				pythonPath: config.python,
+				embeddedInterpreter: config.embeddedInterpreter,
+			},
+		};
 	}
 
 	/** An object that emits language runtime events */
@@ -733,12 +741,15 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 			throw new Error(vscode.l10n.t('No `callMethod` method in the RSession. This is not expected.'));
 		}
 
+		const pythonPath: string[] = this.runtimeMetadata.extraRuntimeData.ipykernelBundle.paths ?? [];
 		const init_err = await this.rSession.callMethod(
 			'reticulate_start_kernel',
 			kernelPath as string,
 			connnectionFile as string,
 			logFile as string,
-			logLevel as string
+			logLevel as string,
+			// Keep the original RPC signature when no bundle is used, including with older hosts.
+			...(pythonPath.length ? [pythonPath] : [])
 		) as string;
 
 		// An empty result means that the initialization went fine.
@@ -879,8 +890,10 @@ class ReticulateRuntimeSession implements positron.LanguageRuntimeSession {
 					const metadata: positron.RuntimeSessionMetadata = { ...this.sessionMetadata, sessionId: `reticulate-python-${randomId}` };
 
 					// When the R session is ready, we can start a new Reticulate session.
+					const config = await ReticulateRuntimeSession.checkRSession(this.rSession);
+					const runtimeMetadata = ReticulateRuntimeSession.applyConfig(this.runtimeMetadata, config);
 					this.pythonSession = await this.createPythonRuntimeSession(
-						this.runtimeMetadata,
+						runtimeMetadata,
 						metadata,
 						kernelSpec
 					);
@@ -947,7 +960,7 @@ class ReticulateRuntimeMetadata implements positron.LanguageRuntimeMetadata {
 	extraRuntimeData: any = {
 		pythonPath: 'Managed by the reticulate package',
 		ipykernelBundle: {
-			disabledReason: 'Cannot bundle ipykernel for reticulate sessions',
+			disabledReason: 'Waiting for the embedded Python interpreter',
 		},
 		externallyManaged: true,
 	};

--- a/extensions/positron-reticulate/src/extension.ts
+++ b/extensions/positron-reticulate/src/extension.ts
@@ -66,7 +66,7 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 
 		switch (option) {
 			case 'auto':
-				const val = this._context.workspaceState.get(autoEnabledStorageKey, false);
+				const val = CONTEXT.workspaceState.get(autoEnabledStorageKey, false);
 				return val;
 			case 'never':
 				return false;
@@ -220,12 +220,12 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 
 	setSessions(hostRSessionId: string, reticulateId: string, session: positron.LanguageRuntimeSession) {
 		let sessionsMap: ReticulateSessionInfo[] =
-			this._context.workspaceState.get('reticulate-sessions-map', []);
+			CONTEXT.workspaceState.get('reticulate-sessions-map', []);
 
 		session.onDidEndSession(() => {
 			// Remove the session from the map when it ends.
 			sessionsMap = sessionsMap.filter((pair) => pair.reticulateSessionId !== session.metadata.sessionId);
-			this._context.workspaceState.update('reticulate-sessions-map', sessionsMap);
+			CONTEXT.workspaceState.update('reticulate-sessions-map', sessionsMap);
 			this._sessions.delete(session.metadata.sessionId);
 		});
 
@@ -241,11 +241,11 @@ export class ReticulateRuntimeManager implements positron.LanguageRuntimeManager
 		}
 
 		this._sessions.set(session.metadata.sessionId, session);
-		this._context.workspaceState.update('reticulate-sessions-map', sessionsMap);
+		CONTEXT.workspaceState.update('reticulate-sessions-map', sessionsMap);
 	}
 
 	getSessions(): Array<ReticulateSessionInfo> {
-		const sessionsMap = this._context.workspaceState.get('reticulate-sessions-map', []);
+		const sessionsMap = CONTEXT.workspaceState.get('reticulate-sessions-map', []);
 		return sessionsMap as Array<ReticulateSessionInfo>;
 	}
 


### PR DESCRIPTION
Python (reticulate) sessions can fail to start when the project's Python environment lacks `ipykernel`, even when the user's code doesn't depend on it. Users see an error about `positron_ipykernel`, as reported in [this comment](https://github.com/posit-dev/positron/issues/6675#issuecomment-5604984461).

This lets reticulate sessions use the `ipykernel` that Positron already ships. It follows the existing `python.useBundledIpykernel` setting and uses the bundle only when it supports the interpreter running inside R.

Ark reports that interpreter's Python version and architecture, and Positron supplies the matching package locations before starting the kernel. The interpreter information is refreshed after R restarts, and the bundle selection is saved for restored sessions.

Updates the Ark submodule to [bc7680f1](https://github.com/posit-dev/ark/commit/bc7680f10e5f50e0e25bf3002f4735e0c02cf94f), including the support merged in [posit-dev/ark#1404](https://github.com/posit-dev/ark/pull/1404).

Closes https://github.com/posit-dev/positron/issues/16036

Closes #15665

Closes #15666

Closes #15667

@:ark @:reticulate

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Python (reticulate) sessions can use Positron's bundled `ipykernel` when it supports the embedded interpreter and `python.useBundledIpykernel` is enabled (https://github.com/posit-dev/positron/issues/16036).

### Commits

- [Support bundled ipykernel for reticulate sessions (#1404)](https://github.com/posit-dev/ark/commit/bc7680f10e5f50e0e25bf3002f4735e0c02cf94f)
- [Move Oak doc to own folder](https://github.com/posit-dev/ark/commit/545cd99dc885bcac044fe60ade8ef6b14aa60797)
- [Bump base64 from 0.22.1 to 0.23.1 (#1398)](https://github.com/posit-dev/ark/commit/43ae0787cc5740e2a7dc6228f95e717caddf033d)
- [Bump syn from 2.0.119 to 3.0.4 (#1397)](https://github.com/posit-dev/ark/commit/50d7010bb3942fa94763537f76b7ae4185c5022b)
- [Bump rust-toolchain from 1.97 to 1.98 (#1395)](https://github.com/posit-dev/ark/commit/d1e4746192c07b732e0e917f2b84226693a124a0)
- [Follow-up for attached packages fix (#1403)](https://github.com/posit-dev/ark/commit/bc7c15c0d5283921bcaedb2a81112269bb10e83c)
- [Bump the rust-crates group with 20 updates (#1396)](https://github.com/posit-dev/ark/commit/a4977c3e978397bf4853d5d90f9b1467aed92532)
- [Consistently catch LSP panics (#1405)](https://github.com/posit-dev/ark/commit/b448bd4d058772f577b6a1abedfc0518fc5d2d88)
- [Log cached source hit at same level as other source fetching events](https://github.com/posit-dev/ark/commit/e1575cf2c1c457f942390c474786a88c54bfabfc)
- [Keep the plot origin when a render is held past source() (#1391)](https://github.com/posit-dev/ark/commit/bb6f70094e2719def03f76c15fc27550bf13f465)
- [Strip carriage returns when splitting lines (#1400)](https://github.com/posit-dev/ark/commit/37fe33a19c4fc678da32c5c23111306b52019f4a)
