### PR TITLE
Variables Pane: Ellipsize Truncated Variable Names

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
@@ -63,12 +63,11 @@
 	flex-shrink: 0;
 	overflow: hidden;
 	align-items: center;
-	white-space: nowrap;
-	text-overflow: ellipsis;
 }
 
 .variable-item .name-column .name-column-indenter {
 	display: flex;
+	min-width: 0;
 }
 
 .variable-item .name-column .gutter {
@@ -89,8 +88,10 @@
 }
 
 .variable-item .name-value {
-	display: flex;
-	align-items: center;
+	overflow: hidden;
+	line-height: 26px;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .variable-item .details-column {

--- a/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variableItem.css
@@ -67,6 +67,7 @@
 
 .variable-item .name-column .name-column-indenter {
 	display: flex;
+	align-items: center;
 	min-width: 0;
 }
 
@@ -89,7 +90,6 @@
 
 .variable-item .name-value {
 	overflow: hidden;
-	line-height: 26px;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }


### PR DESCRIPTION
Fixes https://github.com/posit-dev/positron/issues/15771 thanks to the contribution from @mburtin in https://github.com/posit-dev/positron/pull/15980!

I opened this pull request here because of the CI situation outlined in https://github.com/posit-dev/positron/issues/6628. The commits from https://github.com/posit-dev/positron/pull/15980 are on this branch with the original authorship.

Long variable and function names in the Variables pane were clipped mid-character instead of displaying an ellipsis. This issue was the `text-overflow` styles were being applied to a parent element and not the nested element that the text was located in.

### Screenshots


https://github.com/user-attachments/assets/a7606ef2-4ece-4758-9441-744711a81a35



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Variables pane now displays an ellipsis when long variable or function names are truncated thanks to @mburtin! (#15771)


### Validation Steps

@:variables
@:web

<!--
  Positron team members: e2e feature tags are auto-added based on your changed
  files, so tests run automatically when you open this pull request. Add tags
  here yourself to run more.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->

This is a CSS-only change scoped to variable-name rendering in the Variables pane.

1. Start Positron and open a Python or R session.
2. Create a variable or function with a name long enough to exceed the width of the Variables pane's name column.
3. Open the Variables pane and confirm that:
  - The long name is truncated with an ellipsis instead of being clipped mid-character.
  - The name remains vertically aligned with its chevron icon (if the variable is an object).
  - Expanding and collapsing nested variables still works as expected.
5. Resize the Variables pane and confirm that the ellipsis updates correctly as the available width changes.
6. Confirm that short variable names and values continue to render normally.