### PR TITLE
Update terms notice in provider modal

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/addCustomProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/addCustomProviderView.tsx
@@ -211,7 +211,8 @@ export const AddCustomProviderView = (props: AddCustomProviderViewProps) => {
 
 					{errorMessage && <ProviderErrorBanner message={errorMessage} />}
 					<div style={{ flexGrow: 1 }}>&nbsp;</div>
-					{builtInSource && <ProviderNotice source={builtInSource} />}
+					{/* Built from kind, not builtInSource: the "OpenAI Compatible" built-in isn't always registered. */}
+					<ProviderNotice provider={{ id: kind, displayName: CUSTOM_PROVIDER_KINDS[kind].label, customKind: kind }} />
 				</div>
 			}
 			footer={

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -396,7 +396,7 @@ export const ConnectProviderView = (props: ConnectProviderViewProps) => {
 					{errorMessage && <ProviderErrorBanner message={errorMessage} />}
 					<div style={{ flexGrow: 1 }}>&nbsp;</div>
 					<EditRawConfigLink onClick={props.onEditRawConfig} />
-					<ProviderNotice source={props.source} />
+					<ProviderNotice provider={props.source.provider} />
 				</div>
 			}
 			footer={
@@ -450,9 +450,9 @@ export const ProviderErrorBanner = (props: { message: string }) => (
 	</div>
 );
 
-export const ProviderNotice = (props: { source: IPositronLanguageModelSource }) => {
-	const gettingStarted = getProviderGettingStartedText(props.source.provider);
-	const thirdPartyService = getProviderThirdPartyServiceText(props.source.provider);
+export const ProviderNotice = (props: { provider: IPositronLanguageModelSource['provider'] }) => {
+	const gettingStarted = getProviderGettingStartedText(props.provider);
+	const thirdPartyService = getProviderThirdPartyServiceText(props.provider);
 	if (!gettingStarted && !thirdPartyService) {
 		return null;
 	}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectProviderView.tsx
@@ -12,7 +12,7 @@ import { EmbeddedLink } from '../../../../../base/browser/ui/positronComponents/
 import { IPositronCustomModel, IPositronLanguageModelConfig, IPositronLanguageModelFieldOverride, IPositronLanguageModelSource } from '../../common/interfaces/positronAssistantService.js';
 import { AuthMethod, AuthStatus } from '../types.js';
 import { availableAuthMethods, deriveAuthMethod, deriveAuthStatus, deriveConnectAction } from '../providerConnection.js';
-import { getProviderGettingStartedText } from '../providerLegalText.js';
+import { getProviderGettingStartedText, getProviderThirdPartyServiceText } from '../providerLegalText.js';
 import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
 import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { DropDownListBox } from '../../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
@@ -451,13 +451,15 @@ export const ProviderErrorBanner = (props: { message: string }) => (
 );
 
 export const ProviderNotice = (props: { source: IPositronLanguageModelSource }) => {
-	const text = getProviderGettingStartedText(props.source.provider);
-	if (!text) {
+	const gettingStarted = getProviderGettingStartedText(props.source.provider);
+	const thirdPartyService = getProviderThirdPartyServiceText(props.source.provider);
+	if (!gettingStarted && !thirdPartyService) {
 		return null;
 	}
 	return (
 		<div className='connect-provider-notice' data-testid='provider-notice'>
-			<EmbeddedLink>{text}</EmbeddedLink>
+			{gettingStarted && <EmbeddedLink>{gettingStarted}</EmbeddedLink>}
+			{thirdPartyService && <EmbeddedLink>{thirdPartyService}</EmbeddedLink>}
 		</div>
 	);
 };

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/connectedProviderView.tsx
@@ -183,7 +183,7 @@ export const ConnectedProviderView = (props: ConnectedProviderViewProps) => {
 						</div>
 					}
 					<EditRawConfigLink onClick={props.onEditRawConfig} />
-					<ProviderNotice source={current} />
+					<ProviderNotice provider={current.provider} />
 					{errorMessage && <div className='connect-provider-error'>{errorMessage}</div>}
 				</div>
 			}

--- a/src/vs/workbench/contrib/positronAssistant/browser/providerLegalText.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/providerLegalText.ts
@@ -76,6 +76,29 @@ export function getProviderGettingStartedText(provider: IProvider): string | und
 	}
 }
 
+/**
+ * A one-line third-party notice shown for every provider except Posit AI,
+ * which gets its own marketing copy from {@link getProviderGettingStartedText}
+ * instead. A custom entry gets generic wording, since its kind (e.g.
+ * 'anthropic') names the wire protocol, not who operates the endpoint.
+ */
+export function getProviderThirdPartyServiceText(provider: IProvider): string | undefined {
+	if (provider.id === 'posit-ai') {
+		return undefined;
+	}
+	if (isCustomProvider(provider)) {
+		return localize(
+			'positron.languageModelConfig.custom.thirdPartyService',
+			'This is a custom provider connecting to an endpoint you configured, and your use of it is governed by that provider\'s terms of service.',
+		);
+	}
+	return localize(
+		'positron.languageModelConfig.thirdPartyService',
+		'{0} is a third-party service and your use of {0} is governed by {0}\'s terms of service.',
+		provider.displayName,
+	);
+}
+
 export function getProviderUsageDisclaimerText(provider: IProvider) {
 	if (isCustomProvider(provider)) {
 		return localize(

--- a/src/vs/workbench/contrib/positronAssistant/browser/providerLegalText.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/providerLegalText.ts
@@ -89,7 +89,7 @@ export function getProviderThirdPartyServiceText(provider: IProvider): string | 
 	if (isCustomProvider(provider)) {
 		return localize(
 			'positron.languageModelConfig.custom.thirdPartyService',
-			'This is a custom provider connecting to an endpoint you configured, and your use of it is governed by that provider\'s terms of service.',
+			'This is a custom provider that connects to an endpoint you configure, and your use of it is governed by that provider\'s terms of service.',
 		);
 	}
 	return localize(

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/addCustomProviderView.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/addCustomProviderView.vitest.tsx
@@ -109,6 +109,19 @@ describe('AddCustomProviderView', () => {
 		expect(screen.getByPlaceholderText('Model ID')).toBeInTheDocument();
 	});
 
+	it('shows the third-party notice for the default kind even when its built-in form source is unregistered', () => {
+		// Most installs never have the legacy "OpenAI Compatible" tile in `sources`.
+		rtl.render(
+			<AddCustomProviderView
+				{...dialogProps()}
+				sources={sources.filter(s => s.provider.id !== 'openai-compatible')}
+				onBack={vi.fn()}
+				onCreate={vi.fn()}
+			/>
+		);
+		expect(screen.getByTestId('provider-notice')).toBeInTheDocument();
+	});
+
 	it('changing the type keeps everything already typed', async () => {
 		const user = userEvent.setup();
 		renderView();

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/providerLegalText.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/providerLegalText.vitest.ts
@@ -5,11 +5,12 @@
 
 /// <reference types="vitest/globals" />
 
-import { getProviderGettingStartedText, getProviderTermsOfServiceText, getProviderUsageDisclaimerText } from '../../browser/providerLegalText.js';
+import { getProviderGettingStartedText, getProviderTermsOfServiceText, getProviderThirdPartyServiceText, getProviderUsageDisclaimerText } from '../../browser/providerLegalText.js';
 
 const positAi = { id: 'posit-ai', displayName: 'Posit AI Pass', settingName: 'posit-ai' };
 const custom = { id: 'openai-compatible', displayName: 'OpenAI Compatible', settingName: 'openai-compatible' };
 const customAnthropic = { id: 'my anthropic', displayName: 'my anthropic', customKind: 'anthropic' };
+const anthropicApi = { id: 'anthropic-api', displayName: 'Anthropic', settingName: 'anthropic-api' };
 
 describe('providerLegalText', () => {
 	it('builds a getting-started note for Posit AI Pass', () => {
@@ -34,5 +35,22 @@ describe('providerLegalText', () => {
 		expect(getProviderTermsOfServiceText(customAnthropic)).toBe(getProviderTermsOfServiceText(custom));
 		expect(getProviderUsageDisclaimerText(customAnthropic)).toBe(getProviderUsageDisclaimerText(custom));
 		expect(getProviderUsageDisclaimerText(customAnthropic)).not.toContain('my anthropic');
+	});
+
+	it('builds a third-party notice naming the provider and its terms of service', () => {
+		const text = getProviderThirdPartyServiceText(anthropicApi);
+		expect(text).toContain('Anthropic is a third-party service');
+		expect(text).toContain('governed by Anthropic\'s');
+	});
+
+	it('gives a custom entry generic third-party wording rather than naming its kind or user-chosen name', () => {
+		const text = getProviderThirdPartyServiceText(customAnthropic);
+		expect(text).toBe(getProviderThirdPartyServiceText(custom));
+		expect(text).not.toContain('my anthropic');
+		expect(text).not.toContain('Anthropic');
+	});
+
+	it('omits the third-party notice for Posit AI Pass', () => {
+		expect(getProviderThirdPartyServiceText(positAi)).toBeUndefined();
 	});
 });


### PR DESCRIPTION
- closes https://github.com/posit-dev/positron/issues/16051
- companion docs pr: https://github.com/posit-dev/positron-website/pull/475

## Summary

[#15822](https://github.com/posit-dev/positron/pull/15822) removed the provider modal's legal disclaimer entirely, since the old wording was wrong for most providers. This adds back a correct, minimal notice:

- Posit AI: unchanged, still just its marketing/getting-started copy.
- Every other built-in provider: a plain-text line, "[Provider] is a third-party service and your use of [Provider] is governed by [Provider]'s terms of service."
- Custom providers (`providers.custom` entries and the "OpenAI Compatible" tile): generic wording instead of naming a vendor, since a custom entry's kind names the protocol used, not who operates the endpoint, and its display name is whatever the user typed.

## Changes

- `providerLegalText.ts`: added `getProviderThirdPartyServiceText(provider)`, returning `undefined` for `posit-ai`, generic custom-provider wording for a `providers.custom` entry or the "OpenAI Compatible" tile, and the per-provider sentence otherwise.
- `connectProviderView.tsx`: `ProviderNotice` now renders both the getting-started note and the third-party notice, instead of only the former.
- Added test coverage in `providerLegalText.vitest.ts` for the new function (Posit AI omission, built-in provider wording, custom-provider generic wording).

<img width="612" height="461" alt="image" src="https://github.com/user-attachments/assets/b602f14a-f8ce-4cf7-a8fd-bf560df5d6e7" />

<img width="609" height="357" alt="image" src="https://github.com/user-attachments/assets/8a1bf7b4-30d6-4839-b01b-8443929564d4" />

<img width="609" height="614" alt="image" src="https://github.com/user-attachments/assets/002ce301-fd9f-4351-b1a0-9c88a0d9ca71" />

## Test plan

- [x] `npx vitest run` on `providerLegalText.vitest.ts`, `connectProviderView.vitest.tsx`, `connectedProviderView.vitest.tsx`, `addCustomProviderView.vitest.tsx` — all pass
- [x] `npx eslint --max-warnings 0` on changed files — clean
- [x] `npm run build-check` — 0 errors
- [x] Manually open the Configure LLM Providers modal for a built-in provider (e.g. Anthropic) and a custom provider, and confirm the notice text reads correctly