### PR TITLE
Hide agents window entry point

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.shared.contribution.ts
@@ -374,7 +374,12 @@ configurationRegistry.registerConfiguration({
 				nls.localize('chat.agentsControl.compact', "Replaces the command center search box with a compact agent status indicator and unified chat widget."),
 			],
 			markdownDescription: nls.localize('chat.agentsControl.enabled', "Controls how the 'Agent Status' indicator appears in the title bar command center. When set to `hidden`, the indicator is not shown. Other values show the indicator and automatically enable {0}. The unread and in-progress session indicators require {1} to be enabled.", '`#window.commandCenter#`', '`#chat.viewSessions.enabled#`'),
-			default: 'compact',
+			// --- Start Positron ---
+			// default: 'compact',
+			// Positron doesn't ship the Agents window, so keep the indicator out of
+			// the title bar.
+			default: 'hidden',
+			// --- End Positron ---
 			tags: ['experimental']
 		},
 		[ChatConfiguration.UnifiedAgentsBar]: {
@@ -2240,7 +2245,12 @@ configurationRegistry.registerConfiguration({
 		[ChatConfiguration.TitleBarOpenInAgentsWindowEnabled]: {
 			type: 'boolean',
 			description: nls.localize('chat.titleBar.openInAgentsWindow.enabled', "Controls whether the Open in Agents Window button is shown in the title bar."),
-			default: true,
+			// --- Start Positron ---
+			// default: true,
+			// Positron doesn't ship the Agents window, so the button would open an
+			// empty window.
+			default: false,
+			// --- End Positron ---
 		},
 		'chat.approvedAccountOrganizations': {
 			type: 'array',


### PR DESCRIPTION
Fixes #16034

The 1.134.0 merge brought back upstream's Agents window chrome in the title bar: the "Open in Agents Window" button, and the compact agent status indicator that replaces the command center search box. Positron does not ship the Agents window, so the button opens an empty window.

This turns both off by default. 

- `chat.titleBar.openInAgentsWindow.enabled` now defaults to `false`
- `chat.agentsControl.enabled` now defaults to `hidden`

