### PR TITLE
Offer to start sessions for new python environments

### DIFF
--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -244,6 +244,14 @@ export namespace Interpreters {
     export const environmentPromptMessage = l10n.t(
         'We noticed a new environment has been created. Do you want to select it for the workspace folder?',
     );
+    // --- Start Positron ---
+    export const environmentSessionPromptMessage = l10n.t(
+        'A new Python environment was created in this workspace. Would you like to start a console session with this environment?',
+    );
+    export const startSession = l10n.t('Start Session');
+    export const environmentSessionStartFailed = (environment: string) =>
+        l10n.t('Failed to start a console session for Python environment {0}.', environment);
+    // --- End Positron ---
     export const entireWorkspace = l10n.t('Select at workspace level');
     export const clearAtWorkspace = l10n.t('Clear at workspace level');
     export const selectInterpreterTip = l10n.t(

--- a/extensions/positron-python/src/client/interpreter/contracts.ts
+++ b/extensions/positron-python/src/client/interpreter/contracts.ts
@@ -26,7 +26,10 @@ export interface IComponentAdapter {
     getRefreshPromise(options?: GetRefreshEnvironmentsOptions): Promise<void> | undefined;
     readonly onChanged: Event<PythonEnvironmentsChangedEvent>;
     // VirtualEnvPrompt
-    onDidCreate(resource: Resource, callback: () => void): Disposable;
+    // --- Start Positron ---
+    // onDidCreate(resource: Resource, callback: () => void): Disposable;
+    onDidCreate(resource: Resource, callback: (envPath: string) => void): Disposable;
+    // --- End Positron ---
     // IInterpreterLocatorService
     hasInterpreters(filter?: (e: PythonEnvironment) => Promise<boolean>): Promise<boolean>;
     getInterpreters(resource?: Uri, source?: PythonEnvSource[]): PythonEnvironment[];

--- a/extensions/positron-python/src/client/interpreter/virtualEnvs/virtualEnvPrompt.ts
+++ b/extensions/positron-python/src/client/interpreter/virtualEnvs/virtualEnvPrompt.ts
@@ -48,8 +48,8 @@ export class VirtualEnvironmentPrompt implements IExtensionActivationService {
         // --- Start Positron ---
         // @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IPythonRuntimeManager) private readonly pythonRuntimeManager: IPythonRuntimeManager,
-        // --- End Positron ---
     ) {}
+    // --- End Positron ---
 
     public async activate(resource: Uri): Promise<void> {
         // --- Start Positron ---

--- a/extensions/positron-python/src/client/interpreter/virtualEnvs/virtualEnvPrompt.ts
+++ b/extensions/positron-python/src/client/interpreter/virtualEnvs/virtualEnvPrompt.ts
@@ -2,18 +2,33 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { ConfigurationTarget, Disposable, Uri } from 'vscode';
+// --- Start Positron ---
+// import { ConfigurationTarget, Disposable, Uri } from 'vscode';
+import { Disposable, Uri } from 'vscode';
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+// --- End Positron ---
 import { IExtensionActivationService } from '../../activation/types';
 import { IApplicationShell } from '../../common/application/types';
 import { IDisposableRegistry, IPersistentStateFactory } from '../../common/types';
 import { Common, Interpreters } from '../../common/utils/localize';
-import { traceDecoratorError, traceVerbose } from '../../logging';
+// --- Start Positron ---
+// import { traceDecoratorError, traceVerbose } from '../../logging';
+import { traceDecoratorError, traceError } from '../../logging';
+// --- End Positron ---
 import { isCreatingEnvironment } from '../../pythonEnvironments/creation/createEnvApi';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
-import { IPythonPathUpdaterServiceManager } from '../configuration/types';
-import { IComponentAdapter, IInterpreterHelper, IInterpreterService } from '../contracts';
+// --- Start Positron ---
+// import { IPythonPathUpdaterServiceManager } from '../configuration/types';
+// import { IComponentAdapter, IInterpreterHelper, IInterpreterService } from '../contracts';
+import { IComponentAdapter } from '../contracts';
+import { IPythonRuntimeManager } from '../../positron/manager';
+import { getActivePythonSessions } from '../../positron/session';
+import { PythonRuntimeExtraData } from '../../positron/runtime';
+import { arePathsSame } from '../../pythonEnvironments/common/externalDependencies';
+// --- End Positron ---
 
 const doNotDisplayPromptStateKey = 'MESSAGE_KEY_FOR_VIRTUAL_ENV';
 @injectable()
@@ -22,42 +37,79 @@ export class VirtualEnvironmentPrompt implements IExtensionActivationService {
 
     constructor(
         @inject(IPersistentStateFactory) private readonly persistentStateFactory: IPersistentStateFactory,
-        @inject(IInterpreterHelper) private readonly helper: IInterpreterHelper,
-        @inject(IPythonPathUpdaterServiceManager)
-        private readonly pythonPathUpdaterService: IPythonPathUpdaterServiceManager,
+        // --- Start Positron ---
+        // @inject(IInterpreterHelper) private readonly helper: IInterpreterHelper,
+        // @inject(IPythonPathUpdaterServiceManager)
+        // private readonly pythonPathUpdaterService: IPythonPathUpdaterServiceManager,
+        // --- End Positron ---
         @inject(IDisposableRegistry) private readonly disposableRegistry: Disposable[],
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IComponentAdapter) private readonly pyenvs: IComponentAdapter,
-        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
+        // --- Start Positron ---
+        // @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
+        @inject(IPythonRuntimeManager) private readonly pythonRuntimeManager: IPythonRuntimeManager,
+        // --- End Positron ---
     ) {}
 
     public async activate(resource: Uri): Promise<void> {
-        const disposable = this.pyenvs.onDidCreate(resource, () => this.handleNewEnvironment(resource));
+        // --- Start Positron ---
+        // const disposable = this.pyenvs.onDidCreate(resource, () => this.handleNewEnvironment(resource));
+        const disposable = this.pyenvs.onDidCreate(resource, (envPath) => this.handleNewEnvironment(envPath));
+        // --- End Positron ---
         this.disposableRegistry.push(disposable);
     }
 
     @traceDecoratorError('Error in event handler for detection of new environment')
-    protected async handleNewEnvironment(resource: Uri): Promise<void> {
+    // --- Start Positron ---
+    // protected async handleNewEnvironment(resource: Uri): Promise<void> {
+    protected async handleNewEnvironment(envPath: string): Promise<void> {
+        // --- End Positron ---
         if (isCreatingEnvironment()) {
             return;
         }
-        const interpreters = await this.pyenvs.getWorkspaceVirtualEnvInterpreters(resource);
-        const interpreter =
-            Array.isArray(interpreters) && interpreters.length > 0
-                ? this.helper.getBestInterpreter(interpreters)
-                : undefined;
+        // --- Start Positron ---
+        // const interpreters = await this.pyenvs.getWorkspaceVirtualEnvInterpreters(resource);
+        // const interpreter =
+        //     Array.isArray(interpreters) && interpreters.length > 0
+        //         ? this.helper.getBestInterpreter(interpreters)
+        //         : undefined;
+        // if (!interpreter) {
+        //     return;
+        // }
+        // const currentInterpreter = await this.interpreterService.getActiveInterpreter(resource);
+        // if (currentInterpreter?.id === interpreter.id) {
+        //     traceVerbose('New environment has already been selected');
+        //     return;
+        // }
+        // await this.notifyUser(interpreter, resource);
+        if (await this.hasRunningSession(envPath)) {
+            return;
+        }
+        const interpreter = await this.pyenvs.getInterpreterDetails(envPath);
         if (!interpreter) {
             return;
         }
-        const currentInterpreter = await this.interpreterService.getActiveInterpreter(resource);
-        if (currentInterpreter?.id === interpreter.id) {
-            traceVerbose('New environment has already been selected');
-            return;
-        }
-        await this.notifyUser(interpreter, resource);
+        await this.notifyUser(interpreter);
+        // --- End Positron ---
     }
 
-    protected async notifyUser(interpreter: PythonEnvironment, resource: Uri): Promise<void> {
+    // --- Start Positron ---
+    private async hasRunningSession(pythonPath: string): Promise<boolean> {
+        const sessions = await getActivePythonSessions();
+        return sessions.some((session) => {
+            if (session.getRuntimeState() === positron.RuntimeState.Exited) {
+                return false;
+            }
+            const extraData = session.runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData;
+            return arePathsSame(extraData.pythonPath, pythonPath);
+        });
+    }
+    // --- End Positron ---
+
+    // --- Start Positron ---
+    // protected async notifyUser(interpreter: PythonEnvironment, resource: Uri): Promise<void> {
+    protected async notifyUser(interpreter: PythonEnvironment): Promise<void> {
+        // --- End Positron ---
         const notificationPromptEnabled = this.persistentStateFactory.createWorkspacePersistentState(
             doNotDisplayPromptStateKey,
             true,
@@ -65,9 +117,18 @@ export class VirtualEnvironmentPrompt implements IExtensionActivationService {
         if (!notificationPromptEnabled.value) {
             return;
         }
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
+        // --- Start Positron ---
+        // const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
+        const prompts = [Interpreters.startSession, Common.notNow, Common.doNotShowAgain];
+        // --- End Positron ---
         const telemetrySelections: ['Yes', 'No', 'Ignore'] = ['Yes', 'No', 'Ignore'];
-        const selection = await this.appShell.showInformationMessage(Interpreters.environmentPromptMessage, ...prompts);
+        // --- Start Positron ---
+        // const selection = await this.appShell.showInformationMessage(Interpreters.environmentPromptMessage, ...prompts);
+        const selection = await this.appShell.showInformationMessage(
+            Interpreters.environmentSessionPromptMessage,
+            ...prompts,
+        );
+        // --- End Positron ---
         sendTelemetryEvent(EventName.PYTHON_INTERPRETER_ACTIVATE_ENVIRONMENT_PROMPT, undefined, {
             selection: selection ? telemetrySelections[prompts.indexOf(selection)] : undefined,
         });
@@ -75,14 +136,38 @@ export class VirtualEnvironmentPrompt implements IExtensionActivationService {
             return;
         }
         if (selection === prompts[0]) {
-            await this.pythonPathUpdaterService.updatePythonPath(
-                interpreter.path,
-                ConfigurationTarget.WorkspaceFolder,
-                'ui',
-                resource,
-            );
+            // --- Start Positron ---
+            // await this.pythonPathUpdaterService.updatePythonPath(
+            //     interpreter.path,
+            //     ConfigurationTarget.WorkspaceFolder,
+            //     'ui',
+            //     resource,
+            // );
+            await this.startSession(interpreter);
+            // --- End Positron ---
         } else if (selection === prompts[2]) {
             await notificationPromptEnabled.updateValue(false);
         }
     }
+
+    // --- Start Positron ---
+    private async startSession(interpreter: PythonEnvironment): Promise<void> {
+        // A session may have started while the notification was open.
+        if (await this.hasRunningSession(interpreter.path)) {
+            return;
+        }
+        try {
+            const metadata = await this.pythonRuntimeManager.resolveRuntimeMetadataFromPath(interpreter.path);
+            if (!metadata) {
+                throw new Error(`No runtime could be registered for ${interpreter.path}`);
+            }
+            await positron.runtime.startLanguageRuntime(metadata.runtimeId, metadata.runtimeName);
+        } catch (error) {
+            traceError(`Failed to start a console session for ${interpreter.path}`, error);
+            this.appShell.showErrorMessage(
+                Interpreters.environmentSessionStartFailed(interpreter.detailedDisplayName ?? interpreter.path),
+            );
+        }
+    }
+    // --- End Positron ---
 }

--- a/extensions/positron-python/src/client/interpreter/virtualEnvs/virtualEnvPrompt.ts
+++ b/extensions/positron-python/src/client/interpreter/virtualEnvs/virtualEnvPrompt.ts
@@ -152,10 +152,6 @@ export class VirtualEnvironmentPrompt implements IExtensionActivationService {
 
     // --- Start Positron ---
     private async startSession(interpreter: PythonEnvironment): Promise<void> {
-        // A session may have started while the notification was open.
-        if (await this.hasRunningSession(interpreter.path)) {
-            return;
-        }
         try {
             const metadata = await this.pythonRuntimeManager.resolveRuntimeMetadataFromPath(interpreter.path);
             if (!metadata) {

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -64,15 +64,16 @@ export interface IPythonRuntimeManager extends positron.LanguageRuntimeManager {
         recreateRuntime?: boolean,
         forceRefresh?: boolean,
     ): Promise<positron.LanguageRuntimeMetadata | undefined>;
-    selectLanguageRuntimeFromPath(pythonPath: string, recreateRuntime?: boolean): Promise<string | undefined>;
     /**
-     * Resolves runtime metadata for an interpreter path.
-     * Refreshes discovery and retries once if the path is not found.
+     * Registers the runtime for an interpreter path, refreshing discovery and
+     * retrying once if the path is not yet known. Returns undefined if it still
+     * cannot be registered.
      */
     resolveRuntimeMetadataFromPath(
         pythonPath: string,
         recreateRuntime?: boolean,
     ): Promise<positron.LanguageRuntimeMetadata | undefined>;
+    selectLanguageRuntimeFromPath(pythonPath: string, recreateRuntime?: boolean): Promise<string | undefined>;
     triggerInterpreterRefresh(): Promise<void>;
 }
 
@@ -749,6 +750,27 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
     }
 
     /**
+     * Registers the runtime for an interpreter path, refreshing discovery and
+     * retrying once if the path is not yet known.
+     *
+     * @param pythonPath The path to the Python interpreter.
+     * @param recreateRuntime Whether to recreate an already registered runtime.
+     * @returns The runtime metadata, or undefined if it could not be registered.
+     */
+    async resolveRuntimeMetadataFromPath(
+        pythonPath: string,
+        recreateRuntime?: boolean,
+    ): Promise<positron.LanguageRuntimeMetadata | undefined> {
+        let metadata = await this.registerLanguageRuntimeFromPath(pythonPath, recreateRuntime);
+        if (!metadata) {
+            traceInfo(`Runtime not found for ${pythonPath}, triggering interpreter refresh...`);
+            await this.triggerInterpreterRefresh();
+            metadata = await this.registerLanguageRuntimeFromPath(pythonPath, recreateRuntime);
+        }
+        return metadata;
+    }
+
+    /**
      * Select a Python language runtime in the console by its interpreter path.
      *
      * @param pythonPath The path to the Python interpreter.
@@ -763,28 +785,6 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
             traceError(`Tried to switch to a language runtime that has not been registered: ${pythonPath}`);
             return undefined;
         }
-    }
-
-    /**
-     * Resolves runtime metadata for an interpreter path.
-     * Refreshes discovery and retries once if the path is not found.
-     *
-     * @param pythonPath The path to the Python interpreter.
-     * @param recreateRuntime Whether to recreate an already registered runtime.
-     * @returns The runtime metadata, or undefined if the path is not found.
-     */
-    async resolveRuntimeMetadataFromPath(
-        pythonPath: string,
-        recreateRuntime?: boolean,
-    ): Promise<positron.LanguageRuntimeMetadata | undefined> {
-        const metadata = await this.registerLanguageRuntimeFromPath(pythonPath, recreateRuntime);
-        if (metadata) {
-            return metadata;
-        }
-
-        traceInfo(`Runtime not found for ${pythonPath}, triggering interpreter refresh...`);
-        await this.triggerInterpreterRefresh();
-        return this.registerLanguageRuntimeFromPath(pythonPath, recreateRuntime);
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -65,6 +65,14 @@ export interface IPythonRuntimeManager extends positron.LanguageRuntimeManager {
         forceRefresh?: boolean,
     ): Promise<positron.LanguageRuntimeMetadata | undefined>;
     selectLanguageRuntimeFromPath(pythonPath: string, recreateRuntime?: boolean): Promise<string | undefined>;
+    /**
+     * Resolves runtime metadata for an interpreter path.
+     * Refreshes discovery and retries once if the path is not found.
+     */
+    resolveRuntimeMetadataFromPath(
+        pythonPath: string,
+        recreateRuntime?: boolean,
+    ): Promise<positron.LanguageRuntimeMetadata | undefined>;
     triggerInterpreterRefresh(): Promise<void>;
 }
 
@@ -747,16 +755,7 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
      * @returns Promise that resolves when the runtime is selected.
      */
     async selectLanguageRuntimeFromPath(pythonPath: string, recreateRuntime?: boolean): Promise<string | undefined> {
-        // Try to register the runtime
-        let metadata = await this.registerLanguageRuntimeFromPath(pythonPath, recreateRuntime);
-
-        // If registration failed, the interpreter might be newly created - trigger a refresh and retry
-        if (!metadata) {
-            traceInfo(`Runtime not found for ${pythonPath}, triggering interpreter refresh...`);
-            await this.triggerInterpreterRefresh();
-            metadata = await this.registerLanguageRuntimeFromPath(pythonPath, recreateRuntime);
-        }
-
+        const metadata = await this.resolveRuntimeMetadataFromPath(pythonPath, recreateRuntime);
         if (metadata) {
             await positron.runtime.selectLanguageRuntime(metadata.runtimeId);
             return metadata.runtimeId;
@@ -764,6 +763,28 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
             traceError(`Tried to switch to a language runtime that has not been registered: ${pythonPath}`);
             return undefined;
         }
+    }
+
+    /**
+     * Resolves runtime metadata for an interpreter path.
+     * Refreshes discovery and retries once if the path is not found.
+     *
+     * @param pythonPath The path to the Python interpreter.
+     * @param recreateRuntime Whether to recreate an already registered runtime.
+     * @returns The runtime metadata, or undefined if the path is not found.
+     */
+    async resolveRuntimeMetadataFromPath(
+        pythonPath: string,
+        recreateRuntime?: boolean,
+    ): Promise<positron.LanguageRuntimeMetadata | undefined> {
+        const metadata = await this.registerLanguageRuntimeFromPath(pythonPath, recreateRuntime);
+        if (metadata) {
+            return metadata;
+        }
+
+        traceInfo(`Runtime not found for ${pythonPath}, triggering interpreter refresh...`);
+        await this.triggerInterpreterRefresh();
+        return this.registerLanguageRuntimeFromPath(pythonPath, recreateRuntime);
     }
 
     /**

--- a/extensions/positron-python/src/client/pythonEnvironments/legacyIOC.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/legacyIOC.ts
@@ -132,22 +132,42 @@ class ComponentAdapter implements IComponentAdapter {
 
     // For use in VirtualEnvironmentPrompt.activate()
 
+    // --- Start Positron ---
+    // Locator events store the executable path in different fields:
+    // `envPath` for the JS locator and `new.executable.filename` for the native locator.
     // Call callback if an environment gets created within the resource provided.
-    public onDidCreate(resource: Resource, callback: () => void): vscode.Disposable {
+    // public onDidCreate(resource: Resource, callback: () => void): vscode.Disposable {
+    //     const workspaceFolder = resource ? vscode.workspace.getWorkspaceFolder(resource) : undefined;
+    //     return this.api.onChanged((e) => {
+    //         if (!workspaceFolder || !e.searchLocation) {
+    //             return;
+    //         }
+    //         traceVerbose(`Received event ${JSON.stringify(e)} file change event`);
+    //         if (
+    //             e.type === FileChangeType.Created &&
+    //             isParentPath(e.searchLocation.fsPath, workspaceFolder.uri.fsPath)
+    //         ) {
+    //             callback();
+    //         }
+    //     });
+    // }
+    public onDidCreate(resource: Resource, callback: (envPath: string) => void): vscode.Disposable {
         const workspaceFolder = resource ? vscode.workspace.getWorkspaceFolder(resource) : undefined;
-        return this.api.onChanged((e) => {
-            if (!workspaceFolder || !e.searchLocation) {
+        return this.api.onChanged((e: PythonEnvCollectionChangedEvent & { envPath?: string }) => {
+            if (!workspaceFolder || !e.searchLocation || e.type !== FileChangeType.Created) {
+                return;
+            }
+            const envPath = e.envPath ?? e.new?.executable.filename;
+            if (!envPath) {
                 return;
             }
             traceVerbose(`Received event ${JSON.stringify(e)} file change event`);
-            if (
-                e.type === FileChangeType.Created &&
-                isParentPath(e.searchLocation.fsPath, workspaceFolder.uri.fsPath)
-            ) {
-                callback();
+            if (isParentPath(envPath, workspaceFolder.uri.fsPath)) {
+                callback(envPath);
             }
         });
     }
+    // --- End Positron ---
 
     // Implements IInterpreterHelper
     public async getInterpreterInformation(pythonPath: string): Promise<Partial<PythonEnvironment> | undefined> {

--- a/extensions/positron-python/src/test/interpreters/virtualEnvs/virtualEnvPrompt.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/virtualEnvs/virtualEnvPrompt.unit.test.ts
@@ -76,7 +76,6 @@ suite('Virtual Environment Prompt', () => {
 
         when(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).thenResolve(runtimeMetadata);
 
-        // Stub this directly because ts-mockito cannot infer its overload.
         originalStartLanguageRuntime = (positron.runtime as { startLanguageRuntime?: unknown }).startLanguageRuntime;
         startLanguageRuntimeStub = sinon.stub().resolves(undefined);
         Object.assign(positron.runtime, { startLanguageRuntime: startLanguageRuntimeStub });
@@ -165,19 +164,7 @@ suite('Virtual Environment Prompt', () => {
         verify(appShell.showInformationMessage(Interpreters.environmentSessionPromptMessage, ...prompts)).once();
     });
 
-    test("'Start Session' re-checks sessions and returns if one now exists", async () => {
-        // Simulate a session starting while the notification is open.
-        getActivePythonSessionsStub.onFirstCall().resolves([]);
-        getActivePythonSessionsStub.onSecondCall().resolves([fakeSession(envPath, positron.RuntimeState.Idle)]);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
-
-        await environmentPrompt.handleNewEnvironment(envPath);
-
-        verify(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).never();
-    });
-
-    test("'Start Session' calls resolveRuntimeMetadataFromPath then startLanguageRuntime with the returned id and name", async () => {
+    test("'Start Session' starts the new environment", async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
 
@@ -191,7 +178,7 @@ suite('Virtual Environment Prompt', () => {
         );
     });
 
-    test('If resolveRuntimeMetadataFromPath returns undefined, an error message is shown and startLanguageRuntime is not called', async () => {
+    test('If the environment cannot be registered, an error message is shown', async () => {
         when(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).thenResolve(undefined);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
@@ -203,10 +190,9 @@ suite('Virtual Environment Prompt', () => {
                 Interpreters.environmentSessionStartFailed(interpreter.detailedDisplayName ?? interpreter.path),
             ),
         ).once();
-        sinon.assert.notCalled(startLanguageRuntimeStub);
     });
 
-    test('If startLanguageRuntime rejects, an error message is shown once', async () => {
+    test('If starting the environment rejects, an error message is shown once', async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
         startLanguageRuntimeStub.rejects(new Error('boom'));

--- a/extensions/positron-python/src/test/interpreters/virtualEnvs/virtualEnvPrompt.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/virtualEnvs/virtualEnvPrompt.unit.test.ts
@@ -3,235 +3,243 @@
 
 'use strict';
 
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
 import * as sinon from 'sinon';
 import * as TypeMoq from 'typemoq';
-import { anything, deepEqual, instance, mock, reset, verify, when } from 'ts-mockito';
-import { ConfigurationTarget, Disposable, Uri } from 'vscode';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Disposable } from 'vscode';
 import { ApplicationShell } from '../../../client/common/application/applicationShell';
 import { IApplicationShell } from '../../../client/common/application/types';
 import { PersistentStateFactory } from '../../../client/common/persistentState';
 import { IPersistentState, IPersistentStateFactory } from '../../../client/common/types';
-import { Common } from '../../../client/common/utils/localize';
-import { PythonPathUpdaterService } from '../../../client/interpreter/configuration/pythonPathUpdaterService';
-import { IPythonPathUpdaterServiceManager } from '../../../client/interpreter/configuration/types';
-import { IComponentAdapter, IInterpreterHelper, IInterpreterService } from '../../../client/interpreter/contracts';
-import { InterpreterHelper } from '../../../client/interpreter/helpers';
+import { Common, Interpreters } from '../../../client/common/utils/localize';
+import { IComponentAdapter } from '../../../client/interpreter/contracts';
 import { VirtualEnvironmentPrompt } from '../../../client/interpreter/virtualEnvs/virtualEnvPrompt';
+import { IPythonRuntimeManager } from '../../../client/positron/manager';
 import { PythonEnvironment } from '../../../client/pythonEnvironments/info';
 import * as createEnvApi from '../../../client/pythonEnvironments/creation/createEnvApi';
+import * as sessionModule from '../../../client/positron/session';
+import * as telemetry from '../../../client/telemetry';
+import { EventName } from '../../../client/telemetry/constants';
 
 suite('Virtual Environment Prompt', () => {
     class VirtualEnvironmentPromptTest extends VirtualEnvironmentPrompt {
-        public async handleNewEnvironment(resource: Uri): Promise<void> {
-            await super.handleNewEnvironment(resource);
+        public async handleNewEnvironment(envPath: string): Promise<void> {
+            await super.handleNewEnvironment(envPath);
         }
 
-        public async notifyUser(interpreter: PythonEnvironment, resource: Uri): Promise<void> {
-            await super.notifyUser(interpreter, resource);
+        public async notifyUser(interpreter: PythonEnvironment): Promise<void> {
+            await super.notifyUser(interpreter);
         }
     }
+
+    const envPath = 'path/to/interpreter';
+    const interpreter = { path: envPath, detailedDisplayName: 'Python 3.11' } as unknown as PythonEnvironment;
+    const runtimeMetadata = {
+        runtimeId: 'runtime-id',
+        runtimeName: 'Python 3.11',
+    } as unknown as positron.LanguageRuntimeMetadata;
+
     let persistentStateFactory: IPersistentStateFactory;
-    let helper: IInterpreterHelper;
-    let pythonPathUpdaterService: IPythonPathUpdaterServiceManager;
     let disposable: Disposable;
     let appShell: IApplicationShell;
     let componentAdapter: IComponentAdapter;
-    let interpreterService: IInterpreterService;
+    let pythonRuntimeManager: IPythonRuntimeManager;
     let environmentPrompt: VirtualEnvironmentPromptTest;
     let isCreatingEnvironmentStub: sinon.SinonStub;
+    let getActivePythonSessionsStub: sinon.SinonStub;
+    let sendTelemetryEventStub: sinon.SinonStub;
+    let startLanguageRuntimeStub: sinon.SinonStub;
+    let notificationPromptEnabled: TypeMoq.IMock<IPersistentState<boolean>>;
+    let originalStartLanguageRuntime: unknown;
+    const prompts = [Interpreters.startSession, Common.notNow, Common.doNotShowAgain];
+
     setup(() => {
         persistentStateFactory = mock(PersistentStateFactory);
-        helper = mock(InterpreterHelper);
-        pythonPathUpdaterService = mock(PythonPathUpdaterService);
         componentAdapter = mock<IComponentAdapter>();
-        interpreterService = mock<IInterpreterService>();
+        pythonRuntimeManager = mock<IPythonRuntimeManager>();
         isCreatingEnvironmentStub = sinon.stub(createEnvApi, 'isCreatingEnvironment');
         isCreatingEnvironmentStub.returns(false);
-        when(interpreterService.getActiveInterpreter(anything())).thenResolve({
-            id: 'selected',
-            path: 'path/to/selected',
-        } as unknown as PythonEnvironment);
+        getActivePythonSessionsStub = sinon.stub(sessionModule, 'getActivePythonSessions');
+        getActivePythonSessionsStub.resolves([]);
+        sendTelemetryEventStub = sinon.stub(telemetry, 'sendTelemetryEvent');
+        when(componentAdapter.getInterpreterDetails(envPath)).thenResolve(interpreter);
         disposable = mock(Disposable);
         appShell = mock(ApplicationShell);
+
+        notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
+        notificationPromptEnabled.setup((n) => n.value).returns(() => true);
+        when(persistentStateFactory.createWorkspacePersistentState(anything(), true)).thenReturn(
+            notificationPromptEnabled.object,
+        );
+
+        when(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).thenResolve(runtimeMetadata);
+
+        // Stub this directly because ts-mockito cannot infer its overload.
+        originalStartLanguageRuntime = (positron.runtime as { startLanguageRuntime?: unknown }).startLanguageRuntime;
+        startLanguageRuntimeStub = sinon.stub().resolves(undefined);
+        Object.assign(positron.runtime, { startLanguageRuntime: startLanguageRuntimeStub });
+
         environmentPrompt = new VirtualEnvironmentPromptTest(
             instance(persistentStateFactory),
-            instance(helper),
-            instance(pythonPathUpdaterService),
             [instance(disposable)],
             instance(appShell),
             instance(componentAdapter),
-            instance(interpreterService),
+            instance(pythonRuntimeManager),
         );
     });
 
     teardown(() => {
         sinon.restore();
+        if (originalStartLanguageRuntime === undefined) {
+            delete (positron.runtime as { startLanguageRuntime?: unknown }).startLanguageRuntime;
+        } else {
+            Object.assign(positron.runtime, { startLanguageRuntime: originalStartLanguageRuntime });
+        }
     });
 
-    test('User is notified if interpreter exists and only python path to global interpreter is specified in settings', async () => {
-        const resource = Uri.file('a');
-        const interpreter1 = { path: 'path/to/interpreter1' };
-        const interpreter2 = { path: 'path/to/interpreter2' };
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
-        const notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
+    function fakeSession(pythonPath: string, state: positron.RuntimeState): sessionModule.PythonRuntimeSession {
+        return {
+            getRuntimeState: () => state,
+            runtimeMetadata: { extraRuntimeData: { pythonPath } },
+        } as unknown as sessionModule.PythonRuntimeSession;
+    }
 
-        when(componentAdapter.getWorkspaceVirtualEnvInterpreters(resource)).thenResolve([
-            interpreter1,
-            interpreter2,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ] as any);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        when(helper.getBestInterpreter(deepEqual([interpreter1, interpreter2] as any))).thenReturn(interpreter2 as any);
-        when(persistentStateFactory.createWorkspacePersistentState(anything(), true)).thenReturn(
-            notificationPromptEnabled.object,
-        );
-        notificationPromptEnabled.setup((n) => n.value).returns(() => true);
-        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve();
+    test('If environment is being created, no notification is shown', async () => {
+        isCreatingEnvironmentStub.returns(true);
 
-        await environmentPrompt.handleNewEnvironment(resource);
-
-        verify(appShell.showInformationMessage(anything(), ...prompts)).once();
-    });
-
-    test('User is not notified if currently selected interpreter is the same as new interpreter', async () => {
-        const resource = Uri.file('a');
-        const interpreter1 = { path: 'path/to/interpreter1' };
-        const interpreter2 = { path: 'path/to/interpreter2' };
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
-        const notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
-
-        // Return interpreters using the component adapter instead
-        when(componentAdapter.getWorkspaceVirtualEnvInterpreters(resource)).thenResolve([
-            interpreter1,
-            interpreter2,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ] as any);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        when(helper.getBestInterpreter(deepEqual([interpreter1, interpreter2] as any))).thenReturn(interpreter2 as any);
-        reset(interpreterService);
-        when(interpreterService.getActiveInterpreter(anything())).thenResolve(
-            interpreter2 as unknown as PythonEnvironment,
-        );
-        when(persistentStateFactory.createWorkspacePersistentState(anything(), true)).thenReturn(
-            notificationPromptEnabled.object,
-        );
-        notificationPromptEnabled.setup((n) => n.value).returns(() => true);
-        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve();
-
-        await environmentPrompt.handleNewEnvironment(resource);
+        await environmentPrompt.handleNewEnvironment(envPath);
 
         verify(appShell.showInformationMessage(anything(), ...prompts)).never();
     });
-    test('User is notified if interpreter exists and only python path to global interpreter is specified in settings', async () => {
-        const resource = Uri.file('a');
-        const interpreter1 = { path: 'path/to/interpreter1' };
-        const interpreter2 = { path: 'path/to/interpreter2' };
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
-        const notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
 
-        // Return interpreters using the component adapter instead
-        when(componentAdapter.getWorkspaceVirtualEnvInterpreters(resource)).thenResolve([
-            interpreter1,
-            interpreter2,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ] as any);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        when(helper.getBestInterpreter(deepEqual([interpreter1, interpreter2] as any))).thenReturn(interpreter2 as any);
-        when(persistentStateFactory.createWorkspacePersistentState(anything(), true)).thenReturn(
-            notificationPromptEnabled.object,
-        );
-        notificationPromptEnabled.setup((n) => n.value).returns(() => true);
+    test('If a matching non-exited session already exists, no notification is shown', async () => {
+        getActivePythonSessionsStub.resolves([fakeSession(envPath, positron.RuntimeState.Idle)]);
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(appShell.showInformationMessage(anything(), ...prompts)).never();
+    });
+
+    test('If a matching session has exited, notification is shown', async () => {
+        getActivePythonSessionsStub.resolves([fakeSession(envPath, positron.RuntimeState.Exited)]);
         when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve();
 
-        await environmentPrompt.handleNewEnvironment(resource);
+        await environmentPrompt.handleNewEnvironment(envPath);
 
         verify(appShell.showInformationMessage(anything(), ...prompts)).once();
     });
 
-    test("If user selects 'Yes', python path is updated", async () => {
-        const resource = Uri.file('a');
-        const interpreter1 = { path: 'path/to/interpreter1' };
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
-        const notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
-        when(persistentStateFactory.createWorkspacePersistentState(anything(), true)).thenReturn(
-            notificationPromptEnabled.object,
-        );
-        notificationPromptEnabled.setup((n) => n.value).returns(() => true);
+    test('If a session exists for a different path, notification is shown', async () => {
+        getActivePythonSessionsStub.resolves([fakeSession('path/to/other', positron.RuntimeState.Idle)]);
+        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve();
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(appShell.showInformationMessage(anything(), ...prompts)).once();
+    });
+
+    test('If getInterpreterDetails returns undefined, no notification is shown', async () => {
+        when(componentAdapter.getInterpreterDetails(envPath)).thenResolve(undefined);
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(appShell.showInformationMessage(anything(), ...prompts)).never();
+    });
+
+    test('If the workspace preference is disabled, no notification is shown', async () => {
+        notificationPromptEnabled.reset();
+        notificationPromptEnabled.setup((n) => n.value).returns(() => false);
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(appShell.showInformationMessage(anything(), ...prompts)).never();
+    });
+
+    test('Notification shows the new session message and the three expected labels', async () => {
+        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve();
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(appShell.showInformationMessage(Interpreters.environmentSessionPromptMessage, ...prompts)).once();
+    });
+
+    test("'Start Session' re-checks sessions and returns if one now exists", async () => {
+        // Simulate a session starting while the notification is open.
+        getActivePythonSessionsStub.onFirstCall().resolves([]);
+        getActivePythonSessionsStub.onSecondCall().resolves([fakeSession(envPath, positron.RuntimeState.Idle)]);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
-        when(
-            pythonPathUpdaterService.updatePythonPath(
-                interpreter1.path,
-                ConfigurationTarget.WorkspaceFolder,
-                'ui',
-                resource,
-            ),
-        ).thenResolve();
 
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).never();
+    });
+
+    test("'Start Session' calls resolveRuntimeMetadataFromPath then startLanguageRuntime with the returned id and name", async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await environmentPrompt.notifyUser(interpreter1 as any, resource);
+        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
 
-        verify(persistentStateFactory.createWorkspacePersistentState(anything(), true)).once();
-        verify(appShell.showInformationMessage(anything(), ...prompts)).once();
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).once();
+        sinon.assert.calledOnceWithExactly(
+            startLanguageRuntimeStub,
+            runtimeMetadata.runtimeId,
+            runtimeMetadata.runtimeName,
+        );
+    });
+
+    test('If resolveRuntimeMetadataFromPath returns undefined, an error message is shown and startLanguageRuntime is not called', async () => {
+        when(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).thenResolve(undefined);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
         verify(
-            pythonPathUpdaterService.updatePythonPath(
-                interpreter1.path,
-                ConfigurationTarget.WorkspaceFolder,
-                'ui',
-                resource,
+            appShell.showErrorMessage(
+                Interpreters.environmentSessionStartFailed(interpreter.detailedDisplayName ?? interpreter.path),
+            ),
+        ).once();
+        sinon.assert.notCalled(startLanguageRuntimeStub);
+    });
+
+    test('If startLanguageRuntime rejects, an error message is shown once', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
+        startLanguageRuntimeStub.rejects(new Error('boom'));
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(
+            appShell.showErrorMessage(
+                Interpreters.environmentSessionStartFailed(interpreter.detailedDisplayName ?? interpreter.path),
             ),
         ).once();
     });
 
-    test("If user selects 'No', no operation is performed", async () => {
-        const resource = Uri.file('a');
-        const interpreter1 = { path: 'path/to/interpreter1' };
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
-        const notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
-        when(persistentStateFactory.createWorkspacePersistentState(anything(), true)).thenReturn(
-            notificationPromptEnabled.object,
-        );
-        notificationPromptEnabled.setup((n) => n.value).returns(() => true);
+    test("If user selects 'Not Now', no side effects occur", async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[1] as any);
-        when(
-            pythonPathUpdaterService.updatePythonPath(
-                interpreter1.path,
-                ConfigurationTarget.WorkspaceFolder,
-                'ui',
-                resource,
-            ),
-        ).thenResolve();
-        notificationPromptEnabled
-            .setup((n) => n.updateValue(false))
-            .returns(() => Promise.resolve())
-            .verifiable(TypeMoq.Times.never());
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await environmentPrompt.notifyUser(interpreter1 as any, resource);
+        await environmentPrompt.handleNewEnvironment(envPath);
 
-        verify(persistentStateFactory.createWorkspacePersistentState(anything(), true)).once();
-        verify(appShell.showInformationMessage(anything(), ...prompts)).once();
-        verify(
-            pythonPathUpdaterService.updatePythonPath(
-                interpreter1.path,
-                ConfigurationTarget.WorkspaceFolder,
-                'ui',
-                resource,
-            ),
-        ).never();
-        notificationPromptEnabled.verifyAll();
+        verify(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).never();
+        notificationPromptEnabled.verify((n) => n.updateValue(false), TypeMoq.Times.never());
     });
 
-    test('If user selects "Don\'t show again", prompt is disabled', async () => {
-        const resource = Uri.file('a');
-        const interpreter1 = { path: 'path/to/interpreter1' };
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
-        const notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
-        when(persistentStateFactory.createWorkspacePersistentState(anything(), true)).thenReturn(
-            notificationPromptEnabled.object,
-        );
-        notificationPromptEnabled.setup((n) => n.value).returns(() => true);
+    test('If the prompt is dismissed, no side effects occur', async () => {
+        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(undefined);
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        verify(pythonRuntimeManager.resolveRuntimeMetadataFromPath(envPath)).never();
+        notificationPromptEnabled.verify((n) => n.updateValue(false), TypeMoq.Times.never());
+    });
+
+    test("If user selects 'Don't Show Again', the workspace preference is set to false", async () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[2] as any);
         notificationPromptEnabled
@@ -239,43 +247,22 @@ suite('Virtual Environment Prompt', () => {
             .returns(() => Promise.resolve())
             .verifiable(TypeMoq.Times.once());
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await environmentPrompt.notifyUser(interpreter1 as any, resource);
+        await environmentPrompt.handleNewEnvironment(envPath);
 
-        verify(persistentStateFactory.createWorkspacePersistentState(anything(), true)).once();
-        verify(appShell.showInformationMessage(anything(), ...prompts)).once();
         notificationPromptEnabled.verifyAll();
     });
 
-    test('If prompt is disabled, no notification is shown', async () => {
-        const resource = Uri.file('a');
-        const interpreter1 = { path: 'path/to/interpreter1' };
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
-        const notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<boolean>>();
-        when(persistentStateFactory.createWorkspacePersistentState(anything(), true)).thenReturn(
-            notificationPromptEnabled.object,
+    test('Telemetry selections stay Yes, No, Ignore', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[1] as any);
+
+        await environmentPrompt.handleNewEnvironment(envPath);
+
+        sinon.assert.calledOnceWithExactly(
+            sendTelemetryEventStub,
+            EventName.PYTHON_INTERPRETER_ACTIVATE_ENVIRONMENT_PROMPT,
+            undefined,
+            { selection: 'No' },
         );
-        notificationPromptEnabled.setup((n) => n.value).returns(() => false);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        when(appShell.showInformationMessage(anything(), ...prompts)).thenResolve(prompts[0] as any);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await environmentPrompt.notifyUser(interpreter1 as any, resource);
-
-        verify(persistentStateFactory.createWorkspacePersistentState(anything(), true)).once();
-        verify(appShell.showInformationMessage(anything(), ...prompts)).never();
-    });
-
-    test('If environment is being created, no notification is shown', async () => {
-        isCreatingEnvironmentStub.reset();
-        isCreatingEnvironmentStub.returns(true);
-
-        const resource = Uri.file('a');
-        const prompts = [Common.bannerLabelYes, Common.bannerLabelNo, Common.doNotShowAgain];
-
-        await environmentPrompt.handleNewEnvironment(resource);
-
-        verify(persistentStateFactory.createWorkspacePersistentState(anything(), true)).never();
-        verify(appShell.showInformationMessage(anything(), ...prompts)).never();
     });
 });

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -284,6 +284,25 @@ suite('Python runtime manager', () => {
 
         verify(mockedPositronNamespaces.runtime!.selectLanguageRuntime(runtimeMetadata.object.runtimeId)).once();
     });
+
+    test('resolveRuntimeMetadataFromPath refreshes once before retrying', async () => {
+        sinon.stub(runtime, 'createPythonRuntimeMetadata').resolves(runtimeMetadata.object);
+
+        let resolveCalls = 0;
+        interpreterService.reset();
+        interpreterService
+            .setup((i) => i.getInterpreterDetails(TypeMoq.It.isAny()))
+            .returns(() => {
+                resolveCalls += 1;
+                return Promise.resolve(resolveCalls === 1 ? undefined : interpreter.object);
+            });
+        interpreterService.setup((i) => i.triggerRefresh()).returns(() => Promise.resolve());
+
+        const metadata = await pythonRuntimeManager.resolveRuntimeMetadataFromPath(pythonPath);
+
+        assert.strictEqual(metadata, runtimeMetadata.object);
+        interpreterService.verify((i) => i.triggerRefresh(), TypeMoq.Times.once());
+    });
 });
 
 suite('Python runtime manager - recommendedWorkspaceRuntime', () => {

--- a/extensions/positron-python/src/test/pythonEnvironments/legacyIOC.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/legacyIOC.unit.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as assert from 'assert';
+import * as TypeMoq from 'typemoq';
+import { anything, when } from 'ts-mockito';
+import { EventEmitter, Uri, WorkspaceFolder } from 'vscode';
+import { FileChangeType } from '../../client/common/platform/fileSystemWatcher';
+import { IComponentAdapter } from '../../client/interpreter/contracts';
+import { IServiceManager } from '../../client/ioc/types';
+import { PythonEnvKind } from '../../client/pythonEnvironments/base/info';
+import { IDiscoveryAPI } from '../../client/pythonEnvironments/base/locator';
+import { PythonEnvCollectionChangedEvent } from '../../client/pythonEnvironments/base/watcher';
+import { registerNewDiscoveryForIOC } from '../../client/pythonEnvironments/legacyIOC';
+import { mockedVSCodeNamespaces } from '../vscode-mock';
+
+type FakeChangedEvent = PythonEnvCollectionChangedEvent & { envPath?: string };
+
+suite('Component Adapter - onDidCreate', () => {
+    const workspaceUri = Uri.file('/workspace');
+    const workspaceFolder: WorkspaceFolder = { uri: workspaceUri, name: 'workspace', index: 0 };
+    const resource = Uri.file('/workspace/some-file.py');
+
+    let onChangedEmitter: EventEmitter<FakeChangedEvent>;
+    let adapter: IComponentAdapter;
+
+    setup(() => {
+        onChangedEmitter = new EventEmitter<FakeChangedEvent>();
+
+        const discoveryApi = TypeMoq.Mock.ofType<IDiscoveryAPI>();
+        discoveryApi.setup((a) => a.onChanged).returns(() => onChangedEmitter.event);
+
+        const serviceManager = TypeMoq.Mock.ofType<IServiceManager>();
+        serviceManager.setup((s) => s.addSingleton(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => undefined);
+        serviceManager
+            .setup((s) => s.addSingletonInstance(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .callback((_symbol: unknown, instance: unknown) => {
+                adapter = instance as IComponentAdapter;
+            });
+
+        registerNewDiscoveryForIOC(serviceManager.object, discoveryApi.object);
+
+        when(mockedVSCodeNamespaces.workspace!.getWorkspaceFolder(anything())).thenReturn(workspaceFolder);
+    });
+
+    teardown(() => {
+        onChangedEmitter.dispose();
+    });
+
+    test('js locator shape: callback receives envPath', () => {
+        const received: string[] = [];
+        adapter.onDidCreate(resource, (envPath) => received.push(envPath));
+
+        onChangedEmitter.fire({
+            type: FileChangeType.Created,
+            searchLocation: workspaceUri,
+            envPath: `${workspaceUri.fsPath}/.venv/bin/python`,
+        });
+
+        assert.deepStrictEqual(received, [`${workspaceUri.fsPath}/.venv/bin/python`]);
+    });
+
+    test('native locator shape: callback receives new.executable.filename', () => {
+        const received: string[] = [];
+        adapter.onDidCreate(resource, (envPath) => received.push(envPath));
+
+        onChangedEmitter.fire({
+            type: FileChangeType.Created,
+            searchLocation: workspaceUri,
+            new: {
+                executable: {
+                    filename: `${workspaceUri.fsPath}/.venv/bin/python`,
+                    sysPrefix: '',
+                    ctime: -1,
+                    mtime: -1,
+                },
+                kind: PythonEnvKind.Venv,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+        });
+
+        assert.deepStrictEqual(received, [`${workspaceUri.fsPath}/.venv/bin/python`]);
+    });
+
+    test('Created event with no searchLocation (cold-start native discovery): no callback', () => {
+        const received: string[] = [];
+        adapter.onDidCreate(resource, (envPath) => received.push(envPath));
+
+        onChangedEmitter.fire({
+            type: FileChangeType.Created,
+            envPath: `${workspaceUri.fsPath}/.venv/bin/python`,
+        });
+
+        assert.deepStrictEqual(received, []);
+    });
+
+    test('Created event with searchLocation outside the workspace: no callback', () => {
+        const received: string[] = [];
+        adapter.onDidCreate(resource, (envPath) => received.push(envPath));
+
+        onChangedEmitter.fire({
+            type: FileChangeType.Created,
+            searchLocation: Uri.file('/somewhere/else'),
+            envPath: '/somewhere/else/.venv/bin/python',
+        });
+
+        assert.deepStrictEqual(received, []);
+    });
+
+    [FileChangeType.Changed, FileChangeType.Deleted].forEach((type) => {
+        test(`${type} event: no callback`, () => {
+            const received: string[] = [];
+            adapter.onDidCreate(resource, (envPath) => received.push(envPath));
+
+            onChangedEmitter.fire({
+                type,
+                searchLocation: workspaceUri,
+                envPath: `${workspaceUri.fsPath}/.venv/bin/python`,
+            });
+
+            assert.deepStrictEqual(received, []);
+        });
+    });
+});

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1765,8 +1765,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				metadata = validated;
 				this._startingConsolesByRuntimeId.set(metadata.runtimeId, validated);
 			} catch (err) {
-				// Clear this from the set of starting consoles.
-				this._startingConsolesByRuntimeId.delete(metadata.runtimeId);
+				startPromise.error(err);
+				this.clearStartingSessionMaps(sessionMode, metadata, notebookUri);
 
 				// Log the error and re-throw it.
 				this._logService.error(

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.vitest.ts
@@ -649,6 +649,10 @@ describe('Positron - RuntimeSessionService', () => {
 
 		// The runtime should remain unregistered.
 		expect(languageRuntimeService.getRegisteredRuntime(unregisteredRuntime.runtimeId)).toBe(undefined);
+
+		// A later attempt must not wait on the failed attempt's start promise.
+		manager.setValidateMetadata(async (metadata: ILanguageRuntimeMetadata) => metadata);
+		await autoStartSession(unregisteredRuntime);
 	});
 
 	it('auto start console does nothing if automatic startup is disabled', async () => {


### PR DESCRIPTION
Fixes #14893

Replace the upstream interpreter-selection notification with a Positron-native prompt that offers to start a console session for the newly detected environment.

The implementation:
- carries the exact environment path from both native and JavaScript locator events
- suppresses the prompt when a non-exited session already uses that environment
- resolves and registers the environment runtime before starting a session
- preserves the workspace-scoped Don't Show Again preference

### Screenshots


https://github.com/user-attachments/assets/8b6f2c11-b4a9-47ce-9b4a-633a3122f84e



### Release Notes

#### New Features

- N/A

#### Bug Fixes

- New Python environments detected in a workspace now offer to start a console session instead of selecting a workspace interpreter (#14893).

### Validation Steps

1. Open a workspace with an existing Python interpreter.
2. Create a virtual environment inside the workspace from the terminal. I used `uv venv .venv`
3. Confirm the notification offers three buttons: `Start Session`, `Not Now`, and `Don't Show Again`.
4. Choose `Start Session` and confirm a Python console starts with the new environment.
5. Create another environment and start a session for it before discovery completes; confirm no redundant prompt appears.
6. Confirm `Don't Show Again` suppresses subsequent prompts in that workspace.